### PR TITLE
Hotfix order donation total calculations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "giveth-graphql-api",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "giveth-graphql-api",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "giveth-graphql-api",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Backend GraphQL server for Giveth originally forked from Topia",
   "main": "./dist/index.js",
   "dependencies": {

--- a/src/resolvers/donationResolver.ts
+++ b/src/resolvers/donationResolver.ts
@@ -645,10 +645,11 @@ export class DonationResolver {
 
       // After updating, recalculate user total donated and owner total received
       await updateUserTotalDonated(donorUser.id);
-      await updateUserTotalReceived(Number(project.admin));
 
       // After updating price we update totalDonations
       await updateTotalDonationsOfProject(projectId);
+      await updateUserTotalReceived(Number(project.admin));
+
       return donation.id;
     } catch (e) {
       SentryLogger.captureException(e);


### PR DESCRIPTION
Changed order of calculating donation totals.
Issue: 
- User total received was calculated using project total, but project total donations was calculated AFTER.

Fix:
- Calculated project total received first, then the user total received.