### PR TITLE
Prevent project address from throwing errors silently

### DIFF
--- a/src/resolvers/projectResolver.test.ts
+++ b/src/resolvers/projectResolver.test.ts
@@ -2277,6 +2277,55 @@ function createProjectTestCases() {
       sampleProject.addresses[0].address,
     );
   });
+
+  it('Should create unsuccessfully, when addresses are invalid or repeated', async () => {
+    const address = {
+      address: generateRandomEtheriumAddress(),
+      networkId: NETWORK_IDS.XDAI,
+    };
+    const sampleProject: CreateProjectInput = {
+      title: 'title ' + new Date().getTime(),
+      categories: [SEED_DATA.FOOD_SUB_CATEGORIES[0]],
+      description: 'description',
+      image:
+        'https://gateway.pinata.cloud/ipfs/QmauSzWacQJ9rPkPJgr3J3pdgfNRGAaDCr1yAToVWev2QS',
+      admin: String(SEED_DATA.FIRST_USER.id),
+      addresses: [
+        address,
+        {
+          address: generateRandomEtheriumAddress(),
+          networkId: NETWORK_IDS.MAIN_NET,
+        },
+        address,
+      ],
+    };
+    const accessToken = await generateTestAccessToken(SEED_DATA.FIRST_USER.id);
+    const result = await axios.post(
+      graphqlUrl,
+      {
+        query: createProjectQuery,
+        variables: {
+          project: sampleProject,
+        },
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+    assert.exists(result.data);
+    assert.equal(
+      result.data.errors[0].message,
+      i18n.__(translationErrorMessagesKeys.PROJECT_CREATION_ADDRESS_ERROR),
+    );
+
+    const createdProject = await Project.findOne({
+      where: { title: sampleProject.title },
+    });
+
+    assert.isNull(createdProject);
+  });
   it('Should create successfully with special characters in title', async () => {
     const titleWithoutSpecialCharacters = 'title-_' + new Date().getTime();
     const sampleProject: CreateProjectInput = {

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -179,9 +179,12 @@ export const errorMessages = {
   CHAINVINE_REGISTRATION_ERROR: 'Chainvine ID failed to be generated',
   CHAINVINE_CLICK_EVENT_ERROR: 'Unable to register click event or link donor',
   GITCOIN_ERROR_FETCHING_DATA: 'Unable to fetch gitcoin data, check logs',
+  PROJECT_CREATION_ADDRESS_ERROR:
+    'Unable to create project address, please try with a valid one.',
 };
 
 export const translationErrorMessagesKeys = {
+  PROJECT_CREATION_ADDRESS_ERROR: 'PROJECT_CREATION_ADDRESS_ERROR',
   GITCOIN_ERROR_FETCHING_DATA: 'GITCOIN_ERROR_FETCHING_DATA',
   CHAINVINE_CLICK_EVENT_ERROR: 'CHAINVINE_CLICK_EVENT_ERROR',
   CHAINVINE_REGISTRATION_ERROR: 'CHAINVINE_REGISTRATION_ERROR',

--- a/src/utils/locales/en.json
+++ b/src/utils/locales/en.json
@@ -144,5 +144,6 @@
     "Number of boosted projects exceeds limit",
   "REGISTERED_NON_PROFITS_CATEGORY_DOESNT_EXIST":
     "There is not any category with name registered-non-profits, probably you forgot to run migrations",
-  "PROJECT_UPDATE_CONTENT_LENGTH_SIZE_EXCEEDED": "Content length exceeded"
+  "PROJECT_UPDATE_CONTENT_LENGTH_SIZE_EXCEEDED": "Content length exceeded",
+  "PROJECT_CREATION_ADDRESS_ERROR": "Unable to create project address, please try with a valid one."
 }

--- a/src/utils/locales/es.json
+++ b/src/utils/locales/es.json
@@ -146,5 +146,6 @@
     "Número de proyectos impulsados excede el límite",
   "REGISTERED_NON_PROFITS_CATEGORY_DOESNT_EXIST":
     "No hay ninguna categoría con nombre registrado-sin fines de lucro, probablemente se olvidó de ejecutar las migraciones",
-  "PROJECT_UPDATE_CONTENT_LENGTH_SIZE_EXCEEDED": "El contenido es demasiado largo"
+  "PROJECT_UPDATE_CONTENT_LENGTH_SIZE_EXCEEDED": "El contenido es demasiado largo",
+  "PROJECT_CREATION_ADDRESS_ERROR": "No fue posible crear el project, las direcciones son invalidas"
 }


### PR DESCRIPTION
Critical bug found by Ashley when debugging two projects that somehow have no addresses. 

We where using the insert method that threw no errors. Modified this to throw errors, halting execution and cleaning up.