### PR TITLE
Hotfix prevent draft status from notifying creation

### DIFF
--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -3,7 +3,7 @@ import config from '../config';
 import { User } from '../entities/user';
 
 export enum SegmentEvents {
-  DRAFTED_PROJECT_ACTIVATED = 'Draft activated',
+  DRAFTED_PROJECT_ACTIVATED = 'Draft published',
   PROJECT_LISTED = 'Project listed',
   PROJECT_UNLISTED = 'Project unlisted',
   PROJECT_EDITED = 'Project edited',

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -3,6 +3,7 @@ import config from '../config';
 import { User } from '../entities/user';
 
 export enum SegmentEvents {
+  DRAFTED_PROJECT_ACTIVATED = 'Draft activated',
   PROJECT_LISTED = 'Project listed',
   PROJECT_UNLISTED = 'Project unlisted',
   PROJECT_EDITED = 'Project edited',

--- a/src/entities/project.ts
+++ b/src/entities/project.ts
@@ -232,6 +232,10 @@ class Project extends BaseEntity {
   @Field(type => User, { nullable: true })
   adminUser?: User;
 
+  // Virtual attribute to subquery result into
+  @Field(type => Int, { nullable: true })
+  prevStatusId?: number;
+
   // User reaction to the project
   @Field(type => Reaction, { nullable: true })
   reaction?: Reaction;

--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -1371,6 +1371,11 @@ export class ProjectResolver {
         statusId: ProjStatus.active,
         user,
       });
+      const segmentEventToDispatch =
+        project.status.id === ProjStatus.drafted
+          ? SegmentEvents.DRAFTED_PROJECT_ACTIVATED
+          : SegmentEvents.PROJECT_ACTIVATED;
+
       project.listed = null;
       await project.save();
       const segmentProject = {
@@ -1382,7 +1387,7 @@ export class ProjectResolver {
         slug: project.slug,
       };
       analytics.track(
-        SegmentEvents.PROJECT_ACTIVATED,
+        segmentEventToDispatch,
         `givethId-${ctx.req.user.userId}`,
         segmentProject,
         null,

--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -841,12 +841,14 @@ export class ProjectResolver {
       ...projectInput,
       description: projectInput?.description?.replace(/<img .*?>/g, ''),
     };
-    analytics.track(
-      SegmentEvents.PROJECT_CREATED,
-      `givethId-${ctx.req.user.userId}`,
-      segmentProject,
-      null,
-    );
+    if (status?.id === ProjStatus.active) {
+      analytics.track(
+        SegmentEvents.PROJECT_CREATED,
+        `givethId-${ctx.req.user.userId}`,
+        segmentProject,
+        null,
+      );
+    }
 
     await pubSub.publish('NOTIFICATIONS', payload);
 

--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -1309,6 +1309,7 @@ export class ProjectResolver {
     }
     const prevStatus = project.status;
     project.status = status;
+    project.prevStatusId = prevStatus.id;
     await project.save();
 
     await Project.addProjectStatusHistoryRecord({
@@ -1372,7 +1373,7 @@ export class ProjectResolver {
         user,
       });
       const segmentEventToDispatch =
-        project.status.id === ProjStatus.drafted
+        project.prevStatusId === ProjStatus.drafted
           ? SegmentEvents.DRAFTED_PROJECT_ACTIVATED
           : SegmentEvents.PROJECT_ACTIVATED;
 


### PR DESCRIPTION
It didn't publish the project, as only active projects are the ones that the 2 week cronjob lists. 

The email was sent on creation, so preventing that.
For now I disabled the email, but maybe changing the segment event would be better

Related to https://github.com/Giveth/impact-graph/issues/449