### PR TITLE
Add index for createdAt field in donation entity

### DIFF
--- a/src/entities/donation.ts
+++ b/src/entities/donation.ts
@@ -135,6 +135,7 @@ export class Donation extends BaseEntity {
   @RelationId((donation: Donation) => donation.user)
   userId: number;
 
+  @Index()
   @Field(type => Date)
   @Column()
   createdAt: Date;


### PR DESCRIPTION
As @mendesfabio mentioned
> I'm querying giveth graphql API
but it's taking too much time to return donations, even when i apply the filter fromDate and toDate
looking at the code i noticed we don't have an index on createdAt
could we add it there? it would probably help these kind of query