### PR TITLE
Restart Backend Automatically if impact-graph process failed

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - NODE_ENV=production
       - LOG_PATH=/usr/src/app/logs/impact-graph.log
+    restart: always
     volumes:
       # You should have a production.env file in the config folder
       - type: bind

--- a/docker-compose-local-postgres-redis.yml
+++ b/docker-compose-local-postgres-redis.yml
@@ -4,6 +4,7 @@ services:
   impact-graph-postgress:
     image: postgres
     container_name: impact-graph-postgress
+    restart: always
     environment:
       - POSTGRES_DB=givethio
       - POSTGRES_USER=postgres
@@ -19,6 +20,7 @@ services:
     # For running application use above container port: 5442
     image: postgres
     container_name: impact-graph-postgress-test
+    restart: always
     environment:
       - POSTGRES_DB=givethio
       - POSTGRES_USER=postgres

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - NODE_ENV=production
       - LOG_PATH=/usr/src/app/logs/impact-graph.log
+    restart: always
     volumes:
       # You should have a production.env file in the config folder
       - type: bind

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - NODE_ENV=production
       - LOG_PATH=/usr/src/app/logs/impact-graph.log
+    restart: always
     volumes:
       # You should have a production.env file in the config folder
       - type: bind


### PR DESCRIPTION
After testing, I noticed that some containers are not restarted automatically when anything wrong happens inside the process that the container is running.

I've added a simple fix to how the docker-compose should be run, hopefully this will fix the sudden downtime issue.