### PR TITLE
F_361: Add draft status and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,15 +264,16 @@ You will need to add the above command to your build process so that all databas
 You can generate table with this site
 https://www.tablesgenerator.com/markdown_tables
 
-| id | symbol        | name          | description                                                                   | who can change to |
-|----|---------------|---------------|-------------------------------------------------------------------------------|-------------------|
-| 1  | rejected      | rejected      | his project has been rejected by Giveth or platform owner, We dont use it now |                   |
-| 2  | pending       | pending       | This project is created, but pending approval, We dont use it now             |                   |
-| 3  | clarification | clarification | Clarification requested by Giveth or platform owner, We dont use it now       |                   |
-| 4  | verification  | verification  | Verification in progress (including KYC or otherwise), We dont use it now     |                   |
-| 5  | activate      | activate      | This is an active project                                                     | user and admin    |
-| 6  | deactivate    | deactivate    | Deactivated with user or Giveth Admin                                         | user and admin    |
-| 7  | cancelled     | cancelled     | Cancelled by Giveth Admin                                                     | admin             |
+| id | symbol        | name          | description                                                                          | Who can change to       |
+|----|---------------|---------------|--------------------------------------------------------------------------------------|-------------------------|
+| 1  | rejected      | rejected      | his project has been rejected by Giveth or platform owner, We dont use it now        |                         |
+| 2  | pending       | pending       | This project is created, but pending approval, We dont use it now                    |                         |
+| 3  | clarification | clarification | Clarification requested by Giveth or platform owner, We dont use it now              |                         |
+| 4  | verification  | verification  | Verification in progress (including KYC or otherwise), We dont use it now            |                         |
+| 5  | activated     | activated     | This is an active project                                                            | project owner and admin |
+| 6  | deactivated   | deactivated   | Deactivated with user or Giveth Admin                                                | project owner and admin |
+| 7  | cancelled     | cancelled     | Cancelled by Giveth Admin                                                            | admin                   |
+| 8  | drafted       | drafted       | This project is created as a draft for a potential new project, but can be discarded | project owner           |
 
 **PS** 
 * If a project is **cancelled** just admin can activate that

--- a/migration/1614082100757-SeedProjectStatus.ts
+++ b/migration/1614082100757-SeedProjectStatus.ts
@@ -17,6 +17,7 @@ export class SeedProjectStatus1614082100757 implements MigrationInterface {
         ,('activated','activated','This is an active project')
         ,('deactivated','deactivated','Deactivated with user or Giveth Admin')
         ,('cancelled','cancelled','Cancelled by Giveth Admin')
+        ,('drafted', 'drafted', 'This project is created as a draft for a potential new project, but can be discarded')
         ;`);
   }
   x;

--- a/migration/1645240822841-AddDraftStatusDbValue.ts
+++ b/migration/1645240822841-AddDraftStatusDbValue.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDraftStatusDbValue1645240822841 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const draftedStatus = await queryRunner.query(
+      `SELECT * FROM project_status WHERE "name" = 'drafted'`,
+    );
+    if (draftedStatus.length > 0) {
+      return;
+    }
+
+    await queryRunner.query(`
+            INSERT INTO project_status (symbol, "name", description)
+            VALUES ('drafted', 'drafted', 'This project is created as a draft for a potential new project, but can be discarded')
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/src/entities/project.ts
+++ b/src/entities/project.ts
@@ -43,6 +43,7 @@ export enum ProjStatus {
   active = 5,
   deactive = 6,
   cancelled = 7,
+  drafted = 8,
 }
 
 export enum OrderField {
@@ -239,6 +240,7 @@ class Project extends BaseEntity {
     }
   }
 
+  // only projects with status active can be listed automatically
   static pendingReviewSince(maximumDaysForListing: Number) {
     const maxDaysForListing = moment()
       .subtract(maximumDaysForListing, 'days')
@@ -247,6 +249,7 @@ class Project extends BaseEntity {
     return this.createQueryBuilder('project')
       .where({ updatedAt: LessThan(maxDaysForListing) })
       .andWhere('project.listed IS NULL')
+      .andWhere('project.statusId = :statusId', { statusId: ProjStatus.active })
       .getMany();
   }
 

--- a/src/resolvers/projectResolver.test.ts
+++ b/src/resolvers/projectResolver.test.ts
@@ -802,6 +802,56 @@ function addProjectTestCases() {
       sampleProject.walletAddress,
     );
   });
+  it('Should create draft successfully', async () => {
+    const sampleProject: ProjectInput = {
+      title: 'draftTitle1',
+      categories: [SEED_DATA.CATEGORIES[0]],
+      description: 'description',
+      isDraft: true,
+      admin: String(SEED_DATA.FIRST_USER.id),
+      walletAddress: generateRandomEtheriumAddress(),
+    };
+    const accessToken = await generateTestAccessToken(SEED_DATA.FIRST_USER.id);
+    const result = await axios.post(
+      graphqlUrl,
+      {
+        query: addProjectQuery,
+        variables: {
+          project: sampleProject,
+        },
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+    assert.exists(result.data);
+    assert.exists(result.data.data);
+    assert.exists(result.data.data.addProject);
+    assert.equal(result.data.data.addProject.title, sampleProject.title);
+
+    // When creating project, listed is null by default
+    assert.equal(result.data.data.addProject.listed, null);
+
+    assert.equal(
+      result.data.data.addProject.admin,
+      String(SEED_DATA.FIRST_USER.id),
+    );
+    assert.equal(result.data.data.addProject.verified, false);
+    assert.equal(
+      result.data.data.addProject.status.id,
+      String(ProjStatus.drafted),
+    );
+    assert.equal(
+      result.data.data.addProject.description,
+      sampleProject.description,
+    );
+    assert.equal(
+      result.data.data.addProject.walletAddress,
+      sampleProject.walletAddress,
+    );
+  });
 }
 
 function editProjectTestCases() {

--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -537,7 +537,17 @@ export class ProjectResolver {
         id,
       });
     query = ProjectResolver.addUserReaction(query, connectedWalletUserId, user);
-    return query.getOne();
+    const project = await query.getOne();
+    const userId = connectedWalletUserId || user?.userId;
+
+    if (
+      project?.statusId === ProjStatus.drafted &&
+      (!userId || project?.admin !== String(userId))
+    ) {
+      return null;
+    }
+
+    return project;
   }
 
   // Move this to it's own resolver later
@@ -565,7 +575,17 @@ export class ProjectResolver {
         'user.id = CAST(project.admin AS INTEGER)',
       );
     query = ProjectResolver.addUserReaction(query, connectedWalletUserId, user);
-    return await query.getOne();
+    const project = await query.getOne();
+    const userId = connectedWalletUserId || user?.userId;
+
+    if (
+      project?.statusId === ProjStatus.drafted &&
+      (!userId || project?.admin !== String(userId))
+    ) {
+      return null;
+    }
+
+    return project;
   }
 
   @Mutation(returns => Project)

--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -1166,13 +1166,16 @@ export class ProjectResolver {
   ) {
     let query = this.projectRepository
       .createQueryBuilder('project')
-      .where('CAST(project.admin AS INTEGER) = :userId', { userId })
       .leftJoinAndSelect('project.status', 'status')
       .leftJoinAndMapOne(
         'project.adminUser',
         User,
         'user',
         'user.id = CAST(project.admin AS INTEGER)',
+      )
+      .where('CAST(project.admin AS INTEGER) = :userId', { userId })
+      .andWhere(
+        `project.statusId = ${ProjStatus.active} AND project.listed = true`,
       );
 
     query = ProjectResolver.addUserReaction(query, connectedWalletUserId, user);
@@ -1284,6 +1287,9 @@ export class ProjectResolver {
         User,
         'user',
         'user.id = CAST(project.admin AS INTEGER)',
+      )
+      .where(
+        `project.statusId = ${ProjStatus.active} AND project.listed = true`,
       )
       .orderBy('project.creationDate', 'DESC')
       .take(take)

--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -795,9 +795,17 @@ export class ProjectResolver {
     await validateProjectTitle(projectInput.title);
     const slugBase = slugify(projectInput.title);
     const slug = await this.getAppropriateSlug(slugBase);
-    const status = await this.projectStatusRepository.findOne({
-      id: ProjStatus.active,
-    });
+
+    let status: ProjectStatus | undefined;
+    if (projectInput.isDraft) {
+      status = await this.projectStatusRepository.findOne({
+        id: ProjStatus.drafted,
+      });
+    } else {
+      status = await this.projectStatusRepository.findOne({
+        id: ProjStatus.active,
+      });
+    }
 
     const project = this.projectRepository.create({
       ...projectInput,

--- a/src/resolvers/types/project-input.ts
+++ b/src/resolvers/types/project-input.ts
@@ -52,4 +52,7 @@ export class ProjectInput {
 
   @Field({ nullable: true })
   projectImageIds?: string;
+
+  @Field(tyoe => Boolean, { nullable: true, defaultValue: false })
+  isDraft?: boolean;
 }

--- a/src/services/cronJobs/syncProjectsRequiredForListing.test.ts
+++ b/src/services/cronJobs/syncProjectsRequiredForListing.test.ts
@@ -3,7 +3,7 @@ import {
   createProjectData,
   saveProjectDirectlyToDb,
 } from '../../../test/testUtils';
-import { Project } from '../../entities/project';
+import { Project, ProjStatus } from '../../entities/project';
 import { updateProjectListing } from './syncProjectsRequiredForListing';
 
 // tslint:disable-next-line:no-var-requires
@@ -28,6 +28,18 @@ function updateProjectListingTestCases() {
     const projectData = createProjectData();
     projectData.listed = undefined;
     projectData.creationDate = moment().subtract(12, 'days');
+    const project = await saveProjectDirectlyToDb(projectData);
+
+    await updateProjectListing();
+    const updatedProject = await Project.findOne({ id: project.id });
+    assert.isNotOk(updatedProject?.listed);
+  });
+
+  it('should not make project listed if its a draft project', async () => {
+    const projectData = createProjectData();
+    projectData.listed = undefined;
+    projectData.creationDate = moment().subtract(12, 'days');
+    projectData.statusId = ProjStatus.drafted;
     const project = await saveProjectDirectlyToDb(projectData);
 
     await updateProjectListing();

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -396,6 +396,38 @@ export const fetchProjectUpdatesQuery = `
   }
 `;
 
+export const projectsByUserIdQuery = `
+  query ($take: Float, $skip: Float, $userId: Int!) {
+      projectsByUserId(take: $take, skip: $skip, userId: $userId) {
+        projects {
+          id
+          title
+          balance
+          description
+          image
+          slug
+          creationDate
+          admin
+          walletAddress
+          impactLocation
+          listed
+          givingBlocksId
+          categories {
+            name
+          }
+          reaction {
+            reaction
+            id
+            projectUpdateId
+            userId
+          }
+          qualityScore
+        }
+        totalCount
+      }
+    }
+  `;
+
 export const projectByIdQuery = `
   query(
       $id: Float!, 

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -197,6 +197,47 @@ export const fetchAllProjectsQuery = `
   }
 `;
 
+export const fetchProjectsBySlugQuery = `
+  query (
+    $slug: String!
+  ) {
+    projectBySlug(
+      slug: $slug
+    ) {
+      id
+      title
+      balance
+      image
+      slug
+      creationDate
+      updatedAt
+      admin
+      description
+      walletAddress
+      impactLocation
+      qualityScore
+      verified
+      traceCampaignId
+      listed
+      givingBlocksId
+      status {
+        id
+        symbol
+        name
+        description
+      }
+      reaction {
+        id
+        userId
+        reaction
+      }
+      totalReactions
+      totalDonations
+      totalTraceDonations
+    }
+  }
+`;
+
 export const fetchSimilarProjectsBySlugQuery = `
   query (
     $slug: String!

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -77,6 +77,7 @@ export interface CreateProjectData {
   creationDate: Date;
   updatedAt: Date;
   slug: string;
+  statusId?: number;
   qualityScore?: number;
   totalDonations?: number;
   totalTraceDonations?: number;
@@ -94,8 +95,11 @@ export const saveUserDirectlyToDb = async (walletAddress: string) => {
 export const saveProjectDirectlyToDb = async (
   projectData: CreateProjectData,
 ): Promise<Project> => {
+  const statusId = projectData?.statusId
+    ? projectData.statusId
+    : ProjStatus.active;
   const status = await ProjectStatus.findOne({
-    id: ProjStatus.active,
+    id: statusId,
   });
   const user = (await User.findOne({
     id: Number(projectData.admin),
@@ -274,6 +278,11 @@ export const SEED_DATA = {
       symbol: 'cancelled',
       name: 'cancelled',
       description: 'delisted description',
+    },
+    {
+      symbol: 'drafted',
+      name: 'drafted',
+      description: 'drafted description',
     },
   ],
   DAI_SMART_CONTRACT_ADDRESS: '0x6b175474e89094c44da98b954eedeac495271d0f',

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -150,7 +150,6 @@ export const createProjectData = (): CreateProjectData => {
     creationDate: new Date(),
     updatedAt: new Date(),
     slug: title,
-
     // firstUser's id
     admin: '1',
     qualityScore: 30,


### PR DESCRIPTION
Related to #361 
Details of what I did per point.
0- we need to have a draft status in DB (added migration)
1- saveProject(): Added isDraft otherwise it would be active by default. (added to projectInput)
2- getProject:
Assumed projectbyslug and projectById. (If not logged in and draft project Ill return null)
3- activateProject: draft status can be activated (this is already allowed).
4- Modified cronjob that list projects to ignore drafted ones.
5- Get project list by owner (Mateo told me is the MeResolve -> MyProjects )
Should check user authentication and return all projects including draft, cancelled, deactive, active, ... (Already does this)