### PR TITLE
Fix returning unlisted projects when filtering by acceptGiv, Traceable and verified

### DIFF
--- a/src/resolvers/projectResolver.test.ts
+++ b/src/resolvers/projectResolver.test.ts
@@ -660,6 +660,93 @@ function projectsTestCases() {
       result.data.data.projects.projects[0].totalTraceDonations >= 100,
     );
   });
+  it('should return just listed projects, sort by acceptGiv, DESC', async () => {
+    await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: String(new Date().getTime()),
+      totalTraceDonations: 100,
+      listed: false,
+    });
+    await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: String(new Date().getTime()),
+      totalTraceDonations: 100,
+      listed: true,
+    });
+    const result = await axios.post(graphqlUrl, {
+      query: fetchAllProjectsQuery,
+      variables: {
+        limit: 50,
+        orderBy: {
+          field: 'AcceptGiv',
+          direction: 'DESC',
+        },
+      },
+    });
+    result.data.data.projects.projects.forEach(project => {
+      assert.isTrue(project.listed);
+    });
+  });
+  it('should return just listed projects, sort by Verified, DESC', async () => {
+    await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: String(new Date().getTime()),
+      totalTraceDonations: 100,
+      verified: true,
+      listed: false,
+    });
+    await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: String(new Date().getTime()),
+      totalTraceDonations: 100,
+      verified: true,
+      listed: true,
+    });
+    const result = await axios.post(graphqlUrl, {
+      query: fetchAllProjectsQuery,
+      variables: {
+        limit: 50,
+        orderBy: {
+          field: 'Verified',
+          direction: 'DESC',
+        },
+      },
+    });
+    result.data.data.projects.projects.forEach(project => {
+      assert.isTrue(project.listed);
+    });
+  });
+  it('should return just listed projects, sort by Traceable, DESC', async () => {
+    await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: String(new Date().getTime()),
+      totalTraceDonations: 100,
+      verified: true,
+      traceCampaignId: 'campaignIdInTrace',
+      listed: false,
+    });
+    await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: String(new Date().getTime()),
+      totalTraceDonations: 100,
+      traceCampaignId: 'campaignIdInTrace',
+      verified: true,
+      listed: true,
+    });
+    const result = await axios.post(graphqlUrl, {
+      query: fetchAllProjectsQuery,
+      variables: {
+        limit: 50,
+        orderBy: {
+          field: 'Traceable',
+          direction: 'DESC',
+        },
+      },
+    });
+    result.data.data.projects.projects.forEach(project => {
+      assert.isTrue(project.listed);
+    });
+  });
   it('should return projects, sort by totalTraceDonations, ASC', async () => {
     const result = await axios.post(graphqlUrl, {
       query: fetchAllProjectsQuery,

--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -475,7 +475,7 @@ export class ProjectResolver {
         //   traceableDirection[orderBy.direction],
         // );
 
-        query.where(
+        query.andWhere(
           `project.${orderBy.field} IS${
             orderBy.direction === OrderDirection.ASC ? '' : ' NOT'
           } NULL`,
@@ -498,7 +498,7 @@ export class ProjectResolver {
         //   orderBy.direction,
         //   acceptGivDirection[orderBy.direction],
         // );
-        query.where(
+        query.andWhere(
           `project.${orderBy.field} IS${
             orderBy.direction === OrderDirection.DESC ? '' : ' NOT'
           } NULL`,
@@ -509,7 +509,7 @@ export class ProjectResolver {
         );
         break;
       case OrderField.Verified:
-        query.where(`project.${orderBy.field} = true`);
+        query.andWhere(`project.${orderBy.field} = true`);
         query.orderBy(`project.${OrderField.CreationDate}`, orderBy.direction);
         break;
       default:


### PR DESCRIPTION
related to Giveth/giveth-dapps-v2#692

I finally could reproduce the bug, you can test it with this curl

```
curl --location --request POST 'https://serve.giveth.io/graphql' \
--header 'authority: mainnet.serve.giveth.io' \
--header 'accept: */*' \
--header 'accept-language: en-US,en;q=0.9' \
--header 'authorization;' \
--header 'content-type: application/json' \
--header 'origin: https://giveth.io' \
--header 'referer: https://giveth.io/' \
--header 'sec-ch-ua: " Not A;Brand";v="99", "Chromium";v="101", "Google Chrome";v="101"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'sec-ch-ua-platform: "macOS"' \
--header 'sec-fetch-dest: empty' \
--header 'sec-fetch-mode: cors' \
--header 'sec-fetch-site: same-site' \
--header 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36' \
--data-raw '{
    "operationName": "FetchAllProjects",
    "variables": {
        "orderBy": {
            "field": "AcceptGiv",
            "direction": "DESC"
        },
        "limit": 50,
        "skip": 0
    },
    "query": "query FetchAllProjects($limit: Int, $skip: Int, $orderBy: OrderBy, $filterBy: FilterBy, $searchTerm: String, $category: String, $connectedWalletUserId: Int) {\n  projects(\n    take: $limit\n    skip: $skip\n    orderBy: $orderBy\n    filterBy: $filterBy\n    searchTerm: $searchTerm\n    category: $category\n    connectedWalletUserId: $connectedWalletUserId\n  ) {\n    projects {\n      id\n      title\n       slug\n      listed\n      verified\n    }\n    totalCount\n }\n}"
}'

```
