### PR TITLE
Remake exporting to csv filters fetch

### DIFF
--- a/src/server/adminJs/adminJs-types.ts
+++ b/src/server/adminJs/adminJs-types.ts
@@ -28,10 +28,11 @@ export interface AdminJsProjectsQuery {
   verified?: string;
   // listed?: string;
   isImported?: string;
-  reviewStatus: ReviewStatus;
+  reviewStatus?: ReviewStatus;
 }
 
 export interface AdminJsDonationsQuery {
+  id?: string;
   projectId?: string;
   contactEmail?: string;
   referrerWallet?: string;

--- a/src/server/adminJs/adminJs-types.ts
+++ b/src/server/adminJs/adminJs-types.ts
@@ -44,6 +44,7 @@ export interface AdminJsDonationsQuery {
   currency?: string;
   transactionNetworkId?: string;
   isProjectVerified?: string;
+  qfRoundId?: string;
 }
 
 // headers defined by the verification team for exporting
@@ -95,4 +96,6 @@ export const donationHeaders = [
   'createdAt',
   'referrerWallet',
   'isTokenEligibleForGivback',
+  'qfRoundId',
+  'qfRoundUserScore',
 ];

--- a/src/server/adminJs/adminJs.ts
+++ b/src/server/adminJs/adminJs.ts
@@ -76,8 +76,8 @@ export const getAdminJsRouter = async () => {
 export const extractAdminJsReferrerUrlParams = (req: ActionContext) => {
   const queryStrings = {};
 
-  const refererUrlHeaderIndex = req.rawHeaders.indexOf('Referer');
-  if (refererUrlHeaderIndex < 0) return {};
+  const refererUrlHeaderIndex = req?.rawHeaders?.indexOf('Referer');
+  if (!refererUrlHeaderIndex || refererUrlHeaderIndex < 0) return {};
 
   const refererUrl = new URL(req.rawHeaders[refererUrlHeaderIndex + 1]);
   const searchParams = refererUrl.searchParams;

--- a/src/server/adminJs/tabs/donationTab.ts
+++ b/src/server/adminJs/tabs/donationTab.ts
@@ -185,6 +185,7 @@ export const buildDonationsQuery = (
   const query = Donation.createQueryBuilder('donation')
     .leftJoinAndSelect('donation.user', 'user')
     .leftJoinAndSelect('donation.project', 'project')
+    .leftJoinAndSelect('donation.qfRound', 'qfRound')
     .where('donation.amount > 0')
     .addOrderBy('donation.createdAt', 'DESC');
 
@@ -196,6 +197,11 @@ export const buildDonationsQuery = (
   if (queryStrings.projectId)
     query.andWhere('donation.projectId = :projectId', {
       projectId: queryStrings.projectId,
+    });
+
+  if (queryStrings.qfRoundId)
+    query.andWhere('donation.qfRoundId = :qfRoundId', {
+      qfRoundId: queryStrings.qfRoundId,
     });
 
   if (queryStrings.userId)
@@ -320,6 +326,8 @@ const sendDonationsToGoogleSheet = async (
       createdAt: donation?.createdAt.toISOString(),
       referrerWallet: donation?.referrerWallet || '',
       isTokenEligibleForGivback: Boolean(donation?.isTokenEligibleForGivback),
+      qfRoundId: donation?.qfRound?.id || '',
+      qfRoundUserScore: donation?.qfRoundUserScore || '',
     };
   });
 
@@ -337,6 +345,16 @@ export const donationTab = {
       projectId: {
         isVisible: {
           list: true,
+          filter: true,
+          show: true,
+          edit: false,
+          new: false,
+        },
+      },
+      qfRoundId: {
+        type: Number,
+        isVisible: {
+          list: false,
           filter: true,
           show: true,
           edit: false,
@@ -452,6 +470,15 @@ export const donationTab = {
           new: false,
         },
       },
+      qfRoundUserScore: {
+        isVisible: {
+          list: false,
+          filter: false,
+          show: true,
+          edit: false,
+          new: false,
+        },
+      },
       tokenAddress: {
         isVisible: false,
       },
@@ -466,7 +493,7 @@ export const donationTab = {
       },
       toWalletAddress: {
         isVisible: {
-          list: true,
+          list: false,
           filter: true,
           show: true,
           edit: false,

--- a/src/server/adminJs/tabs/projectsTab.ts
+++ b/src/server/adminJs/tabs/projectsTab.ts
@@ -606,7 +606,7 @@ export const listDelist = async (
 };
 
 export const exportProjectsWithFiltersToCsv = async (
-  _request: ActionContext,
+  _request,
   _response,
   context: AdminJsContextInterface,
 ) => {

--- a/src/server/adminJs/tabs/projectsTab.ts
+++ b/src/server/adminJs/tabs/projectsTab.ts
@@ -5,7 +5,7 @@ import {
   ReviewStatus,
   RevokeSteps,
 } from '../../../entities/project';
-import adminJs from 'adminjs';
+import adminJs, { ActionContext } from 'adminjs';
 import {
   canAccessProjectAction,
   canAccessQfRoundAction,
@@ -62,6 +62,7 @@ import {
   refreshProjectDonationSummaryView,
   refreshProjectEstimatedMatchingView,
 } from '../../../services/projectViewsService';
+import { extractAdminJsReferrerUrlParams } from '../adminJs';
 
 // add queries depending on which filters were selected
 export const buildProjectsQuery = (
@@ -605,16 +606,13 @@ export const listDelist = async (
 };
 
 export const exportProjectsWithFiltersToCsv = async (
-  _request: AdminJsRequestInterface,
+  _request: ActionContext,
   _response,
   context: AdminJsContextInterface,
 ) => {
   try {
     const { records } = context;
-    const rawQueryStrings = await redis.get(
-      `adminbro:${context.currentAdmin.id}:Project`,
-    );
-    const queryStrings = rawQueryStrings ? JSON.parse(rawQueryStrings) : {};
+    const queryStrings = extractAdminJsReferrerUrlParams(_request);
     const projectsQuery = buildProjectsQuery(queryStrings);
     const projects = await projectsQuery.getMany();
 

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -22,11 +22,7 @@ import { runCheckPendingProjectListingCronJob } from '../services/cronJobs/syncP
 import { runCheckProjectVerificationStatus } from '../services/cronJobs/checkProjectVerificationStatus';
 import { webhookHandler } from '../services/transak/webhookHandler';
 
-import {
-  adminJsQueryCache,
-  adminJsRootPath,
-  getAdminJsRouter,
-} from './adminJs/adminJs';
+import { adminJsRootPath, getAdminJsRouter } from './adminJs/adminJs';
 import { redis } from '../redis';
 import { logger } from '../utils/logger';
 import { runNotifyMissingDonationsCronJob } from '../services/cronJobs/notifyDonationsWithSegment';
@@ -337,7 +333,6 @@ export async function bootstrap() {
     );
 
     // AdminJs!
-    app.use(adminJsQueryCache);
     app.use(adminJsRootPath, await getAdminJsRouter());
 
     if (!isTestEnv) {


### PR DESCRIPTION
Related to: https://github.com/Giveth/impact-graph/issues/1002
But also a bug fix, after updating adminjs, all routes changed and express middlewares were no longer accesible.
Removed Redis and instead used the rawHeaders attributes directly to fetch filter params, could not find another way with adminbro objects.