### PR TITLE
Fix projects query

### DIFF
--- a/entities/project.ts
+++ b/entities/project.ts
@@ -241,6 +241,7 @@ class Project extends BaseEntity {
   ) {
     const query = this.createQueryBuilder('project')
       .leftJoinAndSelect('project.status', 'status')
+      // TODO It was very expensive query and made our backend down in production, maybe we should remove the reactions as well
       // .leftJoinAndSelect('project.donations', 'donations')
       .leftJoinAndSelect('project.reactions', 'reactions')
       .leftJoinAndSelect('project.users', 'users')

--- a/entities/project.ts
+++ b/entities/project.ts
@@ -241,7 +241,7 @@ class Project extends BaseEntity {
   ) {
     const query = this.createQueryBuilder('project')
       .leftJoinAndSelect('project.status', 'status')
-      .leftJoinAndSelect('project.donations', 'donations')
+      // .leftJoinAndSelect('project.donations', 'donations')
       .leftJoinAndSelect('project.reactions', 'reactions')
       .leftJoinAndSelect('project.users', 'users')
       .leftJoinAndMapOne(


### PR DESCRIPTION
The backend kept eating memory and restarting in production, after monitoring DB logs I found the `donations` join is very expensive so we have to delete that