### PR TITLE
Fix pagination with in-memory slice

### DIFF
--- a/entities/project.ts
+++ b/entities/project.ts
@@ -249,10 +249,7 @@ class Project extends BaseEntity {
 
     query.orderBy(`project.${sortBy}`, direction);
 
-    const projects = query
-      .take(limit)
-      .skip(offset)
-      .getMany();
+    const projects = query.getMany();
     const totalCount = query.getCount();
 
     return Promise.all([projects, totalCount]);

--- a/resolvers/projectResolver.ts
+++ b/resolvers/projectResolver.ts
@@ -263,7 +263,9 @@ export class ProjectResolver {
       filterBy?.value,
     );
 
-    return { projects, totalCount, categories };
+    const paginated_projects = projects.slice(skip, skip + take)
+
+    return { projects: paginated_projects, totalCount, categories };
   }
 
   @Query(returns => TopProjects)


### PR DESCRIPTION
This would be a temporary measure because of all the typeorm bugs regarding using:
Joins + Take/skip pagination + OrderBy
There are multiple issues returning unexpected results.