### PR TITLE
Add informative logs for create donation mutation

### DIFF
--- a/src/resolvers/donationResolver.ts
+++ b/src/resolvers/donationResolver.ts
@@ -624,6 +624,23 @@ export class DonationResolver {
     @Ctx() ctx: ApolloContext,
     @Arg('referrerId', { nullable: true }) referrerId?: string,
   ): Promise<Number> {
+    const logData = {
+      amount,
+      transactionId,
+      transactionNetworkId,
+      tokenAddress,
+      anonymous,
+      token,
+      projectId,
+      nonce,
+      transakId,
+      referrerId,
+      userId: ctx?.req?.user?.userId,
+    };
+    logger.info(
+      'createDonation() resolver has been called with this data',
+      logData,
+    );
     try {
       const userId = ctx?.req?.user?.userId;
       const donorUser = await findUserById(userId);
@@ -780,7 +797,10 @@ export class DonationResolver {
       return donation.id;
     } catch (e) {
       SentryLogger.captureException(e);
-      logger.error('createDonation() error', e);
+      logger.error('createDonation() error', {
+        error: e,
+        inputData: logData,
+      });
       throw e;
     }
   }


### PR DESCRIPTION
related to #1218 

After merging this we would have some logs like below image

<img width="1085" alt="Screenshot 1402-10-07 at 10 59 16 in the morning" src="https://github.com/Giveth/impact-graph/assets/9850545/7833053a-dc1a-48e9-9114-44466b9c0bc3">
