### PR TITLE
Allow admins to change the admin of a project

### DIFF
--- a/src/server/adminBro.ts
+++ b/src/server/adminBro.ts
@@ -1591,6 +1591,10 @@ const getAdminBroInstance = async () => {
                     );
                   }
 
+                  if (request?.payload?.admin !== project?.admin) {
+                    request.payload.adminChanged = true;
+                  }
+
                   // We put these status changes in payload, so in after hook we would know to send notification for users
                   request.payload.statusChanges = statusChanges.join(',');
                 }
@@ -1606,6 +1610,10 @@ const getAdminBroInstance = async () => {
                   where: { id: request?.record?.id },
                 });
                 if (project) {
+                  if (request?.record?.params?.adminChanged) {
+                    project.adminUserId = Number(project.admin);
+                    await project.save();
+                  }
                   // Not required for now
                   // Project.notifySegment(project, SegmentEvents.PROJECT_EDITED);
 


### PR DESCRIPTION
Allow admins to change the adminuserId.
I did it this way because if I use the default behaviour of the adminJs, it will load 7000+ record array (thiss breaks the server or putss it slow). Its better to just allow changing the string and we will change it by code the relation.

This is a highly requested feature and part of the every week activities.