### PR TITLE
Feature/add admin to all projects query

### DIFF
--- a/entities/project.ts
+++ b/entities/project.ts
@@ -172,6 +172,10 @@ class Project extends BaseEntity {
   @Column({ default: null, nullable: true })
   listed: boolean;
 
+  // Virtual attribute to subquery result into
+  @Field(type => User)
+  adminUser?: User
+
   /**
    * Custom Query Builders to chain together
    */
@@ -227,6 +231,7 @@ class Project extends BaseEntity {
       .leftJoinAndSelect('project.donations', 'donations')
       .leftJoinAndSelect('project.reactions', 'reactions')
       .leftJoinAndSelect('project.users', 'users')
+      .leftJoinAndMapOne('project.adminUser', User, "user", "user.id = CAST(project.admin AS INTEGER)")
       .innerJoinAndSelect('project.categories', 'c')
       .where(
         `project.statusId = ${ProjStatus.active} AND project.listed = true`,
@@ -239,7 +244,10 @@ class Project extends BaseEntity {
 
     query.orderBy(`project.${sortBy}`, direction);
 
-    return query.take(limit).skip(offset).getManyAndCount();
+    const projects = query.take(limit).skip(offset).getMany();
+    const totalCount = query.getCount();
+
+    return Promise.all([projects, totalCount]);
   }
 
   static notifySegment(project: any, eventName: SegmentEvents) {

--- a/resolvers/projectResolver.ts
+++ b/resolvers/projectResolver.ts
@@ -323,29 +323,6 @@ export class ProjectResolver {
     });
   }
 
-  @Query(returns => ProjectAndAdmin)
-  async projectWithAdminBySlug(@Arg('slug') slug: string) {
-    const project = await this.projectRepository
-      .createQueryBuilder('project')
-      // check current slug and previous slugs
-      .where(`:slug = ANY(project."slugHistory") or project.slug = :slug`, {
-        slug,
-      })
-      .leftJoinAndSelect('project.status', 'status')
-      .leftJoinAndSelect('project.categories', 'categories')
-      .leftJoinAndSelect('project.reactions', 'reactions')
-      .getOne();
-
-    // Typeorm does not know how to handle NaN
-    const adminId = Number(project?.admin);
-    if (Number.isNaN(adminId)) {
-      return { project, admin: null };
-    }
-
-    const admin = await User.findOne({ id: adminId });
-    return { project, admin };
-  }
-
   // Move this to it's own resolver later
   @Query(returns => Project)
   async projectBySlug(@Arg('slug') slug: string) {

--- a/resolvers/projectResolver.ts
+++ b/resolvers/projectResolver.ts
@@ -358,6 +358,7 @@ export class ProjectResolver {
       .leftJoinAndSelect('project.status', 'status')
       .leftJoinAndSelect('project.categories', 'categories')
       .leftJoinAndSelect('project.reactions', 'reactions')
+      .leftJoinAndMapOne('project.adminUser', User, "user", "user.id = CAST(project.admin AS INTEGER)")
       .getOne();
   }
 

--- a/resolvers/projectResolver.ts
+++ b/resolvers/projectResolver.ts
@@ -335,7 +335,12 @@ export class ProjectResolver {
       .leftJoinAndSelect('project.status', 'status')
       .leftJoinAndSelect('project.categories', 'categories')
       .leftJoinAndSelect('project.reactions', 'reactions')
-      .leftJoinAndMapOne('project.adminUser', User, "user", "user.id = CAST(project.admin AS INTEGER)")
+      .leftJoinAndMapOne(
+        'project.adminUser',
+        User,
+        'user',
+        'user.id = CAST(project.admin AS INTEGER)',
+      )
       .getOne();
   }
 


### PR DESCRIPTION
Same as the usual project query but now you can query de adminUser
Made the implementation for the joinColumn of a existing column to be used as a foreign key.
```js
adminUser {
  id
}
```