### PR TITLE
Fix returning projects on query user

### DIFF
--- a/entities/user.ts
+++ b/entities/user.ts
@@ -96,7 +96,7 @@ export class User extends BaseEntity {
   )
   organisations: Organisation[]
 
-  @Field(type => Project)
+  @Field(type => [Project])
   @ManyToMany(
     type => Project,
     project => project.users

--- a/resolvers/userResolver.ts
+++ b/resolvers/userResolver.ts
@@ -42,7 +42,7 @@ export class UserResolver {
   async user (@Arg('userId', type => Int) userId: number) {
     return await this.userRepository.findOne({
         where: { id: userId },
-        relations: ['accountVerifications']
+        relations: ['accountVerifications', 'projects']
       }
     )
   }


### PR DESCRIPTION
related to #66 

You can test it with this query:
```
query{
  user(userId:1){
    firstName
    lastName
    projects{
      title
    }
  }
}
```

**Before**
<img width="1440" alt="Screen Shot 1400-06-28 at 22 51 44" src="https://user-images.githubusercontent.com/9850545/133938457-da9b29a1-7037-4c40-b7f7-ae75d806e3e2.png">


**After**
<img width="1437" alt="Screen Shot 1400-06-28 at 22 47 48" src="https://user-images.githubusercontent.com/9850545/133938422-974b1e9b-e35a-4311-b463-72cd228bc211.png">

@aminlatifi please take a look in this PR, @divine-comedian  is kind of block for this bug
