### PR TITLE
Bump json-schema and jsprim - copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36622,7 +36622,7 @@
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
       "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
       "requires": {
-        "semver-regex": "^3.1.2"
+        "semver-regex": "3.1.4"
       }
     },
     "find-yarn-workspace-root": {


### PR DESCRIPTION
Bumps [json-schema](https://github.com/kriszyp/json-schema) and [jsprim](https://github.com/joyent/node-jsprim). These dependencies needed to be updated together.

Updates `json-schema` from 0.2.3 to 0.4.0
- [Release notes](https://github.com/kriszyp/json-schema/releases)
- [Commits](https://github.com/kriszyp/json-schema/compare/v0.2.3...v0.4.0)

Updates `jsprim` from 1.4.1 to 1.4.2
- [Release notes](https://github.com/joyent/node-jsprim/releases)
- [Changelog](https://github.com/TritonDataCenter/node-jsprim/blob/v1.4.2/CHANGES.md)
- [Commits](https://github.com/joyent/node-jsprim/compare/v1.4.1...v1.4.2)

---
updated-dependencies:
- dependency-name: json-schema dependency-type: indirect
- dependency-name: jsprim dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>