### PR TITLE
Feature: Set projects as pending review when edited

### DIFF
--- a/entities/project.ts
+++ b/entities/project.ts
@@ -195,8 +195,8 @@ class Project extends BaseEntity {
   totalProjectUpdates: number;
 
   @Field(type => Boolean, { nullable: true })
-  @Column({ default: null, nullable: true })
-  listed: boolean;
+  @Column({ type: 'boolean', default: null, nullable: true })
+  listed?: boolean | null;
 
   // Virtual attribute to subquery result into
   @Field(type => User, { nullable: true })
@@ -316,7 +316,7 @@ class Project extends BaseEntity {
       .endOf('day');
 
     return this.createQueryBuilder('project')
-      .where({ creationDate: LessThan(maxDaysForListing) })
+      .where({ updatedAt: LessThan(maxDaysForListing) })
       .andWhere('project.listed IS NULL')
       .getMany();
   }

--- a/resolvers/projectResolver.ts
+++ b/resolvers/projectResolver.ts
@@ -434,6 +434,7 @@ export class ProjectResolver {
     }
     project.slug = newSlug;
     project.qualityScore = qualityScore;
+    project.listed = null;
     await project.save();
 
     // We dont wait for trace reponse, because it may increase our response time


### PR DESCRIPTION
When the project is edited the value of listed is set to Null, meaning it's back to review.
From this PR on we will use UpdatedAt to set the listing of the project, because we want to list it again based on the last time it was updated not on creation or it will be listed the next day instantly.

Issue: #264 