### PR TITLE
Throw error when category not exist

### DIFF
--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -367,13 +367,20 @@ export class ProjectResolver {
 
     for (const field in newProjectData) project[field] = newProjectData[field];
 
+    if (!newProjectData.categories) {
+      throw new Error(
+        errorMessages.CATEGORIES_MUST_BE_FROM_THE_FRONTEND_SUBSELECTION,
+      );
+    }
+
     if (newProjectData.categories) {
       const categoriesPromise = newProjectData.categories.map(
         async category => {
           let [c] = await this.categoryRepository.find({ name: category });
           if (c === undefined) {
-            c = new Category();
-            c.name = category;
+            throw new Error(
+              errorMessages.CATEGORIES_MUST_BE_FROM_THE_FRONTEND_SUBSELECTION,
+            );
           }
           return c;
         },
@@ -511,13 +518,21 @@ export class ProjectResolver {
       0,
     );
 
+    if (!projectInput.categories) {
+      throw new Error(
+        errorMessages.CATEGORIES_MUST_BE_FROM_THE_FRONTEND_SUBSELECTION,
+      );
+    }
+
+    // We do not create categories only use existing ones
     const categoriesPromise = Promise.all(
       projectInput.categories
         ? projectInput.categories.map(async category => {
             let [c] = await this.categoryRepository.find({ name: category });
             if (c === undefined) {
-              c = new Category();
-              c.name = category;
+              throw new Error(
+                errorMessages.CATEGORIES_MUST_BE_FROM_THE_FRONTEND_SUBSELECTION,
+              );
             }
             return c;
           })

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -1,6 +1,8 @@
 export const errorMessages = {
   CATEGORIES_LENGTH_SHOULD_NOT_BE_MORE_THAN_FIVE:
     'Please select no more than 5 categories',
+  CATEGORIES_MUST_BE_FROM_THE_FRONTEND_SUBSELECTION:
+    'This category is not valid',
   YOU_ARE_NOT_THE_OWNER_OF_PROJECT: 'You are not the owner of this project.',
   PROJECT_NOT_FOUND: 'Project not found.',
   DONATION_NOT_FOUND: 'donation not found',


### PR DESCRIPTION
This is to prevent malicious parties from creating bad categories.