### PR TITLE
F 168 fix verifying transactions issues

### DIFF
--- a/entities/donation.ts
+++ b/entities/donation.ts
@@ -1,4 +1,4 @@
-import { Field, ID, ObjectType } from 'type-graphql'
+import { Field, ID, ObjectType } from 'type-graphql';
 import {
   PrimaryGeneratedColumn,
   Column,
@@ -7,114 +7,113 @@ import {
   ManyToOne,
   ColumnOptions,
   RelationId,
-  Index
-} from 'typeorm'
-import { Project } from './project'
-import { User } from './user'
+  Index,
+} from 'typeorm';
+import { Project } from './project';
+import { User } from './user';
 
 export const DONATION_STATUS = {
   PENDING: 'pending',
   VERIFIED: 'verified',
-  FAILED: 'failed'
-}
+  FAILED: 'failed',
+};
 
 @Entity()
 @ObjectType()
 export class Donation extends BaseEntity {
   @Field(type => ID)
   @PrimaryGeneratedColumn()
-  id: number
+  id: number;
 
   @Field()
   @Column({ unique: true })
   // It's transactionHash for crypto donation, and trackingCode for fiat donation
-  transactionId: string
+  transactionId: string;
 
-  @Field()
-  @Column('integer',{ nullable: true })
+  @Field({ nullable: true })
+  @Column('integer', { nullable: true })
   // To match the transaction in case user has done speed up
-  nonce: number
+  nonce: number;
 
   @Field()
   @Column({ nullable: false })
-  transactionNetworkId: number
+  transactionNetworkId: number;
 
   @Field()
   @Column('text', { default: 'pending' })
-  status: string
+  status: string;
 
-  @Field()
+  @Field({ nullable: true })
   @Column('text', { nullable: true })
-  verifyErrorMessage: string
+  verifyErrorMessage: string;
 
   @Field()
   @Column('boolean', { default: false })
-  speedup: boolean
+  speedup: boolean;
 
   @Field()
   @Column('boolean', { default: false })
-  isFiat: boolean
+  isFiat: boolean;
 
   @Field()
   @Column()
-  toWalletAddress: string
+  toWalletAddress: string;
 
   @Field()
   @Column()
-  fromWalletAddress: string
+  fromWalletAddress: string;
 
   @Field()
   @Column()
-  currency: string
+  currency: string;
 
   @Field({ nullable: true })
   @Column({ nullable: true })
-  anonymous: boolean
+  anonymous: boolean;
 
   @Field()
   @Column({ type: 'real' })
-  amount: number
+  amount: number;
 
   @Field({ nullable: true })
   @Column({ type: 'real', nullable: true })
-  valueEth: number
+  valueEth: number;
 
   @Field({ nullable: true })
   @Column({ type: 'real', nullable: true })
-  valueUsd: number
+  valueUsd: number;
 
   @Field({ nullable: true })
   @Column({ type: 'real', nullable: true })
-  priceEth: number
+  priceEth: number;
 
   @Field({ nullable: true })
   @Column({ type: 'real', nullable: true })
-  priceUsd: number
+  priceUsd: number;
 
   @Index()
   @Field(type => Project)
   @ManyToOne(type => Project, { eager: true })
-  project: Project
+  project: Project;
   @RelationId((donation: Donation) => donation.project)
-  projectId: number
+  projectId: number;
 
   @Index()
   @Field(type => User, { nullable: true })
   @ManyToOne(type => User, { eager: true, nullable: true })
-  user: User
+  user: User;
   @RelationId((donation: Donation) => donation.user)
-  userId: number
+  userId: number;
 
   @Field(type => Date)
   @Column()
-  createdAt: Date
+  createdAt: Date;
 
   @Field(type => String, { nullable: true })
   @Column({ nullable: true })
-  donationType?: string
-
+  donationType?: string;
 
   @Field(type => String, { nullable: true })
   @Column({ nullable: true })
-  transakStatus?: string
+  transakStatus?: string;
 }

--- a/services/transactionService.test.ts
+++ b/services/transactionService.test.ts
@@ -1,14 +1,15 @@
-import { assert } from 'chai'
-import 'mocha'
-import { getTransactionInfoFromNetwork } from './transactionService'
-import { assertThrowsAsync } from '../test/testUtils'
-import { errorMessages } from '../utils/errorMessages'
-import { NETWORK_IDS } from '../provider'
+import { assert } from 'chai';
+import 'mocha';
+import { getTransactionInfoFromNetwork } from './transactionService';
+import { assertThrowsAsync } from '../test/testUtils';
+import { errorMessages } from '../utils/errorMessages';
+import { NETWORK_IDS } from '../provider';
+const ONE_DAY = 60 * 60 * 24;
 
 const getTransactionDetailTestCases = () => {
   it('should return transaction detail for normal transfer on mainnet', async () => {
     // https://etherscan.io/tx/0x37765af1a7924fb6ee22c83668e55719c9ecb1b79928bd4b208c42dfff44da3a
-    const amount = 0.04
+    const amount = 0.04;
     const transactionInfo = await getTransactionInfoFromNetwork({
       txHash:
         '0x37765af1a7924fb6ee22c83668e55719c9ecb1b79928bd4b208c42dfff44da3a',
@@ -17,14 +18,14 @@ const getTransactionDetailTestCases = () => {
       fromAddress: '0x839395e20bbB182fa440d08F850E6c7A8f6F0780',
       toAddress: '0x5ac583feb2b1f288c0a51d6cdca2e8c814bfe93b',
       timestamp: 1607360947,
-      amount
-    })
-    assert.isOk(transactionInfo)
-    assert.equal(transactionInfo.currency, 'ETH')
-    assert.equal(transactionInfo.amount, amount)
-  })
+      amount,
+    });
+    assert.isOk(transactionInfo);
+    assert.equal(transactionInfo.currency, 'ETH');
+    assert.equal(transactionInfo.amount, amount);
+  });
   it('should return error when transactionHash is wrong on mainnet', async () => {
-    const amount = 0.04
+    const amount = 0.04;
     // https://etherscan.io/tx/0x37765af1a7924fb6ee22c83668e55719c9ecb1b79928bd4b208c42dfff44da3a
     const badFunc = async () => {
       await getTransactionInfoFromNetwork({
@@ -35,14 +36,14 @@ const getTransactionDetailTestCases = () => {
         fromAddress: '0x839395e20bbB182fa440d08F850E6c7A8f6F0780',
         toAddress: '0x5ac583feb2b1f288c0a51d6cdca2e8c814bfe93b',
         amount,
-        timestamp: 1607360947
-      })
-    }
-    await assertThrowsAsync(badFunc, errorMessages.TRANSACTION_NOT_FOUND)
-  })
+        timestamp: 1607360947,
+      });
+    };
+    await assertThrowsAsync(badFunc, errorMessages.TRANSACTION_NOT_FOUND);
+  });
 
   it('should return error when fromAddress of transaction is different from donation fromAddress', async () => {
-    const amount = 0.04
+    const amount = 0.04;
     // https://etherscan.io/tx/0x37765af1a7924fb6ee22c83668e55719c9ecb1b79928bd4b208c42dfff44da3a
     const badFunc = async () => {
       await getTransactionInfoFromNetwork({
@@ -53,17 +54,17 @@ const getTransactionDetailTestCases = () => {
         fromAddress: '0x2ea846dc38c6b6451909f1e7ff2bf613a96dc1f3',
         toAddress: '0x5ac583feb2b1f288c0a51d6cdca2e8c814bfe93b',
         amount,
-        timestamp: 1607360947
-      })
-    }
+        timestamp: 1607360947,
+      });
+    };
     await assertThrowsAsync(
       badFunc,
-      errorMessages.TRANSACTION_FROM_ADDRESS_IS_DIFFERENT_FROM_SENT_FROM_ADDRESS
-    )
-  })
+      errorMessages.TRANSACTION_FROM_ADDRESS_IS_DIFFERENT_FROM_SENT_FROM_ADDRESS,
+    );
+  });
 
   it('should return error when fromAddress of transaction is different from donation fromAddress', async () => {
-    const amount = 0.04
+    const amount = 0.04;
     // https://etherscan.io/tx/0x37765af1a7924fb6ee22c83668e55719c9ecb1b79928bd4b208c42dfff44da3a
     const badFunc = async () => {
       await getTransactionInfoFromNetwork({
@@ -74,17 +75,17 @@ const getTransactionDetailTestCases = () => {
         fromAddress: '0x2ea846dc38c6b6451909f1e7ff2bf613a96dc1f3',
         toAddress: '0x5ac583feb2b1f288c0a51d6cdca2e8c814bfe93b',
         amount,
-        timestamp: 1607360947
-      })
-    }
+        timestamp: 1607360947,
+      });
+    };
     await assertThrowsAsync(
       badFunc,
-      errorMessages.TRANSACTION_FROM_ADDRESS_IS_DIFFERENT_FROM_SENT_FROM_ADDRESS
-    )
-  })
+      errorMessages.TRANSACTION_FROM_ADDRESS_IS_DIFFERENT_FROM_SENT_FROM_ADDRESS,
+    );
+  });
 
   it('should return error when transaction time is newer than sent timestamp on mainnet', async () => {
-    const amount = 0.04
+    const amount = 0.04;
     // https://etherscan.io/tx/0x37765af1a7924fb6ee22c83668e55719c9ecb1b79928bd4b208c42dfff44da3a
     const badFunc = async () => {
       await getTransactionInfoFromNetwork({
@@ -95,20 +96,20 @@ const getTransactionDetailTestCases = () => {
         fromAddress: '0x839395e20bbB182fa440d08F850E6c7A8f6F0780',
         toAddress: '0x5ac583feb2b1f288c0a51d6cdca2e8c814bfe93b',
         amount,
-        timestamp: 1607360949
-      })
-    }
+        timestamp: 1607360950 + ONE_DAY,
+      });
+    };
     await assertThrowsAsync(
       badFunc,
-      errorMessages.TRANSACTION_CANT_BE_OLDER_THAN_DONATION
-    )
-  })
+      errorMessages.TRANSACTION_CANT_BE_OLDER_THAN_DONATION,
+    );
+  });
 
   it('should return transaction when transactionHash is wrong because of speedup in mainnet', async () => {
-    const amount = 0.04
+    const amount = 0.04;
     // https://etherscan.io/tx/0x37765af1a7924fb6ee22c83668e55719c9ecb1b79928bd4b208c42dfff44da3a
     const txHash =
-      '0x37765af1a7924fb6ee22c83668e55719c9ecb1b79928bd4b208c42dfff44da21'
+      '0x37765af1a7924fb6ee22c83668e55719c9ecb1b79928bd4b208c42dfff44da21';
     const transactionInfo = await getTransactionInfoFromNetwork({
       txHash,
       symbol: 'ETH',
@@ -117,16 +118,16 @@ const getTransactionDetailTestCases = () => {
       toAddress: '0x5ac583feb2b1f288c0a51d6cdca2e8c814bfe93b',
       nonce: 3938,
       amount,
-      timestamp: 1607360947
-    })
-    assert.isOk(transactionInfo)
-    assert.equal(transactionInfo.currency, 'ETH')
-    assert.equal(transactionInfo.amount, amount)
-    assert.notEqual(transactionInfo.hash, txHash)
-  })
+      timestamp: 1607360947,
+    });
+    assert.isOk(transactionInfo);
+    assert.equal(transactionInfo.currency, 'ETH');
+    assert.equal(transactionInfo.amount, amount);
+    assert.notEqual(transactionInfo.hash, txHash);
+  });
   it('should return transaction detail for DAI token transfer on mainnet', async () => {
     // https://etherscan.io/tx/0x5b80133493a5be96385f00ce22a69c224e66fa1fc52b3b4c33e9057f5e873f49
-    const amount = 1760
+    const amount = 1760;
     const transactionInfo = await getTransactionInfoFromNetwork({
       txHash:
         '0x5b80133493a5be96385f00ce22a69c224e66fa1fc52b3b4c33e9057f5e873f49',
@@ -135,15 +136,15 @@ const getTransactionDetailTestCases = () => {
       fromAddress: '0x5ac583feb2b1f288c0a51d6cdca2e8c814bfe93b',
       toAddress: '0x2Ea846Dc38C6b6451909F1E7ff2bF613a96DC1F3',
       amount,
-      timestamp: 1624772582
-    })
-    assert.isOk(transactionInfo)
-    assert.equal(transactionInfo.currency, 'DAI')
-    assert.equal(transactionInfo.amount, amount)
-  })
+      timestamp: 1624772582,
+    });
+    assert.isOk(transactionInfo);
+    assert.equal(transactionInfo.currency, 'DAI');
+    assert.equal(transactionInfo.amount, amount);
+  });
 
   it('should return error when fromAddress of transaction is different from donation fromAddress for DAI in mainnet', async () => {
-    const amount = 1760
+    const amount = 1760;
     // https://etherscan.io/tx/0x5b80133493a5be96385f00ce22a69c224e66fa1fc52b3b4c33e9057f5e873f49
     const badFunc = async () => {
       await getTransactionInfoFromNetwork({
@@ -155,17 +156,17 @@ const getTransactionDetailTestCases = () => {
         toAddress: '0x2Ea846Dc38C6b6451909F1E7ff2bF613a96DC1F3',
         amount,
         nonce: 4,
-        timestamp: 1624772582
-      })
-    }
+        timestamp: 1624772582,
+      });
+    };
     await assertThrowsAsync(
       badFunc,
-      errorMessages.TRANSACTION_FROM_ADDRESS_IS_DIFFERENT_FROM_SENT_FROM_ADDRESS
-    )
-  })
+      errorMessages.TRANSACTION_FROM_ADDRESS_IS_DIFFERENT_FROM_SENT_FROM_ADDRESS,
+    );
+  });
 
   it('should return error when toAddress of transaction is different to donation toAddress for DAI in mainnet', async () => {
-    const amount = 1760
+    const amount = 1760;
     // https://etherscan.io/tx/0x5b80133493a5be96385f00ce22a69c224e66fa1fc52b3b4c33e9057f5e873f49
     const badFunc = async () => {
       await getTransactionInfoFromNetwork({
@@ -177,17 +178,17 @@ const getTransactionDetailTestCases = () => {
         toAddress: '0x2Ea846Dc38C6b6451909F1E7ff2bF613a96DC1F4',
         amount,
         nonce: 4,
-        timestamp: 1624772582
-      })
-    }
+        timestamp: 1624772582,
+      });
+    };
     await assertThrowsAsync(
       badFunc,
-      errorMessages.TRANSACTION_TO_ADDRESS_IS_DIFFERENT_FROM_SENT_TO_ADDRESS
-    )
-  })
+      errorMessages.TRANSACTION_TO_ADDRESS_IS_DIFFERENT_FROM_SENT_TO_ADDRESS,
+    );
+  });
 
   it('should return error when sent nonce didnt mine already', async () => {
-    const amount = 1760
+    const amount = 1760;
     const badFunc = async () => {
       await getTransactionInfoFromNetwork({
         txHash:
@@ -198,18 +199,18 @@ const getTransactionDetailTestCases = () => {
         toAddress: '0x2Ea846Dc38C6b6451909F1E7ff2bF613a96DC1F3',
         amount,
         nonce: 99999999,
-        timestamp: 1624772582
-      })
-    }
+        timestamp: 1624772582,
+      });
+    };
     await assertThrowsAsync(
       badFunc,
-      errorMessages.TRANSACTION_WITH_THIS_NONCE_IS_NOT_MINED_ALREADY
-    )
-  })
+      errorMessages.TRANSACTION_WITH_THIS_NONCE_IS_NOT_MINED_ALREADY,
+    );
+  });
 
   it('should return error when transaction amount is different with donation amount', async () => {
     // https://etherscan.io/tx/0x5b80133493a5be96385f00ce22a69c224e66fa1fc52b3b4c33e9057f5e873f49
-    const amount = 1730
+    const amount = 1730;
     const badFunc = async () => {
       await getTransactionInfoFromNetwork({
         txHash:
@@ -220,20 +221,20 @@ const getTransactionDetailTestCases = () => {
         toAddress: '0x2Ea846Dc38C6b6451909F1E7ff2bF613a96DC1F3',
         amount,
         nonce: 4,
-        timestamp: 1624772582
-      })
-    }
+        timestamp: 1624772582,
+      });
+    };
     await assertThrowsAsync(
       badFunc,
-      errorMessages.TRANSACTION_AMOUNT_IS_DIFFERENT_WITH_SENT_AMOUNT
-    )
-  })
+      errorMessages.TRANSACTION_AMOUNT_IS_DIFFERENT_WITH_SENT_AMOUNT,
+    );
+  });
 
   it('should return transaction detail for DAI token transfer on mainnet when transaction is invalid but speedup', async () => {
     // https://etherscan.io/tx/0x5b80133493a5be96385f00ce22a69c224e66fa1fc52b3b4c33e9057f5e873f49
-    const amount = 1760
+    const amount = 1760;
     const txHash =
-      '0x5b80133493a5be96385f00ce22a69c224e66fa1fc52b3b4c33e9057f5e871229'
+      '0x5b80133493a5be96385f00ce22a69c224e66fa1fc52b3b4c33e9057f5e871229';
     const transactionInfo = await getTransactionInfoFromNetwork({
       txHash,
       symbol: 'DAI',
@@ -242,17 +243,17 @@ const getTransactionDetailTestCases = () => {
       toAddress: '0x2Ea846Dc38C6b6451909F1E7ff2bF613a96DC1F3',
       amount,
       nonce: 4,
-      timestamp: 1624772582
-    })
-    assert.isOk(transactionInfo)
-    assert.equal(transactionInfo.currency, 'DAI')
-    assert.equal(transactionInfo.amount, amount)
-    assert.notEqual(transactionInfo.hash, txHash)
-  })
+      timestamp: 1624772582,
+    });
+    assert.isOk(transactionInfo);
+    assert.equal(transactionInfo.currency, 'DAI');
+    assert.equal(transactionInfo.amount, amount);
+    assert.notEqual(transactionInfo.hash, txHash);
+  });
 
   it('should return transaction detail for normal transfer on ropsten', async () => {
     // https://ropsten.etherscan.io/tx/0xd65478445fa41679fc5fd2a171f56a71a2f006a2246d4b408be97a251e330da7
-    const amount = 0.001
+    const amount = 0.001;
     const transactionInfo = await getTransactionInfoFromNetwork({
       txHash:
         '0xd65478445fa41679fc5fd2a171f56a71a2f006a2246d4b408be97a251e330da7',
@@ -261,17 +262,17 @@ const getTransactionDetailTestCases = () => {
       fromAddress: '0xb20a327c9b4da091f454b1ce0e2e4dc5c128b5b4',
       toAddress: '0x5d28fe1e9f895464aab52287d85ebff32b351674',
       amount,
-      timestamp: 1621072452
-    })
-    assert.isOk(transactionInfo)
-    assert.equal(transactionInfo.currency, 'ETH')
-    assert.equal(transactionInfo.amount, amount)
-  })
+      timestamp: 1621072452,
+    });
+    assert.isOk(transactionInfo);
+    assert.equal(transactionInfo.currency, 'ETH');
+    assert.equal(transactionInfo.amount, amount);
+  });
   it('should return transaction when transactionHash is wrong because of speedup on ropsten', async () => {
     // https://ropsten.etherscan.io/tx/0xd65478445fa41679fc5fd2a171f56a71a2f006a2246d4b408be97a251e330da7
-    const amount = 0.001
+    const amount = 0.001;
     const txHash =
-      '0xd65478445fa41679fc5fd2a171f56a71a2f006a2246d4b408be97a251e331234'
+      '0xd65478445fa41679fc5fd2a171f56a71a2f006a2246d4b408be97a251e331234';
     const transactionInfo = await getTransactionInfoFromNetwork({
       txHash,
       symbol: 'ETH',
@@ -280,20 +281,20 @@ const getTransactionDetailTestCases = () => {
       toAddress: '0x5d28fe1e9f895464aab52287d85ebff32b351674',
       amount,
       nonce: 70,
-      timestamp: 1621072452
-    })
-    assert.isOk(transactionInfo)
-    assert.equal(transactionInfo.currency, 'ETH')
-    assert.equal(transactionInfo.amount, amount)
-    assert.notEqual(transactionInfo.hash, txHash)
+      timestamp: 1621072452,
+    });
+    assert.isOk(transactionInfo);
+    assert.equal(transactionInfo.currency, 'ETH');
+    assert.equal(transactionInfo.amount, amount);
+    assert.notEqual(transactionInfo.hash, txHash);
     assert.equal(
       transactionInfo.hash,
-      '0xd65478445fa41679fc5fd2a171f56a71a2f006a2246d4b408be97a251e330da7'
-    )
-  })
+      '0xd65478445fa41679fc5fd2a171f56a71a2f006a2246d4b408be97a251e330da7',
+    );
+  });
   it('should return transaction detail for normal transfer on xdai', async () => {
     // https://blockscout.com/xdai/mainnet/tx/0x57b913ac40b2027a08655bdb495befc50612b72a9dd1f2be81249c970503c734
-    const amount = 0.001
+    const amount = 0.001;
     const transactionInfo = await getTransactionInfoFromNetwork({
       txHash:
         '0x57b913ac40b2027a08655bdb495befc50612b72a9dd1f2be81249c970503c734',
@@ -302,14 +303,14 @@ const getTransactionDetailTestCases = () => {
       fromAddress: '0xb20a327c9b4da091f454b1ce0e2e4dc5c128b5b4',
       toAddress: '0x7ee789b7e6fa20eab7ecbce44626afa7f58a94b7',
       amount,
-      timestamp: 1621241124
-    })
-    assert.isOk(transactionInfo)
-    assert.equal(transactionInfo.currency, 'XDAI')
-    assert.equal(transactionInfo.amount, amount)
-  })
+      timestamp: 1621241124,
+    });
+    assert.isOk(transactionInfo);
+    assert.equal(transactionInfo.currency, 'XDAI');
+    assert.equal(transactionInfo.amount, amount);
+  });
   it('should return error when transactionHash is wrong on  xdai', async () => {
-    const amount = 0.001
+    const amount = 0.001;
     const badFunc = async () => {
       await getTransactionInfoFromNetwork({
         txHash:
@@ -319,15 +320,15 @@ const getTransactionDetailTestCases = () => {
         fromAddress: '0xb20a327c9b4da091f454b1ce0e2e4dc5c128b5b4',
         toAddress: '0x7ee789b7e6fa20eab7ecbce44626afa7f58a94b7',
         amount,
-        timestamp: 1621241124
-      })
-    }
-    await assertThrowsAsync(badFunc, errorMessages.TRANSACTION_NOT_FOUND)
-  })
+        timestamp: 1621241124,
+      });
+    };
+    await assertThrowsAsync(badFunc, errorMessages.TRANSACTION_NOT_FOUND);
+  });
 
   it('should return transaction when transactionHash is wrong because of speedup in xdai', async () => {
     // https://blockscout.com/xdai/mainnet/tx/0x57b913ac40b2027a08655bdb495befc50612b72a9dd1f2be81249c970503c734
-    const amount = 0.001
+    const amount = 0.001;
     const transactionInfo = await getTransactionInfoFromNetwork({
       txHash:
         '0x57b913ac40b2027a08655bdb495befc50612b72a9dd1f2be81249c970503c722',
@@ -337,15 +338,15 @@ const getTransactionDetailTestCases = () => {
       toAddress: '0x7ee789b7e6fa20eab7ecbce44626afa7f58a94b7',
       amount,
       nonce: 10,
-      timestamp: 1621241124
-    })
-    assert.isOk(transactionInfo)
-    assert.equal(transactionInfo.currency, 'XDAI')
-    assert.equal(transactionInfo.amount, amount)
-  })
+      timestamp: 1621241124,
+    });
+    assert.isOk(transactionInfo);
+    assert.equal(transactionInfo.currency, 'XDAI');
+    assert.equal(transactionInfo.amount, amount);
+  });
   it('should return transaction detail for HNY token transfer on XDAI', async () => {
     // https://blockscout.com/xdai/mainnet/tx/0x99e70642fe1aa03cb2db35c3e3909466e66b233840b7b1e0dd47296c878c16b4
-    const amount = 0.001
+    const amount = 0.001;
     const transactionInfo = await getTransactionInfoFromNetwork({
       txHash:
         '0x99e70642fe1aa03cb2db35c3e3909466e66b233840b7b1e0dd47296c878c16b4',
@@ -354,15 +355,15 @@ const getTransactionDetailTestCases = () => {
       fromAddress: '0x826976d7c600d45fb8287ca1d7c76fc8eb732030',
       toAddress: '0x5A5a0732c1231D99DB8FFcA38DbEf1c8316fD3E1',
       amount,
-      timestamp: 1617903449
-    })
-    assert.isOk(transactionInfo)
-    assert.equal(transactionInfo.currency, 'HNY')
-    assert.equal(transactionInfo.amount, amount)
-  })
+      timestamp: 1617903449,
+    });
+    assert.isOk(transactionInfo);
+    assert.equal(transactionInfo.currency, 'HNY');
+    assert.equal(transactionInfo.amount, amount);
+  });
   it('should return error when transaction time is newer than sent timestamp for HNY token transfer on XDAI', async () => {
     // https://blockscout.com/xdai/mainnet/tx/0x99e70642fe1aa03cb2db35c3e3909466e66b233840b7b1e0dd47296c878c16b4
-    const amount = 0.001
+    const amount = 0.001;
     const badFunc = async () => {
       await getTransactionInfoFromNetwork({
         txHash:
@@ -372,17 +373,17 @@ const getTransactionDetailTestCases = () => {
         fromAddress: '0x826976d7c600d45fb8287ca1d7c76fc8eb732030',
         toAddress: '0x5A5a0732c1231D99DB8FFcA38DbEf1c8316fD3E1',
         amount,
-        timestamp: 1617903451
-      })
-    }
+        timestamp: 1617903450 + ONE_DAY,
+      });
+    };
     await assertThrowsAsync(
       badFunc,
-      errorMessages.TRANSACTION_CANT_BE_OLDER_THAN_DONATION
-    )
-  })
+      errorMessages.TRANSACTION_CANT_BE_OLDER_THAN_DONATION,
+    );
+  });
   it('should return transaction detail for HNY token transfer on when transaction is invalid but speedup ', async () => {
     // https://blockscout.com/xdai/mainnet/tx/0x99e70642fe1aa03cb2db35c3e3909466e66b233840b7b1e0dd47296c878c16b4
-    const amount = 0.001
+    const amount = 0.001;
     const transactionInfo = await getTransactionInfoFromNetwork({
       txHash:
         '0x99e70642fe1aa03cb2db35c3e3909466e66b233840b7b1e0dd47296c878c1234',
@@ -392,11 +393,11 @@ const getTransactionDetailTestCases = () => {
       toAddress: '0x5A5a0732c1231D99DB8FFcA38DbEf1c8316fD3E1',
       amount,
       nonce: 41,
-      timestamp: 1617903449
-    })
-    assert.isOk(transactionInfo)
-    assert.equal(transactionInfo.currency, 'HNY')
-    assert.equal(transactionInfo.amount, amount)
-  })
-}
-describe('getTransactionDetail test cases', getTransactionDetailTestCases)
+      timestamp: 1617903449,
+    });
+    assert.isOk(transactionInfo);
+    assert.equal(transactionInfo.currency, 'HNY');
+    assert.equal(transactionInfo.amount, amount);
+  });
+};
+describe('getTransactionDetail test cases', getTransactionDetailTestCases);

--- a/services/transactionService.test.ts
+++ b/services/transactionService.test.ts
@@ -268,6 +268,25 @@ const getTransactionDetailTestCases = () => {
     assert.equal(transactionInfo.currency, 'ETH');
     assert.equal(transactionInfo.amount, amount);
   });
+
+  it('should return transaction detail for UNI token transfer on ropsten', async () => {
+    // https://ropsten.etherscan.io/tx/0xba3c2627c9d3dd963455648b4f9d7239e8b5c80d0aa85ac354d2b762d99e4441
+    const amount = 0.01;
+    const transactionInfo = await getTransactionInfoFromNetwork({
+      txHash:
+        '0xba3c2627c9d3dd963455648b4f9d7239e8b5c80d0aa85ac354d2b762d99e4441',
+      symbol: 'UNI',
+      networkId: NETWORK_IDS.ROPSTEN,
+      fromAddress: '0x826976d7c600d45fb8287ca1d7c76fc8eb732030',
+      toAddress: '0x8f951903c9360345b4e1b536c7f5ae8f88a64e79',
+      amount,
+      timestamp: 1615739937,
+    });
+    assert.isOk(transactionInfo);
+    assert.equal(transactionInfo.currency, 'UNI');
+    assert.equal(transactionInfo.amount, amount);
+  });
+
   it('should return transaction when transactionHash is wrong because of speedup on ropsten', async () => {
     // https://ropsten.etherscan.io/tx/0xd65478445fa41679fc5fd2a171f56a71a2f006a2246d4b408be97a251e330da7
     const amount = 0.001;
@@ -359,6 +378,23 @@ const getTransactionDetailTestCases = () => {
     });
     assert.isOk(transactionInfo);
     assert.equal(transactionInfo.currency, 'HNY');
+    assert.equal(transactionInfo.amount, amount);
+  });
+  it('should return transaction detail for USDC token transfer on XDAI', async () => {
+    // https://blockscout.com/xdai/mainnet/tx/0x00aef89fc40cea0cc0cb7ae5ac18c0e586dccb200b230a9caabca0e08ff7a36b
+    const amount = 1;
+    const transactionInfo = await getTransactionInfoFromNetwork({
+      txHash:
+        '0x00aef89fc40cea0cc0cb7ae5ac18c0e586dccb200b230a9caabca0e08ff7a36b',
+      symbol: 'USDC',
+      networkId: NETWORK_IDS.XDAI,
+      fromAddress: '0x826976d7c600d45fb8287ca1d7c76fc8eb732030',
+      toAddress: '0x87f1c862c166b0ceb79da7ad8d0864d53468d076',
+      amount,
+      timestamp: 1626278641,
+    });
+    assert.isOk(transactionInfo);
+    assert.equal(transactionInfo.currency, 'USDC');
     assert.equal(transactionInfo.amount, amount);
   });
   it('should return error when transaction time is newer than sent timestamp for HNY token transfer on XDAI', async () => {

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -238,10 +238,6 @@ function validateTransactionWithInputData(
     );
   }
   if (transaction.amount !== input.amount) {
-    console.log('validateTransactionWithInputData() different amount', {
-      transaction,
-      input,
-    });
     throw new Error(
       errorMessages.TRANSACTION_AMOUNT_IS_DIFFERENT_WITH_SENT_AMOUNT,
     );

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -91,9 +91,10 @@ async function findTransactionByNonce(data: {
   // userRecentTransactions just includes the transactions that source is our fromAddress
   // so if the lowest nonce in this array is smaller than the sent nonce we would know that we should not
   // check latest transactions
-  const smallestNonce = userRecentTransactions.length > 0 ? userRecentTransactions[
-    userRecentTransactions.length - 1
-  ].nonce : undefined;
+  const smallestNonce =
+    userRecentTransactions.length > 0
+      ? userRecentTransactions[userRecentTransactions.length - 1].nonce
+      : undefined;
 
   if (smallestNonce !== undefined && smallestNonce < nonce) {
     console.log('checkIfTransactionHasBeenSpeedup', {
@@ -241,9 +242,10 @@ function validateTransactionWithInputData(
       errorMessages.TRANSACTION_AMOUNT_IS_DIFFERENT_WITH_SENT_AMOUNT,
     );
   }
-  if (transaction.timestamp <= input.timestamp) {
+  const ONE_HOUR = 60 * 60;
+  if (input.timestamp - transaction.timestamp > ONE_HOUR) {
     // because we first create donation, then transaction will be mined, the transaction always should be greater than
-    // donation created time
+    // donation created time, but we set one hour because maybe our server time is different with blockchain time server
     throw new Error(errorMessages.TRANSACTION_CANT_BE_OLDER_THAN_DONATION);
   }
 }

--- a/services/transactionService.ts
+++ b/services/transactionService.ts
@@ -238,6 +238,10 @@ function validateTransactionWithInputData(
     );
   }
   if (transaction.amount !== input.amount) {
+    console.log('validateTransactionWithInputData() different amount', {
+      transaction,
+      input,
+    });
     throw new Error(
       errorMessages.TRANSACTION_AMOUNT_IS_DIFFERENT_WITH_SENT_AMOUNT,
     );

--- a/utils/tokenUtils.ts
+++ b/utils/tokenUtils.ts
@@ -1,5 +1,5 @@
-import { errorMessages } from './errorMessages'
-import { NETWORK_IDS } from '../provider'
+import { errorMessages } from './errorMessages';
+import { NETWORK_IDS } from '../provider';
 
 /**
  * tokens list comes from https://github.com/Giveth/giveth-next/blob/master/src/utils/erc20TokenList.js
@@ -9,537 +9,538 @@ const mainnetTokens = [
     address: '0xd56dac73a4d6766464b38ec6d91eb45ce7457c44',
     symbol: 'PAN',
     name: 'Panvala',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x6b175474e89094c44da98b954eedeac495271d0f',
     symbol: 'DAI',
     name: 'Dai',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
     symbol: 'USDT',
     name: 'Tether',
-    decimals: 6
+    decimals: 6,
   },
   {
     address: '0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b',
     symbol: 'CRO',
     name: 'Crypto.com Coin',
-    decimals: 8
+    decimals: 8,
   },
   {
     address: '0x514910771af9ca656af840dff83e8264ecf986ca',
     symbol: 'LINK',
     name: 'Chainlink',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x2af5d2ad76741191d15dfe7bf6ac92d4bd912ca3',
     symbol: 'LEO',
     name: 'UNUS SED LEO',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
     symbol: 'USDC',
     name: 'USD Coin',
-    decimals: 6
+    decimals: 6,
   },
   {
     address: '0x6f259637dcd74c767781e37bc6133cd6a68aa161',
     symbol: 'HT',
     name: 'Huobi Token',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xc00e94cb662c3520282e6f5717214004a7f26888',
     symbol: 'COMP',
     name: 'Compound',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2',
     symbol: 'MKR',
     name: 'Maker',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xf1290473e210b2108a85237fbcd7b6eb42cc654f',
     symbol: 'HEDG',
     name: 'HedgeTrade',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
     symbol: 'BAT',
     name: 'Basic Attention Token',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x75231f58b43240c9718dd58b4967c5114342a86c',
     symbol: 'OKB',
     name: 'OKB',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x8e870d67f660d95d5be530380d0ec0bd388289e1',
     symbol: 'PAX',
     name: 'Paxos Standard',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xe41d2489571d322189246dafa5ebde1f4699f498',
     symbol: 'ZRX',
     name: '0x',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xdd974d5c2e2928dea5f71b9825b8b646686bd200',
     symbol: 'KNC',
     name: 'Kyber Network',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xd26114cd6ee289accf82350c8d8487fedb8a0c07',
     symbol: 'OMG',
     name: 'OMG Network',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x10086399dd8c1e3de736724af52587a2044c9fa2',
     symbol: 'TMTG',
     name: 'The Midas Touch Gold',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x1985365e9f78359a9b6ad760e32412f4a445e862',
     symbol: 'REP',
     name: 'Augur',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x80fb784b7ed66730e8b1dbd9820afd29931aab03',
     symbol: 'LEND',
     name: 'Aave',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
     symbol: 'SNX',
     name: 'Synthetix Network Token',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xe99a894a69d7c2e3c92e61b64c505a6a57d2bc07',
     symbol: 'HYN',
     name: 'Hyperion',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c',
     symbol: 'ENJ',
     name: 'Enjin Coin',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x408e41876cccdc0f92210600ef50372656052a38',
     symbol: 'REN',
     name: 'Ren',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xdf574c24545e5ffecb9a659c229253d4111d87e1',
     symbol: 'HUSD',
     name: 'HUSD',
-    decimals: 8
+    decimals: 8,
   },
   {
     address: '0xaaaebe6fe48e54f431b0c390cfaf0b017d09d42d',
     symbol: 'CEL',
     name: 'Celsius',
-    decimals: 4
+    decimals: 4,
   },
   {
     address: '0xbd0793332e9fb844a52a205a233ef27a5b34b927',
     symbol: 'ZB',
     name: 'ZB Token',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x973e52691176d36453868d9d86572788d27041a9',
     symbol: 'DX',
     name: 'DxChain Token',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x4a220e6096b25eadb88358cb44068a3248254675',
     symbol: 'QNT',
     name: 'Quant',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x6c6ee5e31d828de241282b9606c8e98ea48526e2',
     symbol: 'HOT',
     name: 'Holo',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xba9d4199fab4f26efe3551d490e3821486f135ba',
     symbol: 'CHSB',
     name: 'SwissBorg',
-    decimals: 8
+    decimals: 8,
   },
   {
     address: '0xbbbbca6a901c926f240b89eacb641d8aec7aeafd',
     symbol: 'LRC',
     name: 'Loopring',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x744d70fdbe2ba4cf95131626614a1763df805b9e',
     symbol: 'SNT',
     name: 'Status',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xa974c709cfb4566686553a20790685a47aceaa33',
     symbol: 'XIN',
     name: 'Mixin',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c',
     symbol: 'BNT',
     name: 'Bancor',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x039b5649a59967e3e936d7471f9c3700100ee1ab',
     symbol: 'KCS',
     name: 'KuCoin Shares',
-    decimals: 6
+    decimals: 6,
   },
   {
     address: '0xb63b606ac810a52cca15e44bb630fd42d8d1d83d',
     symbol: 'MCO',
     name: 'MCO',
-    decimals: 8
+    decimals: 8,
   },
   {
     address: '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0',
     symbol: 'MATIC',
     name: 'Matic Network',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x73cee8348b9bdd48c64e13452b8a6fbc81630573',
     symbol: 'EGR',
     name: 'Egoras',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x1776e1f26f98b1a5df9cd347953a26dd3cb46671',
     symbol: 'NMR',
     name: 'Numeraire',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
     symbol: 'WBTC',
     name: 'Wrapped Bitcoin',
-    decimals: 8
+    decimals: 8,
   },
   {
     address: '0x0f5d2fb29fb7d3cfee444a200298f468908cc942',
     symbol: 'MANA',
     name: 'Decentraland',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xa74476443119a942de498590fe1f2454d7d4ac0d',
     symbol: 'GNT',
     name: 'Golem',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x45804880de22913dafe09f4980848ece6ecbaf78',
     symbol: 'PAXG',
     name: 'PAX Gold',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x607f4c5bb672230e8672085532f7e901544a7375',
     symbol: 'RLC',
     name: 'iExec RLC',
-    decimals: 9
+    decimals: 9,
   },
   {
     address: '0xbf2179859fc6d5bee9bf9158632dc51678a4100e',
     symbol: 'ELF',
     name: 'aelf',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x446c9033e7516d820cc9a2ce2d0b7328b579406f',
     symbol: 'SOLVE',
     name: 'SOLVE',
-    decimals: 8
+    decimals: 8,
   },
   {
     address: '0x8762db106b2c2a0bccb3a80d1ed41273552616e8',
     symbol: 'RSR',
     name: 'Reserve Rights',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xf51ebf9a26dbc02b13f8b3a9110dac47a4d62d78',
     symbol: 'APIX',
     name: 'APIX',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x960b236a07cf122663c4303350609a66a7b288c0',
     symbol: 'ANT',
     name: 'Aragon',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e',
     symbol: 'UBT',
     name: 'Unibright',
-    decimals: 8
+    decimals: 8,
   },
   {
     address: '0xbe428c3867f05dea2a89fc76a102b544eac7f772',
     symbol: 'CVT',
     name: 'CyberVein',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xb683d83a532e2cb7dfa5275eed3698436371cc9f',
     symbol: 'BTU',
     name: 'BTU Protocol',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x1c83501478f1320977047008496dacbd60bb15ef',
     symbol: 'DGTX',
     name: 'Digitex Futures',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x6bc1f3a1ae56231dbb64d3e82e070857eae86045',
     symbol: 'XSR',
     name: 'Xensor',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x419c4db4b9e25d6db2ad9691ccb832c8d9fda05e',
     symbol: 'DRGN',
     name: 'Dragonchain',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xdb25f211ab05b1c97d595516f45794528a807ad8',
     symbol: 'EURS',
     name: 'STASIS EURO',
-    decimals: 2
+    decimals: 2,
   },
   {
     address: '0x595832f8fc6bf59c85c527fec3740a1b7a361269',
     symbol: 'POWR',
     name: 'Power Ledger',
-    decimals: 6
+    decimals: 6,
   },
   {
     address: '0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9',
     symbol: 'SXP',
     name: 'Swipe',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xa15c7ebe1f07caf6bff097d8a589fb8ac49ae5b3',
     symbol: 'NPXS',
     name: 'Pundi X',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xe66747a101bff2dba3697199dcce5b743b454759',
     symbol: 'GT',
     name: 'Gatechain Token',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x653430560be843c4a3d143d0110e896c2ab8ac0d',
     symbol: 'MOF',
     name: 'Molecular Future',
-    decimals: 16
+    decimals: 16,
   },
   {
     address: '0xff56cc6b1e6ded347aa0b7676c85ab0b3d08b0fa',
     symbol: 'ORBS',
     name: 'Orbs',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x80a7e048f37a50500351c204cb407766fa3bae7f',
     symbol: 'CRPT',
     name: 'Crypterium',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xf970b8e36e23f7fc3fd752eea86f8be8d83375a6',
     symbol: 'RCN',
     name: 'Ripio Credit Network',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x0cf0ee63788a0849fe5297f3407f701e122cc023',
     symbol: 'DATA',
     name: 'Streamr',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xa66daa57432024023db65477ba87d4e7f5f95213',
     symbol: 'HPT',
     name: 'Huobi Pool Token',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xfc29b6e626b67776675fff55d5bc0452d042f434',
     symbol: 'BHT',
     name: 'BHEX Token',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x6810e776880c02933d47db1b9fc05908e5386b96',
     symbol: 'GNO',
     name: 'Gnosis',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xb705268213d593b8fd88d3fdeff93aff5cbdcfae',
     symbol: 'IDEX',
     name: 'IDEX',
-    decimals: 18
-  }
-]
+    decimals: 18,
+  },
+];
 
 const ropstenTokens = [
   {
     address: '0xad6d458402f60fd3bd25163575031acdce07538d',
     symbol: 'DAI',
     name: 'DAI Ropsten',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x067eA48882E6D728A37acfd1535ec03f8E33794a',
     symbol: 'YAY',
     name: 'Giveth Ropsten Test',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
     symbol: 'UNI',
-    name: 'UNI Ropsten'
-  }
-]
+    name: 'UNI Ropsten',
+    decimals: 18,
+  },
+];
 
 const xDaiTokens = [
   {
     address: '0x981fb9ba94078a2275a8fc906898ea107b9462a8',
     symbol: 'PAN',
     name: 'Panvala',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x71850b7E9Ee3f13Ab46d67167341E4bDc905Eef9',
     symbol: 'HNY',
     name: 'Honey',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e',
     symbol: 'STAKE',
-    name: 'STAKE on xDai'
-    // decimals: 18
+    name: 'STAKE on xDai',
+    decimals: 18
   },
   {
     address: '0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83',
     symbol: 'USDC',
-    name: 'USDC on xDai'
-    // decimals: 18
+    name: 'USDC on xDai',
+    decimals: 6
   },
   {
     address: '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1',
     symbol: 'WETH',
-    name: 'Wrapped Ether on xDai'
-    // decimals: 18
+    name: 'Wrapped Ether on xDai',
+    decimals: 18
   },
   {
     address: '0xE2e73A1c69ecF83F464EFCE6A5be353a37cA09b2',
     symbol: 'LINK',
-    name: 'ChainLink Token on xDai'
-    // decimals: 18
+    name: 'ChainLink Token on xDai',
+    decimals: 18
   },
   {
     address: '0x1e16aa4Df73d29C029d94CeDa3e3114EC191E25A',
     symbol: 'xMOON',
-    name: 'Moons on xDai'
-    // decimals: 18
+    name: 'Moons on xDai',
+    decimals: 18
   },
   {
     address: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d',
     symbol: 'WXDAI',
     name: 'Wrapped XDAI',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x4ECaBa5870353805a9F068101A40E0f32ed605C6',
     symbol: 'USDT',
     name: 'Tether USD on xDai',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x8e5bBbb09Ed1ebdE8674Cda39A0c169401db4252',
     symbol: 'WBTC',
     name: 'Wrapped BTC on xDai',
-    decimals: 18
+    decimals: 18,
   },
   {
     address: '0x3a97704a1b25F08aa230ae53B352e2e72ef52843',
     symbol: 'AGVE',
-    name: 'Agave Token'
-    // decimals: 18
-  }
-]
+    name: 'Agave Token',
+    decimals: 18,
+  },
+];
 
 export const findTokenByNetworkAndSymbol = (
   networkId: number,
-  symbol: string
+  symbol: string,
 ): {
-  address: string
-  symbol: string
-  decimals: number
+  address: string;
+  symbol: string;
+  decimals: number;
 } => {
-  let token
+  let token;
   if (networkId === NETWORK_IDS.MAIN_NET) {
-    token = mainnetTokens.find(item => item.symbol === symbol)
+    token = mainnetTokens.find(item => item.symbol === symbol);
   } else if (networkId === NETWORK_IDS.XDAI) {
-    token = xDaiTokens.find(item => item.symbol === symbol)
+    token = xDaiTokens.find(item => item.symbol === symbol);
   } else if (networkId === NETWORK_IDS.ROPSTEN) {
-    token = ropstenTokens.find(item => item.symbol === symbol)
+    token = ropstenTokens.find(item => item.symbol === symbol);
   } else {
-    throw new Error(errorMessages.INVALID_NETWORK_ID)
+    throw new Error(errorMessages.INVALID_NETWORK_ID);
   }
   if (!token) {
-    throw new Error(errorMessages.INVALID_TOKEN_SYMBOL)
+    throw new Error(errorMessages.INVALID_TOKEN_SYMBOL);
   }
   return {
     address: token.address,
     decimals: token.decimals,
-    symbol
-  }
-}
+    symbol,
+  };
+};


### PR DESCRIPTION
related to #168 

merging #166 to staging, I  monitored the logs and found these problems
* Can not calculate amount for `UNI` transfer on `Ropsten`
* Can not calculate amount for `USDC` transfer on `xDai`
* Checking transaction time and donation time cause some edge cases
* `verifyErrorMessage` and `nonce` are not nullable and cause errors when calling graphql query

I have resolved these issues in this PR. ( and for `UNI` and `USDC` I have added some test cases to make sure they are ok)