### PR TITLE
remove password from user response

### DIFF
--- a/entities/user.ts
+++ b/entities/user.ts
@@ -40,7 +40,7 @@ export class User extends BaseEntity {
   walletAddress?: string
 
   @Field({ nullable: true })
-  @Column({ nullable: true })
+  @Column({ nullable: true, select: false })
   password?: string
 
   @Field({ nullable: true })

--- a/user/LoginResolver.ts
+++ b/user/LoginResolver.ts
@@ -104,9 +104,12 @@ export class LoginResolver {
         throw Error('Invalid login type')
     }
 
-    const user: any = await User.findOne({
-      where: { email, loginType: 'password' }
-    })
+    const user: any = await User
+      .createQueryBuilder('user')
+      .where('user.email = :email', {email})
+      .andWhere('user.loginType = :loginType', {loginType: 'password'})
+      .addSelect('user.password')
+      .getOne()
 
     if (!user) {
       console.log(`No user with email address ${email}`)
@@ -137,6 +140,7 @@ export class LoginResolver {
 
     const response = new LoginResponse()
 
+    delete user.password
     response.user = user
     response.token = accessToken
     return response

--- a/user/register/RegisterResolver.ts
+++ b/user/register/RegisterResolver.ts
@@ -44,6 +44,7 @@ export class RegisterResolver {
 
     await sendEmail(email, await createConfirmationUrl(user.id))
 
+    delete user.password
     return user
   }
 


### PR DESCRIPTION
### What are the changes and their implications?

Before this, the hashed passwords for every user could be requested.

- hide password column from find or query
- explicitly delete password from login/register resolver response