### PR TITLE
Remove chainType from older seed token values

### DIFF
--- a/migration/data/seedTokens.ts
+++ b/migration/data/seedTokens.ts
@@ -1058,7 +1058,6 @@ const seedTokens: ITokenData[] = [
     address: '0x0000000000000000000000000000000000000000',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISM_GOERLI,
-
     coingeckoId: 'ethereum',
   },
   {
@@ -1067,7 +1066,6 @@ const seedTokens: ITokenData[] = [
     address: '0x4200000000000000000000000000000000000042',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISM_GOERLI,
-
     coingeckoId: 'optimism',
   },
   {
@@ -1076,7 +1074,6 @@ const seedTokens: ITokenData[] = [
     address: '0x4200000000000000000000000000000000000006',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISM_GOERLI,
-
     coingeckoId: 'weth',
   },
   {
@@ -1085,7 +1082,6 @@ const seedTokens: ITokenData[] = [
     address: '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISM_GOERLI,
-
     coingeckoId: 'dai',
   },
 
@@ -1096,7 +1092,6 @@ const seedTokens: ITokenData[] = [
     address: '0x0000000000000000000000000000000000000000',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISTIC,
-
     coingeckoId: 'ethereum',
   },
   {
@@ -1105,7 +1100,6 @@ const seedTokens: ITokenData[] = [
     address: '0x4200000000000000000000000000000000000042',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISTIC,
-
     coingeckoId: 'optimism',
   },
   {
@@ -1114,7 +1108,6 @@ const seedTokens: ITokenData[] = [
     address: '0x350a791bfc2c21f9ed5d10980dad2e2638ffa7f6',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISTIC,
-
     coingeckoId: 'chainlink',
   },
   {
@@ -1123,7 +1116,6 @@ const seedTokens: ITokenData[] = [
     address: '0x68f180fcce6836688e9084f035309e29bf0a2095',
     decimals: 8,
     networkId: NETWORK_IDS.OPTIMISTIC,
-
     coingeckoId: 'wrapped-bitcoin',
   },
   {
@@ -1132,7 +1124,6 @@ const seedTokens: ITokenData[] = [
     address: '0x8700daec35af8ff88c16bdf0418774cb3d7599b4',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISTIC,
-
     coingeckoId: 'havven',
   },
   {
@@ -1141,7 +1132,6 @@ const seedTokens: ITokenData[] = [
     address: '0x4200000000000000000000000000000000000006',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISTIC,
-
     coingeckoId: 'weth',
   },
   {
@@ -1150,7 +1140,6 @@ const seedTokens: ITokenData[] = [
     address: '0x94b008aA00579c1307B0EF2c499aD98a8ce58e58',
     decimals: 6,
     networkId: NETWORK_IDS.OPTIMISTIC,
-
     coingeckoId: 'tether',
   },
   {
@@ -1159,7 +1148,6 @@ const seedTokens: ITokenData[] = [
     address: '0x7F5c764cBc14f9669B88837ca1490cCa17c31607',
     decimals: 6,
     networkId: NETWORK_IDS.OPTIMISTIC,
-
     coingeckoId: 'usd-coin',
   },
   {
@@ -1168,7 +1156,6 @@ const seedTokens: ITokenData[] = [
     address: '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISTIC,
-
     coingeckoId: 'dai',
   },
   // CELO tokens

--- a/migration/data/seedTokens.ts
+++ b/migration/data/seedTokens.ts
@@ -22,7 +22,6 @@ const seedTokens: ITokenData[] = [
     address: '0x0000000000000000000000000000000000000000',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Giveth Token',
@@ -30,7 +29,6 @@ const seedTokens: ITokenData[] = [
     address: '0x900db999074d9277c5da2a43f252d74366230da0',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Panvala',
@@ -38,7 +36,6 @@ const seedTokens: ITokenData[] = [
     address: '0xd56dac73a4d6766464b38ec6d91eb45ce7457c44',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Dai',
@@ -46,7 +43,6 @@ const seedTokens: ITokenData[] = [
     address: '0x6b175474e89094c44da98b954eedeac495271d0f',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Rai Reflex Index',
@@ -54,7 +50,6 @@ const seedTokens: ITokenData[] = [
     address: '0x03ab458634910aad20ef5f1c8ee96f1d6ac54919',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'dAppNode',
@@ -62,7 +57,6 @@ const seedTokens: ITokenData[] = [
     address: '0xda007777d86ac6d989cc9f79a73261b3fc5e0da0',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Gemini Dollar',
@@ -70,7 +64,6 @@ const seedTokens: ITokenData[] = [
     address: '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd',
     decimals: 2,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Gitcoin',
@@ -78,7 +71,6 @@ const seedTokens: ITokenData[] = [
     address: '0xde30da39c46104798bb5aa3fe8b9e0e1f348163f',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'ShapeShift FOX Token (FOX)',
@@ -86,7 +78,6 @@ const seedTokens: ITokenData[] = [
     address: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Curve DAO Token',
@@ -94,7 +85,6 @@ const seedTokens: ITokenData[] = [
     address: '0xD533a949740bb3306d119CC777fa900bA034cd52',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'TerraUSD',
@@ -102,7 +92,6 @@ const seedTokens: ITokenData[] = [
     address: '0xa47c8bf37f92abed4a126bda807a7b7498661acd',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Sushi Token',
@@ -110,7 +99,6 @@ const seedTokens: ITokenData[] = [
     address: '0x6b3595068778dd592e39a122f4f5a5cf09c90fe2',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Balancer',
@@ -118,7 +106,6 @@ const seedTokens: ITokenData[] = [
     address: '0xba100000625a3754423978a60c9317c58a424e3d',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'PieDAO DOUGH',
@@ -126,7 +113,6 @@ const seedTokens: ITokenData[] = [
     address: '0xad32a8e6220741182940c5abf610bde99e737b2d',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Wrapped MIR Token',
@@ -134,7 +120,6 @@ const seedTokens: ITokenData[] = [
     address: '0x09a3ecafa817268f77be1283176b946c4ff2e608',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Metagame SEED',
@@ -142,7 +127,6 @@ const seedTokens: ITokenData[] = [
     address: '0x30cf203b48edaa42c3b4918e955fed26cd012a3f',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'PoH Universal Basic Income',
@@ -150,7 +134,6 @@ const seedTokens: ITokenData[] = [
     address: '0xdd1ad9a21ce722c151a836373babe42c868ce9a4',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Tether',
@@ -158,7 +141,6 @@ const seedTokens: ITokenData[] = [
     address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
     decimals: 6,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Crypto.com Coin',
@@ -166,7 +148,6 @@ const seedTokens: ITokenData[] = [
     address: '0xa0b73e1ff0b80914ab6fe0444e65848c4c34450b',
     decimals: 8,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Chainlink',
@@ -174,7 +155,6 @@ const seedTokens: ITokenData[] = [
     address: '0x514910771af9ca656af840dff83e8264ecf986ca',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'UNUS SED LEO',
@@ -182,7 +162,6 @@ const seedTokens: ITokenData[] = [
     address: '0x2af5d2ad76741191d15dfe7bf6ac92d4bd912ca3',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'USD Coin',
@@ -190,7 +169,6 @@ const seedTokens: ITokenData[] = [
     address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
     decimals: 6,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Huobi Token',
@@ -198,7 +176,6 @@ const seedTokens: ITokenData[] = [
     address: '0x6f259637dcd74c767781e37bc6133cd6a68aa161',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Compound',
@@ -206,7 +183,6 @@ const seedTokens: ITokenData[] = [
     address: '0xc00e94cb662c3520282e6f5717214004a7f26888',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Maker',
@@ -214,7 +190,6 @@ const seedTokens: ITokenData[] = [
     address: '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'HedgeTrade',
@@ -222,7 +197,6 @@ const seedTokens: ITokenData[] = [
     address: '0xf1290473e210b2108a85237fbcd7b6eb42cc654f',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Basic Attention Token',
@@ -230,7 +204,6 @@ const seedTokens: ITokenData[] = [
     address: '0x0d8775f648430679a709e98d2b0cb6250d2887ef',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'OKB',
@@ -238,7 +211,6 @@ const seedTokens: ITokenData[] = [
     address: '0x75231f58b43240c9718dd58b4967c5114342a86c',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Paxos Standard',
@@ -246,7 +218,6 @@ const seedTokens: ITokenData[] = [
     address: '0x8e870d67f660d95d5be530380d0ec0bd388289e1',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'ZRX 0x',
@@ -254,7 +225,6 @@ const seedTokens: ITokenData[] = [
     address: '0xe41d2489571d322189246dafa5ebde1f4699f498',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Kyber Network',
@@ -262,7 +232,6 @@ const seedTokens: ITokenData[] = [
     address: '0xdd974d5c2e2928dea5f71b9825b8b646686bd200',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'OMG Network',
@@ -270,7 +239,6 @@ const seedTokens: ITokenData[] = [
     address: '0xd26114cd6ee289accf82350c8d8487fedb8a0c07',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'The Midas Touch Gold',
@@ -278,7 +246,6 @@ const seedTokens: ITokenData[] = [
     address: '0x10086399dd8c1e3de736724af52587a2044c9fa2',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Augur',
@@ -286,7 +253,6 @@ const seedTokens: ITokenData[] = [
     address: '0x1985365e9f78359a9b6ad760e32412f4a445e862',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Lend Aave',
@@ -294,7 +260,6 @@ const seedTokens: ITokenData[] = [
     address: '0x80fb784b7ed66730e8b1dbd9820afd29931aab03',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Synthetix Network Token',
@@ -302,7 +267,6 @@ const seedTokens: ITokenData[] = [
     address: '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Hyperion',
@@ -310,7 +274,6 @@ const seedTokens: ITokenData[] = [
     address: '0xe99a894a69d7c2e3c92e61b64c505a6a57d2bc07',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Enjin Coin',
@@ -318,7 +281,6 @@ const seedTokens: ITokenData[] = [
     address: '0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Ren',
@@ -326,7 +288,6 @@ const seedTokens: ITokenData[] = [
     address: '0x408e41876cccdc0f92210600ef50372656052a38',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'HUSD',
@@ -334,7 +295,6 @@ const seedTokens: ITokenData[] = [
     address: '0xdf574c24545e5ffecb9a659c229253d4111d87e1',
     decimals: 8,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Celsius',
@@ -342,7 +302,6 @@ const seedTokens: ITokenData[] = [
     address: '0xaaaebe6fe48e54f431b0c390cfaf0b017d09d42d',
     decimals: 4,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'ZB Token',
@@ -350,7 +309,6 @@ const seedTokens: ITokenData[] = [
     address: '0xbd0793332e9fb844a52a205a233ef27a5b34b927',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'DxChain Token',
@@ -358,7 +316,6 @@ const seedTokens: ITokenData[] = [
     address: '0x973e52691176d36453868d9d86572788d27041a9',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Quant',
@@ -366,7 +323,6 @@ const seedTokens: ITokenData[] = [
     address: '0x4a220e6096b25eadb88358cb44068a3248254675',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Holo',
@@ -374,7 +330,6 @@ const seedTokens: ITokenData[] = [
     address: '0x6c6ee5e31d828de241282b9606c8e98ea48526e2',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'SwissBorg',
@@ -382,7 +337,6 @@ const seedTokens: ITokenData[] = [
     address: '0xba9d4199fab4f26efe3551d490e3821486f135ba',
     decimals: 8,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Loopring',
@@ -390,7 +344,6 @@ const seedTokens: ITokenData[] = [
     address: '0xbbbbca6a901c926f240b89eacb641d8aec7aeafd',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Status',
@@ -398,7 +351,6 @@ const seedTokens: ITokenData[] = [
     address: '0x744d70fdbe2ba4cf95131626614a1763df805b9e',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Mixin',
@@ -406,7 +358,6 @@ const seedTokens: ITokenData[] = [
     address: '0xa974c709cfb4566686553a20790685a47aceaa33',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Bancor',
@@ -414,7 +365,6 @@ const seedTokens: ITokenData[] = [
     address: '0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'KuCoin Shares',
@@ -422,7 +372,6 @@ const seedTokens: ITokenData[] = [
     address: '0x039b5649a59967e3e936d7471f9c3700100ee1ab',
     decimals: 6,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'MCO',
@@ -430,7 +379,6 @@ const seedTokens: ITokenData[] = [
     address: '0xb63b606ac810a52cca15e44bb630fd42d8d1d83d',
     decimals: 8,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Matic Network',
@@ -438,7 +386,6 @@ const seedTokens: ITokenData[] = [
     address: '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Egoras',
@@ -446,7 +393,6 @@ const seedTokens: ITokenData[] = [
     address: '0x73cee8348b9bdd48c64e13452b8a6fbc81630573',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Numeraire',
@@ -454,7 +400,6 @@ const seedTokens: ITokenData[] = [
     address: '0x1776e1f26f98b1a5df9cd347953a26dd3cb46671',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Wrapped Bitcoin',
@@ -462,7 +407,6 @@ const seedTokens: ITokenData[] = [
     address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
     decimals: 8,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Decentraland',
@@ -470,7 +414,6 @@ const seedTokens: ITokenData[] = [
     address: '0x0f5d2fb29fb7d3cfee444a200298f468908cc942',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Golem',
@@ -478,7 +421,6 @@ const seedTokens: ITokenData[] = [
     address: '0xa74476443119a942de498590fe1f2454d7d4ac0d',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'PAX Gold',
@@ -486,7 +428,6 @@ const seedTokens: ITokenData[] = [
     address: '0x45804880de22913dafe09f4980848ece6ecbaf78',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'iExec RLC',
@@ -494,7 +435,6 @@ const seedTokens: ITokenData[] = [
     address: '0x607f4c5bb672230e8672085532f7e901544a7375',
     decimals: 9,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'aelf',
@@ -502,7 +442,6 @@ const seedTokens: ITokenData[] = [
     address: '0xbf2179859fc6d5bee9bf9158632dc51678a4100e',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'SOLVE',
@@ -510,7 +449,6 @@ const seedTokens: ITokenData[] = [
     address: '0x446c9033e7516d820cc9a2ce2d0b7328b579406f',
     decimals: 8,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Reserve Rights',
@@ -518,7 +456,6 @@ const seedTokens: ITokenData[] = [
     address: '0x8762db106b2c2a0bccb3a80d1ed41273552616e8',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'APIX',
@@ -526,7 +463,6 @@ const seedTokens: ITokenData[] = [
     address: '0xf51ebf9a26dbc02b13f8b3a9110dac47a4d62d78',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Aragon',
@@ -534,7 +470,6 @@ const seedTokens: ITokenData[] = [
     address: '0xa117000000f279d81a1d3cc75430faa017fa5a2e',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Unibright',
@@ -542,7 +477,6 @@ const seedTokens: ITokenData[] = [
     address: '0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e',
     decimals: 8,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'BrightID',
@@ -550,7 +484,6 @@ const seedTokens: ITokenData[] = [
     address: '0x5dd57da40e6866c9fcc34f4b6ddc89f1ba740dfe',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'yearn.finance',
@@ -558,7 +491,6 @@ const seedTokens: ITokenData[] = [
     address: '0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'SHIBA INU',
@@ -566,7 +498,6 @@ const seedTokens: ITokenData[] = [
     address: '0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: '1INCH Token',
@@ -574,7 +505,6 @@ const seedTokens: ITokenData[] = [
     address: '0x111111111117dc0aa78b770fa6a738034120c302',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'CyberVein',
@@ -582,7 +512,6 @@ const seedTokens: ITokenData[] = [
     address: '0xbe428c3867f05dea2a89fc76a102b544eac7f772',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'BTU Protocol',
@@ -590,7 +519,6 @@ const seedTokens: ITokenData[] = [
     address: '0xb683d83a532e2cb7dfa5275eed3698436371cc9f',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Digitex Futures',
@@ -598,7 +526,6 @@ const seedTokens: ITokenData[] = [
     address: '0xc666081073e8dff8d3d1c2292a29ae1a2153ec09',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Xensor',
@@ -606,7 +533,6 @@ const seedTokens: ITokenData[] = [
     address: '0x6bc1f3a1ae56231dbb64d3e82e070857eae86045',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Dragonchain',
@@ -614,7 +540,6 @@ const seedTokens: ITokenData[] = [
     address: '0x419c4db4b9e25d6db2ad9691ccb832c8d9fda05e',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'STASIS EURO',
@@ -622,7 +547,6 @@ const seedTokens: ITokenData[] = [
     address: '0xdb25f211ab05b1c97d595516f45794528a807ad8',
     decimals: 2,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Power Ledger',
@@ -630,7 +554,6 @@ const seedTokens: ITokenData[] = [
     address: '0x595832f8fc6bf59c85c527fec3740a1b7a361269',
     decimals: 6,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Swipe',
@@ -638,7 +561,6 @@ const seedTokens: ITokenData[] = [
     address: '0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Pundi X',
@@ -646,7 +568,6 @@ const seedTokens: ITokenData[] = [
     address: '0xa15c7ebe1f07caf6bff097d8a589fb8ac49ae5b3',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Gatechain Token',
@@ -654,7 +575,6 @@ const seedTokens: ITokenData[] = [
     address: '0xe66747a101bff2dba3697199dcce5b743b454759',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Molecular Future',
@@ -662,7 +582,6 @@ const seedTokens: ITokenData[] = [
     address: '0x653430560be843c4a3d143d0110e896c2ab8ac0d',
     decimals: 16,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Orbs',
@@ -670,7 +589,6 @@ const seedTokens: ITokenData[] = [
     address: '0xff56cc6b1e6ded347aa0b7676c85ab0b3d08b0fa',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Crypterium',
@@ -678,7 +596,6 @@ const seedTokens: ITokenData[] = [
     address: '0x80a7e048f37a50500351c204cb407766fa3bae7f',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Ripio Credit Network',
@@ -686,7 +603,6 @@ const seedTokens: ITokenData[] = [
     address: '0xf970b8e36e23f7fc3fd752eea86f8be8d83375a6',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Streamr',
@@ -694,7 +610,6 @@ const seedTokens: ITokenData[] = [
     address: '0x0cf0ee63788a0849fe5297f3407f701e122cc023',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Huobi Pool Token',
@@ -702,7 +617,6 @@ const seedTokens: ITokenData[] = [
     address: '0xa66daa57432024023db65477ba87d4e7f5f95213',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'BHEX Token',
@@ -710,7 +624,6 @@ const seedTokens: ITokenData[] = [
     address: '0xfc29b6e626b67776675fff55d5bc0452d042f434',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Gnosis',
@@ -718,7 +631,6 @@ const seedTokens: ITokenData[] = [
     address: '0x6810e776880c02933d47db1b9fc05908e5386b96',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'IDEX',
@@ -726,7 +638,6 @@ const seedTokens: ITokenData[] = [
     address: '0xb705268213d593b8fd88d3fdeff93aff5cbdcfae',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'NuCypher',
@@ -734,7 +645,6 @@ const seedTokens: ITokenData[] = [
     address: '0x4fE83213D56308330EC302a8BD641f1d0113A4Cc',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Idle Finance',
@@ -742,7 +652,6 @@ const seedTokens: ITokenData[] = [
     address: '0x875773784Af8135eA0ef43b5a374AaD105c5D39e',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Yield Guild',
@@ -750,7 +659,6 @@ const seedTokens: ITokenData[] = [
     address: '0x25f8087ead173b73d6e8b84329989a8eea16cf73',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Alchemix',
@@ -758,7 +666,6 @@ const seedTokens: ITokenData[] = [
     address: '0xdbdb4d16eda451d0503b854cf79d55697f90c8df',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Amp',
@@ -766,7 +673,6 @@ const seedTokens: ITokenData[] = [
     address: '0xff20817765cb7f73d4bde2e66e067e58d11095c2',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Ankr Network',
@@ -774,7 +680,6 @@ const seedTokens: ITokenData[] = [
     address: '0x8290333cef9e6d528dd5618fb97a76f268f3edd4',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Axie Infinity Shard',
@@ -782,7 +687,6 @@ const seedTokens: ITokenData[] = [
     address: '0xbb0e17ef65f82ab018d8edd776e8dd940327b28b',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'BarnBridge Governance Token',
@@ -790,7 +694,6 @@ const seedTokens: ITokenData[] = [
     address: '0x0391D2021f89DC339F60Fff84546EA23E337750f',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Cryptex',
@@ -798,7 +701,6 @@ const seedTokens: ITokenData[] = [
     address: '0x321c2fe4446c7c963dc41dd58879af648838f98d',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Fantom Token',
@@ -806,7 +708,6 @@ const seedTokens: ITokenData[] = [
     address: '0x4e15361fd6b4bb609fa63c81a2be19d873717870',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Graph Token',
@@ -814,7 +715,6 @@ const seedTokens: ITokenData[] = [
     address: '0xc944e90c64b2c07662a292be6244bdf05cda44a7',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Injective Token',
@@ -822,7 +722,6 @@ const seedTokens: ITokenData[] = [
     address: '0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Livepeer Token',
@@ -830,7 +729,6 @@ const seedTokens: ITokenData[] = [
     address: '0x58b6a8a3302369daec383334672404ee733ab239',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Moss Carbon Credit',
@@ -838,7 +736,6 @@ const seedTokens: ITokenData[] = [
     address: '0xfc98e825a2264d890f9a1e68ed50e1526abccacd',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Orchid',
@@ -846,7 +743,6 @@ const seedTokens: ITokenData[] = [
     address: '0x4575f41308EC1483f3d399aa9a2826d74Da13Deb',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'The Sandbox',
@@ -854,7 +750,6 @@ const seedTokens: ITokenData[] = [
     address: '0x3845badAde8e6dFF049820680d1F14bD3903a5d0',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Skale',
@@ -862,7 +757,6 @@ const seedTokens: ITokenData[] = [
     address: '0x00c83aecc790e8a4453e5dd3b0b4b3680501a7a7',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Smooth Love Potion',
@@ -870,7 +764,6 @@ const seedTokens: ITokenData[] = [
     address: '0xcc8fa225d80b9c7d42f96e9570156c65d6caaa25',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Somnium Space Cubes',
@@ -878,7 +771,6 @@ const seedTokens: ITokenData[] = [
     address: '0xdf801468a808a32656d2ed2d2d80b72a129739f4',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Storj',
@@ -886,7 +778,6 @@ const seedTokens: ITokenData[] = [
     address: '0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Wrapped LUNA Token',
@@ -894,7 +785,6 @@ const seedTokens: ITokenData[] = [
     address: '0xd2877702675e6ceb975b4a1dff9fb7baf4c91ea9',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'UMA Voting Token v1',
@@ -902,7 +792,6 @@ const seedTokens: ITokenData[] = [
     address: '0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Uniswap',
@@ -910,7 +799,6 @@ const seedTokens: ITokenData[] = [
     address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Wrapped Centrifuge',
@@ -918,7 +806,6 @@ const seedTokens: ITokenData[] = [
     address: '0xc221b7e65ffc80de234bbb6667abdd46593d34f0',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Audius',
@@ -926,7 +813,6 @@ const seedTokens: ITokenData[] = [
     address: '0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Mask Network',
@@ -934,7 +820,6 @@ const seedTokens: ITokenData[] = [
     address: '0x69af81e73a73b40adf4f3d4223cd9b1ece623074',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Radicle',
@@ -942,7 +827,6 @@ const seedTokens: ITokenData[] = [
     address: '0x31c8eacbffdd875c74b94b077895bd78cf1e64a3',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'API3',
@@ -950,7 +834,6 @@ const seedTokens: ITokenData[] = [
     address: '0x0b38210ea11411557c13457D4dA7dC6ea731B88a',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'The Burn Token',
@@ -958,7 +841,6 @@ const seedTokens: ITokenData[] = [
     address: '0x71590d4ed14d9cbacb2cff8abf919ac4d22c5b7b',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'SuperRare',
@@ -966,7 +848,6 @@ const seedTokens: ITokenData[] = [
     address: '0xba5bde662c17e2adff1075610382b9b691296350',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Fetch',
@@ -974,7 +855,6 @@ const seedTokens: ITokenData[] = [
     address: '0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85',
     decimals: 18,
     networkId: 1,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Ethereum native token',
@@ -982,7 +862,6 @@ const seedTokens: ITokenData[] = [
     address: '0x0000000000000000000000000000000000000000',
     decimals: 18,
     networkId: 3,
-    chainType: ChainType.EVM,
   },
   {
     name: 'DAI Ropsten',
@@ -990,7 +869,6 @@ const seedTokens: ITokenData[] = [
     address: '0xad6d458402f60fd3bd25163575031acdce07538d',
     decimals: 18,
     networkId: 3,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Giveth Ropsten Test',
@@ -998,7 +876,6 @@ const seedTokens: ITokenData[] = [
     address: '0x067eA48882E6D728A37acfd1535ec03f8E33794a',
     decimals: 18,
     networkId: 3,
-    chainType: ChainType.EVM,
   },
   {
     name: 'UNI Ropsten',
@@ -1006,7 +883,6 @@ const seedTokens: ITokenData[] = [
     address: '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984',
     decimals: 18,
     networkId: 3,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Xdai native token',
@@ -1014,7 +890,6 @@ const seedTokens: ITokenData[] = [
     address: '0x0000000000000000000000000000000000000000',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Giveth Token',
@@ -1022,7 +897,6 @@ const seedTokens: ITokenData[] = [
     address: '0x4f4F9b8D5B4d0Dc10506e5551B0513B61fD59e75',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Curve DAO Token',
@@ -1030,7 +904,6 @@ const seedTokens: ITokenData[] = [
     address: '0x1337BedC9D22ecbe766dF105c9623922A27963EC',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'dAppNode on xDAI',
@@ -1038,7 +911,6 @@ const seedTokens: ITokenData[] = [
     address: '0xc60e38C6352875c051B481Cbe79Dd0383AdB7817',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Panvala',
@@ -1046,7 +918,6 @@ const seedTokens: ITokenData[] = [
     address: '0x981fb9ba94078a2275a8fc906898ea107b9462a8',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Honey',
@@ -1054,7 +925,6 @@ const seedTokens: ITokenData[] = [
     address: '0x71850b7E9Ee3f13Ab46d67167341E4bDc905Eef9',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'STAKE on xDai',
@@ -1062,7 +932,6 @@ const seedTokens: ITokenData[] = [
     address: '0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'USDC on xDai',
@@ -1070,7 +939,6 @@ const seedTokens: ITokenData[] = [
     address: '0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83',
     decimals: 6,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Wrapped Ether on xDai',
@@ -1078,7 +946,6 @@ const seedTokens: ITokenData[] = [
     address: '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'ChainLink Token on xDai',
@@ -1086,7 +953,6 @@ const seedTokens: ITokenData[] = [
     address: '0xE2e73A1c69ecF83F464EFCE6A5be353a37cA09b2',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Moons on xDai',
@@ -1094,7 +960,6 @@ const seedTokens: ITokenData[] = [
     address: '0x1e16aa4Df73d29C029d94CeDa3e3114EC191E25A',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Wrapped XDAI',
@@ -1102,7 +967,6 @@ const seedTokens: ITokenData[] = [
     address: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Tether USD on xDai',
@@ -1110,7 +974,6 @@ const seedTokens: ITokenData[] = [
     address: '0x4ECaBa5870353805a9F068101A40E0f32ed605C6',
     decimals: 6,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Wrapped BTC on xDai',
@@ -1118,7 +981,6 @@ const seedTokens: ITokenData[] = [
     address: '0x8e5bBbb09Ed1ebdE8674Cda39A0c169401db4252',
     decimals: 8,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Agave Token',
@@ -1126,7 +988,6 @@ const seedTokens: ITokenData[] = [
     address: '0x3a97704a1b25F08aa230ae53B352e2e72ef52843',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'xDAI Native Comb',
@@ -1134,7 +995,6 @@ const seedTokens: ITokenData[] = [
     address: '0x38Fb649Ad3d6BA1113Be5F57B927053E97fC5bF7',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'DAOhaus',
@@ -1142,7 +1002,6 @@ const seedTokens: ITokenData[] = [
     address: '0xb0C5f3100A4d9d9532a4CfD68c55F1AE8da987Eb',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Fox Token',
@@ -1150,7 +1009,6 @@ const seedTokens: ITokenData[] = [
     address: '0x21a42669643f45Bc0e086b8Fc2ed70c23D67509d',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Bright on xDAI',
@@ -1158,7 +1016,6 @@ const seedTokens: ITokenData[] = [
     address: '0x83FF60E2f93F8eDD0637Ef669C69D5Fb4f64cA8E',
     decimals: 18,
     networkId: 100,
-    chainType: ChainType.EVM,
   },
 
   // Goerli tokens
@@ -1168,7 +1025,6 @@ const seedTokens: ITokenData[] = [
     address: '0x0000000000000000000000000000000000000000',
     decimals: 18,
     networkId: 5,
-    chainType: ChainType.EVM,
   },
   {
     address: '0xdc31Ee1784292379Fbb2964b3B9C4124D8F89C60',
@@ -1176,7 +1032,6 @@ const seedTokens: ITokenData[] = [
     name: 'DAI Goerli',
     decimals: 18,
     networkId: 5,
-    chainType: ChainType.EVM,
   },
   {
     address: '0xA2470F25bb8b53Bd3924C7AC0C68d32BF2aBd5be',
@@ -1184,7 +1039,6 @@ const seedTokens: ITokenData[] = [
     name: 'GIV test',
     decimals: 18,
     networkId: 5,
-    chainType: ChainType.EVM,
   },
 
   // POLYGON tokens
@@ -1195,7 +1049,6 @@ const seedTokens: ITokenData[] = [
     decimals: 18,
     mainnetAddress: '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0',
     networkId: NETWORK_IDS.POLYGON,
-    chainType: ChainType.EVM,
   },
 
   // OPTIMISM Goerli tokens
@@ -1205,7 +1058,7 @@ const seedTokens: ITokenData[] = [
     address: '0x0000000000000000000000000000000000000000',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISM_GOERLI,
-    chainType: ChainType.EVM,
+
     coingeckoId: 'ethereum',
   },
   {
@@ -1214,7 +1067,7 @@ const seedTokens: ITokenData[] = [
     address: '0x4200000000000000000000000000000000000042',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISM_GOERLI,
-    chainType: ChainType.EVM,
+
     coingeckoId: 'optimism',
   },
   {
@@ -1223,7 +1076,7 @@ const seedTokens: ITokenData[] = [
     address: '0x4200000000000000000000000000000000000006',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISM_GOERLI,
-    chainType: ChainType.EVM,
+
     coingeckoId: 'weth',
   },
   {
@@ -1232,7 +1085,7 @@ const seedTokens: ITokenData[] = [
     address: '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISM_GOERLI,
-    chainType: ChainType.EVM,
+
     coingeckoId: 'dai',
   },
 
@@ -1243,7 +1096,7 @@ const seedTokens: ITokenData[] = [
     address: '0x0000000000000000000000000000000000000000',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISTIC,
-    chainType: ChainType.EVM,
+
     coingeckoId: 'ethereum',
   },
   {
@@ -1252,7 +1105,7 @@ const seedTokens: ITokenData[] = [
     address: '0x4200000000000000000000000000000000000042',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISTIC,
-    chainType: ChainType.EVM,
+
     coingeckoId: 'optimism',
   },
   {
@@ -1261,7 +1114,7 @@ const seedTokens: ITokenData[] = [
     address: '0x350a791bfc2c21f9ed5d10980dad2e2638ffa7f6',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISTIC,
-    chainType: ChainType.EVM,
+
     coingeckoId: 'chainlink',
   },
   {
@@ -1270,7 +1123,7 @@ const seedTokens: ITokenData[] = [
     address: '0x68f180fcce6836688e9084f035309e29bf0a2095',
     decimals: 8,
     networkId: NETWORK_IDS.OPTIMISTIC,
-    chainType: ChainType.EVM,
+
     coingeckoId: 'wrapped-bitcoin',
   },
   {
@@ -1279,7 +1132,7 @@ const seedTokens: ITokenData[] = [
     address: '0x8700daec35af8ff88c16bdf0418774cb3d7599b4',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISTIC,
-    chainType: ChainType.EVM,
+
     coingeckoId: 'havven',
   },
   {
@@ -1288,7 +1141,7 @@ const seedTokens: ITokenData[] = [
     address: '0x4200000000000000000000000000000000000006',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISTIC,
-    chainType: ChainType.EVM,
+
     coingeckoId: 'weth',
   },
   {
@@ -1297,7 +1150,7 @@ const seedTokens: ITokenData[] = [
     address: '0x94b008aA00579c1307B0EF2c499aD98a8ce58e58',
     decimals: 6,
     networkId: NETWORK_IDS.OPTIMISTIC,
-    chainType: ChainType.EVM,
+
     coingeckoId: 'tether',
   },
   {
@@ -1306,7 +1159,7 @@ const seedTokens: ITokenData[] = [
     address: '0x7F5c764cBc14f9669B88837ca1490cCa17c31607',
     decimals: 6,
     networkId: NETWORK_IDS.OPTIMISTIC,
-    chainType: ChainType.EVM,
+
     coingeckoId: 'usd-coin',
   },
   {
@@ -1315,7 +1168,7 @@ const seedTokens: ITokenData[] = [
     address: '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',
     decimals: 18,
     networkId: NETWORK_IDS.OPTIMISTIC,
-    chainType: ChainType.EVM,
+
     coingeckoId: 'dai',
   },
   // CELO tokens
@@ -1328,7 +1181,6 @@ const seedTokens: ITokenData[] = [
     // We usually set isGivbackEligible true for native tokens
     isGivbackEligible: true,
     networkId: NETWORK_IDS.CELO,
-    chainType: ChainType.EVM,
   },
   {
     symbol: 'cUSD',
@@ -1336,7 +1188,6 @@ const seedTokens: ITokenData[] = [
     address: '0x765DE816845861e75A25fCA122bb6898B8B1282a',
     decimals: 18,
     networkId: NETWORK_IDS.CELO,
-    chainType: ChainType.EVM,
   },
   {
     symbol: 'cEUR',
@@ -1344,7 +1195,6 @@ const seedTokens: ITokenData[] = [
     address: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
     decimals: 18,
     networkId: NETWORK_IDS.CELO,
-    chainType: ChainType.EVM,
   },
   {
     symbol: 'cREAL',
@@ -1352,7 +1202,6 @@ const seedTokens: ITokenData[] = [
     address: '0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787',
     decimals: 18,
     networkId: NETWORK_IDS.CELO,
-    chainType: ChainType.EVM,
   },
   // CELO ALFAJORES tokens
   {
@@ -1362,7 +1211,6 @@ const seedTokens: ITokenData[] = [
     // address: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
     decimals: 18,
     networkId: NETWORK_IDS.CELO_ALFAJORES,
-    chainType: ChainType.EVM,
   },
   {
     symbol: 'cUSD',
@@ -1370,7 +1218,6 @@ const seedTokens: ITokenData[] = [
     address: '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
     decimals: 18,
     networkId: NETWORK_IDS.CELO_ALFAJORES,
-    chainType: ChainType.EVM,
   },
   {
     symbol: 'cEUR',
@@ -1378,7 +1225,6 @@ const seedTokens: ITokenData[] = [
     address: '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
     decimals: 18,
     networkId: NETWORK_IDS.CELO_ALFAJORES,
-    chainType: ChainType.EVM,
   },
   {
     symbol: 'cREAL',
@@ -1386,7 +1232,6 @@ const seedTokens: ITokenData[] = [
     address: '0xE4D517785D091D3c54818832dB6094bcc2744545',
     decimals: 18,
     networkId: NETWORK_IDS.CELO_ALFAJORES,
-    chainType: ChainType.EVM,
   },
 
   // ETC tokens
@@ -1396,7 +1241,6 @@ const seedTokens: ITokenData[] = [
     address: '0x0000000000000000000000000000000000000000',
     decimals: 18,
     networkId: NETWORK_IDS.ETC,
-    chainType: ChainType.EVM,
   },
 
   // ETC tokens
@@ -1406,7 +1250,6 @@ const seedTokens: ITokenData[] = [
     address: '0x82A618305706B14e7bcf2592D4B9324A366b6dAd',
     decimals: 18,
     networkId: NETWORK_IDS.ETC,
-    chainType: ChainType.EVM,
   },
   // HEBE tokens
   {
@@ -1415,7 +1258,6 @@ const seedTokens: ITokenData[] = [
     address: '0x88d8C3Dc6B5324f34E8Cf229a93E197048671abD',
     decimals: 18,
     networkId: NETWORK_IDS.ETC,
-    chainType: ChainType.EVM,
   },
 
   // Mordor ETC testnet tokens
@@ -1425,7 +1267,6 @@ const seedTokens: ITokenData[] = [
     address: '0x0000000000000000000000000000000000000000',
     decimals: 18,
     networkId: NETWORK_IDS.MORDOR_ETC_TESTNET,
-    chainType: ChainType.EVM,
   },
   {
     name: 'Wrapped Ethereum',
@@ -1433,7 +1274,6 @@ const seedTokens: ITokenData[] = [
     address: '0x3B2e50b6CBe03AcA7578Da058eFe2Acc56dd386e',
     decimals: 18,
     networkId: NETWORK_IDS.MORDOR_ETC_TESTNET,
-    chainType: ChainType.EVM,
   },
   // SOLANA mainnet
   {


### PR DESCRIPTION
Removed chainType from older seed token values to fix migration issues.
As older schema doesn't have chainType and evm is default value of chainType in new schema, it won't cause issue