### PR TITLE
Add drop schema on start

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -40,7 +40,6 @@ class Config {
   TYPEORM_DROP_SCHEMA: string
   APOLLO_KEY: string
   REGISTER_USERNAME_PASSWORD: string
-  DB_DROP_SEED: boolean
 
   STRIPE_KEY: string
   STRIPE_SECRET: string
@@ -63,7 +62,7 @@ class Config {
     })
   }
 
-  get (envVar: string): string | boolean | number {
+  get (envVar: string): string | number {
     return this[envVar]
   }
 }

--- a/server/createSchema.ts
+++ b/server/createSchema.ts
@@ -17,7 +17,7 @@ const createSchema = async (): Promise<GraphQLSchema> => {
         resolvers.push.apply(resolvers, [RegisterResolver, ConfirmUserResolver])
     }
 
-    const dropSeed = config.get('DB_DROP_SEED') as boolean
+    const dropSchema = config.get('TYPEORM_DROP_SCHEMA') === 'true'
     await TypeORM.createConnection({
         type: 'postgres',
         database: config.get('TYPEORM_DATABASE_NAME') as string,
@@ -29,15 +29,15 @@ const createSchema = async (): Promise<GraphQLSchema> => {
         synchronize: true,
         logger: 'advanced-console',
         logging: 'all',
-        dropSchema: dropSeed,
+        dropSchema,
         cache: true
     })
 
-    if (dropSeed) {
-        // seed database with some data
-        const { defaultUser } = await seedDatabase()
-    }
-
+    // if (dropSchema) {
+    //     // seed database with some data
+    //     const { defaultUser } = await seedDatabase()
+    // }
+    //
     // build TypeGraphQL executable schema
     const schema = await TypeGraphQL.buildSchema({
         resolvers,


### PR DESCRIPTION
@geleeroyale I removed `DB_DROP_SEED` key and fixed the bug to use `TYPEORM_DROP_SCHEMA` in order to drop schema on start.
We should be cautious about when this key should have `true` value