### PR TITLE
Hotfix: Add projectsByUserId query

### DIFF
--- a/resolvers/projectResolver.ts
+++ b/resolvers/projectResolver.ts
@@ -63,7 +63,7 @@ class AllProjects {
   @Field(type => Int)
   totalCount: number;
 
-  @Field(type => [Category])
+  @Field(type => [Category], { nullable: true })
   categories: Category[];
 }
 
@@ -969,7 +969,7 @@ export class ProjectResolver {
       .getOne();
   }
 
-  @Query(returns => [Project], { nullable: true })
+  @Query(returns => AllProjects, { nullable: true })
   async projectsByUserId(
     @Arg('userId', type => Int) userId: number,
     @Arg('take', { defaultValue: 10 }) take: number,
@@ -985,6 +985,7 @@ export class ProjectResolver {
         'user.id = CAST(project.admin AS INTEGER)',
       )
       .where("CAST(project.admin AS INTEGER) = :userId", { userId: userId })
+      .orderBy('project.creationDate', 'DESC')
       .take(take)
       .skip(skip)
       .getManyAndCount();

--- a/resolvers/projectResolver.ts
+++ b/resolvers/projectResolver.ts
@@ -969,6 +969,31 @@ export class ProjectResolver {
       .getOne();
   }
 
+  @Query(returns => [Project], { nullable: true })
+  async projectsByUserId(
+    @Arg('userId', type => Int) userId: number,
+    @Arg('take', { defaultValue: 10 }) take: number,
+    @Arg('skip', { defaultValue: 0 }) skip: number
+  ) {
+    const [projects, projectsCount] = await this.projectRepository
+      .createQueryBuilder('project')
+      .leftJoinAndMapOne(
+        'project.adminUser',
+        User,
+        'user',
+        'user.id = CAST(project.admin AS INTEGER)',
+      )
+      .where("CAST(project.admin AS INTEGER) = :userId", { userId: userId })
+      .take(take)
+      .skip(skip)
+      .getManyAndCount();
+
+    return {
+      projects,
+      totalCount: projectsCount
+    }
+  }
+
   async updateProjectStatus(
     projectId: number,
     status: number,

--- a/resolvers/projectResolver.ts
+++ b/resolvers/projectResolver.ts
@@ -977,6 +977,7 @@ export class ProjectResolver {
   ) {
     const [projects, projectsCount] = await this.projectRepository
       .createQueryBuilder('project')
+      .leftJoinAndSelect('project.status', 'status')
       .leftJoinAndMapOne(
         'project.adminUser',
         User,


### PR DESCRIPTION
There is currently a bug in prod where people are querying projects they are not owners of. 
Also current project queries are not paginated in their profile page.
Adding this to fix it.
Issue: https://github.com/Giveth/impact-graph/issues/231