### PR TITLE
Hotfix Update slug only on duplicates

### DIFF
--- a/resolvers/projectResolver.ts
+++ b/resolvers/projectResolver.ts
@@ -450,8 +450,11 @@ export class ProjectResolver {
     const slugBase = slugify(projectInput.title)
 
     let slug = slugBase
-    for (let i = 1; await this.projectRepository.findOne({ slug }); i++) {
-      slug = slugBase + '-' + i
+
+    const [, projectCount] = await Project.findAndCount({ slug })
+
+    if (projectCount > 0) {
+      slug = slugBase + '-' + projectCount
     }
 
     const status = await this.projectStatusRepository.findOne({


### PR DESCRIPTION
The previous implementation changed the project slug with additional data such as -1.
This fixes it and only does it when there are duplicated titles. 