### PR TITLE
Add donation currency stats query

### DIFF
--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -915,6 +915,16 @@ export const fetchProjectsBySlugQuery = `
   }
 `;
 
+export const getDonationCurrencyStats = `
+  query {
+    getDonationStats {
+      currency
+      uniqueDonorCount
+      currencyPercentage
+    }
+  }
+`;
+
 export const fetchSimilarProjectsBySlugQuery = `
   query (
     $slug: String!


### PR DESCRIPTION
No related issue. @mohammadranjbarz @RamRamez 
Its for our internal Analytics dashboard. Can test the query on your db viewer. 
Review and merge for Ramin if posible.

Query
```
export const getDonationCurrencyStats = `
  query {
    getDonationStats {
      currency
      uniqueDonorCount
      currencyPercentage
    }
  }
`;
```

Results example: 
```
{
  "data": {
    "getDonationStats": [
      {
        "currency": "ETH",
        "uniqueDonorCount": 4,
        "currencyPercentage": 80
      },
      {
        "currency": "GIV",
        "uniqueDonorCount": 1,
        "currencyPercentage": 20
      }
    ]
  }
}
```