### PR TITLE
Hotfix: Fix nulls order in traceable sort

### DIFF
--- a/entities/project.ts
+++ b/entities/project.ts
@@ -261,7 +261,13 @@ class Project extends BaseEntity {
     if (searchTerm) this.addSearchQuery(query, searchTerm);
     if (filter) this.addFilterQuery(query, filter, filterValue);
 
-    query.orderBy(`project.${sortBy}`, direction);
+    if (sortBy == 'traceCampaignId') {
+      // TODO: PRISMA will fix this, temporary fix inverting nulls.
+      let traceableDirection = { 'ASC': 'NULLS FIRST', 'DESC': 'NULLS LAST' }
+      query.orderBy(`project.${sortBy}`, direction, traceableDirection[direction]);
+    } else {
+      query.orderBy(`project.${sortBy}`, direction);
+    }
 
     const projects = query.take(limit).skip(offset).getMany();
     const totalCount = query.getCount();


### PR DESCRIPTION
Issue: https://github.com/Giveth/impact-graph/issues/208
I feel the sort by Id was fine but the nulls where in the wrong order. Inverted the nulls and now looks like this:
DESC:
![image](https://user-images.githubusercontent.com/92376054/144295864-e5f7f114-933a-4148-ab3d-e10f2f0eaf1f.png)
ASC:
![image](https://user-images.githubusercontent.com/92376054/144296060-6538c6de-b4db-4189-a80d-9736a1db097f.png)
