### PR TITLE
Add token filters to recurringDonationsByUserId webservice

### DIFF
--- a/src/resolvers/recurringDonationResolver.test.ts
+++ b/src/resolvers/recurringDonationResolver.test.ts
@@ -823,7 +823,6 @@ function recurringDonationsByUserIdTestCases() {
     }
   });
   it('should sort by the createdAt ASC', async () => {
-    const project = await saveProjectDirectlyToDb(createProjectData());
     const donor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
 
     await saveRecurringDonationDirectlyToDb({
@@ -860,7 +859,6 @@ function recurringDonationsByUserIdTestCases() {
     }
   });
   it('should sort by the flowRate ASC', async () => {
-    const project = await saveProjectDirectlyToDb(createProjectData());
     const donor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
 
     await saveRecurringDonationDirectlyToDb({
@@ -901,7 +899,6 @@ function recurringDonationsByUserIdTestCases() {
     }
   });
   it('should sort by the flowRate DESC', async () => {
-    const project = await saveProjectDirectlyToDb(createProjectData());
     const donor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
 
     await saveRecurringDonationDirectlyToDb({
@@ -942,7 +939,6 @@ function recurringDonationsByUserIdTestCases() {
     }
   });
   it('should filter by two tokens', async () => {
-    const project = await saveProjectDirectlyToDb(createProjectData());
     const donor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
 
     const d1 = await saveRecurringDonationDirectlyToDb({
@@ -957,7 +953,7 @@ function recurringDonationsByUserIdTestCases() {
         currency: 'USDC',
       },
     });
-    const d3 = await saveRecurringDonationDirectlyToDb({
+    await saveRecurringDonationDirectlyToDb({
       donationData: {
         donorId: donor.id,
         currency: 'USDT',
@@ -975,11 +971,221 @@ function recurringDonationsByUserIdTestCases() {
       },
       {},
     );
+    const donations =
+      result.data.data.recurringDonationsByUserId.recurringDonations;
+    assert.equal(result.data.data.recurringDonationsByUserId.totalCount, 2);
+    assert.isOk(donations.find(d => Number(d.id) === d1.id));
+    assert.isOk(donations.find(d => Number(d.id) === d2.id));
+  });
+  it('should filter by one token', async () => {
+    const donor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+
+    const d1 = await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        donorId: donor.id,
+        currency: 'DAI',
+      },
+    });
+    const d2 = await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        donorId: donor.id,
+        currency: 'USDT',
+      },
+    });
+    await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        donorId: donor.id,
+        currency: 'USDT',
+      },
+    });
+
+    const result = await axios.post(
+      graphqlUrl,
+      {
+        query: fetchRecurringDonationsByUserIdQuery,
+        variables: {
+          userId: donor.id,
+          filteredTokens: ['DAI'],
+        },
+      },
+      {},
+    );
+    const donations =
+      result.data.data.recurringDonationsByUserId.recurringDonations;
+    assert.equal(result.data.data.recurringDonationsByUserId.totalCount, 1);
+    assert.isOk(donations.find(d => Number(d.id) === d1.id));
+  });
+  it('should not filter if filteredTokens is not passing', async () => {
+    const donor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+
+    const d1 = await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        donorId: donor.id,
+        currency: 'DAI',
+      },
+    });
+    const d2 = await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        donorId: donor.id,
+        currency: 'USDC',
+      },
+    });
+    await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        donorId: donor.id,
+        currency: 'USDT',
+      },
+    });
+
+    const result = await axios.post(
+      graphqlUrl,
+      {
+        query: fetchRecurringDonationsByUserIdQuery,
+        variables: {
+          userId: donor.id,
+        },
+      },
+      {},
+    );
+    const donations =
+      result.data.data.recurringDonationsByUserId.recurringDonations;
+    assert.equal(result.data.data.recurringDonationsByUserId.totalCount, 3);
+    assert.isOk(donations.find(d => Number(d.id) === d1.id));
+  });
+  it('should filter by finishStatus filter both true and false', async () => {
+    const donor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+
+    const d1 = await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        donorId: donor.id,
+        finished: true,
+      },
+    });
+    const d2 = await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        donorId: donor.id,
+        finished: false,
+      },
+    });
+
+    const result = await axios.post(
+      graphqlUrl,
+      {
+        query: fetchRecurringDonationsByUserIdQuery,
+        variables: {
+          userId: donor.id,
+          finishStatus: [true, false],
+        },
+      },
+      {},
+    );
 
     const donations =
       result.data.data.recurringDonationsByUserId.recurringDonations;
     assert.equal(result.data.data.recurringDonationsByUserId.totalCount, 2);
     assert.isOk(donations.find(d => Number(d.id) === d1.id));
+    assert.isOk(donations.find(d => Number(d.id) === d2.id));
+  });
+  it('should return just not finished recurring donations when not passing finishStatus', async () => {
+    const donor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+
+    const d1 = await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        donorId: donor.id,
+        finished: true,
+      },
+    });
+    const d2 = await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        donorId: donor.id,
+        finished: false,
+      },
+    });
+
+    const result = await axios.post(
+      graphqlUrl,
+      {
+        query: fetchRecurringDonationsByUserIdQuery,
+        variables: {
+          userId: donor.id,
+        },
+      },
+      {},
+    );
+
+    const donations =
+      result.data.data.recurringDonationsByUserId.recurringDonations;
+    assert.equal(result.data.data.recurringDonationsByUserId.totalCount, 1);
+    assert.isNotOk(donations.find(d => Number(d.id) === d1.id));
+    assert.isOk(donations.find(d => Number(d.id) === d2.id));
+  });
+  it('should filter by finishStatus filter just true', async () => {
+    const donor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+
+    const d1 = await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        donorId: donor.id,
+        finished: true,
+      },
+    });
+    const d2 = await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        donorId: donor.id,
+        finished: false,
+      },
+    });
+
+    const result = await axios.post(
+      graphqlUrl,
+      {
+        query: fetchRecurringDonationsByUserIdQuery,
+        variables: {
+          userId: donor.id,
+          finishStatus: [true],
+        },
+      },
+      {},
+    );
+
+    const donations =
+      result.data.data.recurringDonationsByUserId.recurringDonations;
+    assert.equal(result.data.data.recurringDonationsByUserId.totalCount, 1);
+    assert.isOk(donations.find(d => Number(d.id) === d1.id));
+    assert.isNotOk(donations.find(d => Number(d.id) === d2.id));
+  });
+  it('should filter by finishStatus filter just false', async () => {
+    const project = await saveProjectDirectlyToDb(createProjectData());
+    const donor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+
+    const d1 = await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        donorId: donor.id,
+        finished: true,
+      },
+    });
+    const d2 = await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        donorId: donor.id,
+        finished: false,
+      },
+    });
+
+    const result = await axios.post(
+      graphqlUrl,
+      {
+        query: fetchRecurringDonationsByUserIdQuery,
+        variables: {
+          userId: donor.id,
+          finishStatus: [false],
+        },
+      },
+      {},
+    );
+
+    const donations =
+      result.data.data.recurringDonationsByUserId.recurringDonations;
+    assert.equal(result.data.data.recurringDonationsByUserId.totalCount, 1);
+    assert.isNotOk(donations.find(d => Number(d.id) === d1.id));
     assert.isOk(donations.find(d => Number(d.id) === d2.id));
   });
 }

--- a/src/resolvers/recurringDonationResolver.ts
+++ b/src/resolvers/recurringDonationResolver.ts
@@ -118,6 +118,9 @@ class UserRecurringDonationsArgs {
 
   @Field(type => Boolean, { nullable: true, defaultValue: false })
   finished: boolean;
+
+  @Field(type => [String], { nullable: true, defaultValue: [] })
+  filteredTokens: string[];
 }
 
 @ObjectType()
@@ -327,6 +330,7 @@ export class RecurringDonationResolver {
       userId,
       status,
       finished,
+      filteredTokens,
     }: UserRecurringDonationsArgs,
     @Ctx() ctx: ApolloContext,
   ) {
@@ -360,6 +364,12 @@ export class RecurringDonationResolver {
     if (status) {
       query.andWhere(`donation.status = :status`, {
         status,
+      });
+    }
+
+    if (filteredTokens && filteredTokens.length > 0) {
+      query.andWhere(`recurringDonation.currency IN (:...filteredTokens)`, {
+        filteredTokens,
       });
     }
 

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -331,7 +331,7 @@ export const fetchRecurringDonationsByProjectIdQuery = `
     $projectId: Int!
     $searchTerm: String
     $status: String
-    $finished: Boolean
+    $finishStatus: [Boolean!]
     $orderBy: RecurringDonationSortBy
   ) {
     recurringDonationsByProjectId(
@@ -340,7 +340,7 @@ export const fetchRecurringDonationsByProjectIdQuery = `
       projectId: $projectId
       searchTerm: $searchTerm
       status: $status
-      finished: $finished
+      finishStatus: $finishStatus
       orderBy: $orderBy
 
     ) {
@@ -371,7 +371,7 @@ export const fetchRecurringDonationsByUserIdQuery = `
     $skip: Int
     $status: String
     $orderBy: RecurringDonationSortBy
-    $finished: Boolean
+    $finishStatus: [Boolean!]
     $userId: Int!
     $filteredTokens: [String!]
   ) {
@@ -381,7 +381,7 @@ export const fetchRecurringDonationsByUserIdQuery = `
       orderBy: $orderBy
       userId: $userId
       status: $status
-      finished: $finished
+      finishStatus: $finishStatus
       filteredTokens: $filteredTokens
     ) {
       recurringDonations {

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -373,6 +373,7 @@ export const fetchRecurringDonationsByUserIdQuery = `
     $orderBy: RecurringDonationSortBy
     $finished: Boolean
     $userId: Int!
+    $filteredTokens: [String!]
   ) {
     recurringDonationsByUserId(
       take: $take
@@ -381,6 +382,7 @@ export const fetchRecurringDonationsByUserIdQuery = `
       userId: $userId
       status: $status
       finished: $finished
+      filteredTokens: $filteredTokens
     ) {
       recurringDonations {
         id

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -1923,6 +1923,7 @@ export const saveRecurringDonationDirectlyToDb = async (params?: {
     status: params?.donationData?.status || 'pending',
     networkId: params?.donationData?.networkId || NETWORK_IDS.OPTIMISM_SEPOLIA,
     currency: params?.donationData?.currency || 'USDT',
+    finished: params?.donationData?.finished || false,
     txHash: params?.donationData?.txHash || generateRandomEtheriumAddress(),
     anonymous,
     donorId,


### PR DESCRIPTION
related to #1398

@MohammadPCh 
* recurringDonationsByUserId
  * You can pass  finishStatus if you want( if you don't pass the default value is [false])
  ```
  const result = await axios.post(
      graphqlUrl,
      {
        query: fetchRecurringDonationsByUserIdQuery,
        variables: {
          userId: donor.id,
          finishStatus: [true],
        },
      },
      {},
    );
```
  * You can pass  filteredTokens if you want( if you don't pass the default value is [] and we return all tokens)
  ```
    const result = await axios.post(
      graphqlUrl,
      {
        query: fetchRecurringDonationsByUserIdQuery,
        variables: {
          userId: donor.id,
          filteredTokens: ['DAI', 'USDC'],
        },
      },
      {},
    );
  ```
* recurringDonationsByProjectId
  * You can pass  finishStatus if you want( if you don't pass the default value is [false])
  ```
      const result = await axios.post(
      graphqlUrl,
      {
        query: fetchRecurringDonationsByProjectIdQuery,
        variables: {
          projectId: project.id,
             finishStatus: [true, false],
        },
      },
      {},
    );

  ```
  
  Is it ok?