### PR TITLE
Feature/automatic revoke sets project as draft

### DIFF
--- a/src/repositories/projectRepository.ts
+++ b/src/repositories/projectRepository.ts
@@ -24,6 +24,10 @@ export const findProjectById = (
 
 export const projectsWithoutUpdateAfterTimeFrame = async (date: Date) => {
   return Project.createQueryBuilder('project')
+    .leftJoinAndSelect(
+      'project.projectVerificationForm',
+      'projectVerificationForm',
+    )
     .innerJoinAndMapOne(
       'project.projectUpdate',
       ProjectUpdate,

--- a/src/repositories/projectVerificationRepository.ts
+++ b/src/repositories/projectVerificationRepository.ts
@@ -26,6 +26,16 @@ export const createProjectVerificationForm = async (params: {
   }).save();
 };
 
+export const updateProjectVerificationFormStatusOnly = async (
+  projectVerificationFormId: number,
+  verificationStatus: PROJECT_VERIFICATION_STATUSES,
+): Promise<UpdateResult> => {
+  return ProjectVerificationForm.update(
+    { id: projectVerificationFormId },
+    { status: verificationStatus },
+  );
+};
+
 export const verifyMultipleForms = async (params: {
   verificationStatus: PROJECT_VERIFICATION_STATUSES;
   formIds?: number[] | string[];

--- a/src/services/cronJobs/checkProjectVerificationStatus.ts
+++ b/src/services/cronJobs/checkProjectVerificationStatus.ts
@@ -16,6 +16,11 @@ import { logger } from '../../utils/logger';
 import moment = require('moment');
 import { projectsWithoutUpdateAfterTimeFrame } from '../../repositories/projectRepository';
 import { errorMessages } from '../../utils/errorMessages';
+import {
+  ProjectVerificationForm,
+  PROJECT_VERIFICATION_STATUSES,
+} from '../../entities/projectVerificationForm';
+import { updateProjectVerificationFormStatusOnly } from '../../repositories/projectVerificationRepository';
 
 const analytics = getAnalytics();
 
@@ -136,6 +141,17 @@ const remindUpdatesOrRevokeVerification = async (project: Project) => {
   }
 
   await project.save();
+
+  // draft the verification form to allow reapply
+  if (
+    project.projectVerificationForm &&
+    project.verificationStatus === RevokeSteps.Revoked
+  ) {
+    await updateProjectVerificationFormStatusOnly(
+      project.projectVerificationForm.id,
+      PROJECT_VERIFICATION_STATUSES.DRAFT,
+    );
+  }
 
   // save status changes history
   if (project.verificationStatus === RevokeSteps.Revoked) {


### PR DESCRIPTION
Related to https://github.com/Giveth/giveth-dapps-v2/issues/1497

Summary:
1. Revoking badge / unverifying a project in admin bro (project page) will set form as draft.

2. Rejecting form (in form page) doesn't do anything different, admin still needs to click make editable by user manually.

3. Cronjob for revoking now also sets form as draft if revoked the project badge.

Let me know if any changes. @MoeNick @mohammadranjbarz 