### PR TITLE
Feature: Add admin canceled project status

### DIFF
--- a/entities/project.ts
+++ b/entities/project.ts
@@ -26,9 +26,9 @@ export enum ProjStatus {
   pen = 2,
   clr = 3,
   ver = 4,
-  act = 5,
-  can = 6,
-  del = 7
+  active = 5,
+  deactive = 6,
+  cancel = 7
 }
 
 @Entity()
@@ -172,7 +172,7 @@ class Project extends BaseEntity {
 
   // Status 7 is deleted status
   mayUpdateStatus (user: User) {
-    if (this.statusId === ProjStatus.del) return false
+    if (this.statusId === ProjStatus.cancel) return false
 
     if (this.users.filter(o => o.id === user.id).length > 0) {
       return true

--- a/entities/project.ts
+++ b/entities/project.ts
@@ -21,6 +21,16 @@ import { User } from './user'
 import { ProjectStatus } from './projectStatus'
 import ProjectTracker from '../services/segment/projectTracker'
 
+export enum ProjStatus {
+  rjt = 1,
+  pen = 2,
+  clr = 3,
+  ver = 4,
+  act = 5,
+  can = 6,
+  del = 7
+}
+
 @Entity()
 @ObjectType()
 class Project extends BaseEntity {
@@ -162,7 +172,7 @@ class Project extends BaseEntity {
 
   // Status 7 is deleted status
   mayUpdateStatus (user: User) {
-    if (this.statusId == 7) return false
+    if (this.statusId === ProjStatus.del) return false
 
     if (this.users.filter(o => o.id === user.id).length > 0) {
       return true

--- a/entities/projectStatus.ts
+++ b/entities/projectStatus.ts
@@ -4,7 +4,8 @@ import {
   Column,
   Entity,
   BaseEntity,
-  OneToMany
+  OneToMany,
+  Index
 } from 'typeorm'
 import { Project } from './project'
 
@@ -19,6 +20,7 @@ export class ProjectStatus extends BaseEntity{
   @Column('text', { unique: true })
   symbol: string
 
+  @Index()
   @Field()
   @Column({ nullable: true })
   name: string

--- a/resolvers/projectResolver.ts
+++ b/resolvers/projectResolver.ts
@@ -225,7 +225,7 @@ export class ProjectResolver {
         relations: ['reactions'],
         where: {
           status: {
-            id: ProjStatus.act
+            id: ProjStatus.active
           }
         }
       })
@@ -503,7 +503,7 @@ export class ProjectResolver {
     const slugBase = slugify(projectInput.title)
     const slug = await this.getAppropriateSlug(slugBase)
     const status = await this.projectStatusRepository.findOne({
-      id: 5
+      id: ProjStatus.active
     })
 
     const project = this.projectRepository.create({
@@ -916,7 +916,7 @@ export class ProjectResolver {
   ): Promise<Boolean> {
     try {
       const user = await getLoggedInUser(ctx)
-      const didDeactivate = await this.updateProjectStatus(projectId, ProjStatus.can, user)
+      const didDeactivate = await this.updateProjectStatus(projectId, ProjStatus.deactive, user)
       if (didDeactivate)
        {
          const project = await Project.findOne({ id: projectId })
@@ -954,7 +954,7 @@ export class ProjectResolver {
   ): Promise<Boolean> {
     try {
       const user = await getLoggedInUser(ctx)
-      return await this.updateProjectStatus(projectId, ProjStatus.act, user)
+      return await this.updateProjectStatus(projectId, ProjStatus.active, user)
     } catch (error) {
       Logger.captureException(error)
       throw error

--- a/resolvers/projectResolver.ts
+++ b/resolvers/projectResolver.ts
@@ -1,6 +1,6 @@
 import NotificationPayload from '../entities/notificationPayload'
 import { Reaction, REACTION_TYPE } from '../entities/reaction'
-import { Project, ProjectUpdate } from '../entities/project'
+import { Project, ProjectUpdate, ProjStatus } from '../entities/project'
 import { InjectRepository } from 'typeorm-typedi-extensions'
 import { ProjectStatus } from '../entities/projectStatus'
 import { ProjectInput, ImageUpload } from './types/project-input'
@@ -43,15 +43,6 @@ import {
 
 const analytics = getAnalytics()
 
-enum ProjStatus {
-  rjt = 1,
-  pen = 2,
-  clr = 3,
-  ver = 4,
-  act = 5,
-  can = 6,
-  del = 7
-}
 import { inspect } from 'util'
 import { errorMessages } from '../utils/errorMessages';
 import { isWalletAddressSmartContract, validateProjectWalletAddress } from '../utils/validators/projectValidator';

--- a/resolvers/projectResolver.ts
+++ b/resolvers/projectResolver.ts
@@ -372,26 +372,6 @@ export class ProjectResolver {
     project.qualityScore = qualityScore
     await project.save()
 
-    const segmentProject = {
-      email: user.email,
-      title: project.title,
-      lastName: user.lastName,
-      firstName: user.firstName,
-      OwnerId: user.id,
-      slug: project.slug,
-      walletAddress: project.walletAddress
-    }
-
-    analytics.track(
-      'Project edited',
-      `givethId-${user.userId}`,
-      segmentProject,
-      null
-    )
-
-    if (config.get('TRIGGER_BUILD_ON_NEW_PROJECT') === 'true')
-      triggerBuild(projectId)
-
     return project
   }
 

--- a/server/bootstrap.ts
+++ b/server/bootstrap.ts
@@ -17,7 +17,7 @@ import { graphqlUploadExpress } from 'graphql-upload'
 import { Database, Resource } from '@admin-bro/typeorm';
 import { validate } from 'class-validator'
 
-import { Project } from '../entities/project'
+import { Project, ProjStatus } from '../entities/project'
 import { ProjectStatus } from '../entities/projectStatus';
 import { User } from '../entities/user';
 
@@ -369,7 +369,7 @@ export async function bootstrap () {
                 actionType: 'bulk',
                 isVisible: true,
                 handler: async (request, response, context) => {
-                  return updateStatuslProjects(context, request, 5)
+                  return updateStatuslProjects(context, request, ProjStatus.active)
                 },
                 component: false,
               },
@@ -377,7 +377,7 @@ export async function bootstrap () {
                 actionType: 'bulk',
                 isVisible: true,
                 handler: async (request, response, context) => {
-                  return updateStatuslProjects(context, request, 6)
+                  return updateStatuslProjects(context, request, ProjStatus.deactive)
                 },
                 component: false,
               },
@@ -385,7 +385,7 @@ export async function bootstrap () {
                 actionType: 'bulk',
                 isVisible: true,
                 handler: async (request, response, context) => {
-                  return updateStatuslProjects(context, request, 7)
+                  return updateStatuslProjects(context, request, ProjStatus.cancel)
                 },
                 component: false,
               }

--- a/services/segment/projectTracker.ts
+++ b/services/segment/projectTracker.ts
@@ -1,0 +1,46 @@
+import { User } from '../../entities/user';
+import { Project } from '../../entities/project';
+import { getAnalytics } from '../../analytics';
+
+const analytics = getAnalytics()
+
+/**
+ * Notifies Segment any event concerning the project
+ */
+class ProjectTracker {
+    project: Project
+    eventName: string
+    projectOwner?: User
+
+    constructor(projectToUpdate: Project, eventTitle: string) {
+        this.project = projectToUpdate
+        this.eventName = eventTitle
+    }
+
+    async track() {
+        this.projectOwner = await User.findOne({ id: Number(this.project.admin) })
+
+        if(this.projectOwner) {
+            analytics.track(
+                this.eventName,
+                this.projectOwner.segmentUserId(),
+                this.segmentProjectAttributes(),
+                null
+            )
+        }
+    }
+
+    private segmentProjectAttributes() {
+        return {
+            email: this.projectOwner?.email,
+            title: this.project.title,
+            lastName: this.projectOwner?.lastName,
+            firstName: this.projectOwner?.firstName,
+            OwnerId: this.projectOwner?.id,
+            slug: this.project.slug,
+            walletAddress: this.project.walletAddress
+        }
+    }
+}
+
+export default ProjectTracker;


### PR DESCRIPTION
This PR begins using the status 7 called Delisted already in our db. 
This status means the Admin cancelled a project and only said admin can activate it again, not the project owner. 
Also added a class to notify segment of project updates that will be sent when updating the project from the index view in the adminbro, or editing the project individually.

Removed the "Project edited" segment call @divine-comedian  on the editProject mutation as this will be called in the AfterUpdate callback in the project entity. 

To test this PR you can enter de adminbro an call the actions on the bluebar:
![image](https://user-images.githubusercontent.com/92376054/138623799-959a907d-9d4a-4478-a994-63668592d34b.png)

Finally you can also test the "Project edited" segment call by editing the project individually in the adminbro or calling the following mutation (edit it as you need):
`
mutation {
  editProject(projectId: 1, newProjectData: { title: "test" }) {
    id
  }
}
`
 
 Result (ignore project deleted, I renamed it as cancelled): 
 
![image](https://user-images.githubusercontent.com/92376054/138623957-924aa307-7bb3-46b1-a11d-024c58c9000c.png)

If you could do some testing @divine-comedian and @laurenluz  that would be awesome. Remember to change to my branch and run the impact graph. 
