### PR TITLE
remove refresh_project_summary_from totals and add user cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,14 +22,6 @@
         "@sentry/node": "6.16.1",
         "@sentry/tracing": "^6.2.0",
         "@solana/web3.js": "^1.87.6",
-        "@types/connect-redis": "0.0.23",
-        "@types/cors": "^2.8.10",
-        "@types/dotenv": "^8.2.0",
-        "@types/express": "^4.17.21",
-        "@types/graphql-upload": "15.0.2",
-        "@types/jsonwebtoken": "^8.5.0",
-        "@types/marked": "^4.0.8",
-        "@types/node": "^14.14.31",
         "@uniswap/sdk": "^3.0.3",
         "abi-decoder": "^2.4.0",
         "adminjs": "6.8.3",
@@ -81,16 +73,23 @@
         "twitter-api-sdk": "^1.0.9",
         "type-graphql": "2.0.0-beta.1",
         "typedi": "0.8.0",
-        "typeorm": "0.3.20",
-        "typescript": "^4.9.4"
+        "typeorm": "0.3.20"
       },
       "devDependencies": {
         "@types/axios": "^0.14.0",
         "@types/bull": "^3.15.5",
         "@types/chai": "^4.2.15",
+        "@types/connect-redis": "0.0.23",
+        "@types/cors": "^2.8.10",
+        "@types/dotenv": "^8.2.0",
+        "@types/express": "^4.17.21",
+        "@types/graphql-upload": "15.0.2",
         "@types/html-to-text": "^9.0.0",
+        "@types/jsonwebtoken": "^8.5.0",
         "@types/lodash": "^4.14.197",
+        "@types/marked": "^4.0.8",
         "@types/mocha": "^8.2.1",
+        "@types/node": "^14.14.31",
         "@types/node-cron": "^3.0.0",
         "@typescript-eslint/eslint-plugin": "^7.2.0",
         "@typescript-eslint/parser": "^7.2.0",
@@ -106,7 +105,8 @@
         "prettier": "^3.2.5",
         "sinon": "^13.0.1",
         "ts-node": "10.9.2",
-        "ts-node-dev": "2.0.0"
+        "ts-node-dev": "2.0.0",
+        "typescript": "^4.9.4"
       },
       "engines": {
         "node": ">=16.14.2"
@@ -6154,6 +6154,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
+      "devOptional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -6288,6 +6289,7 @@
       "version": "0.0.23",
       "resolved": "https://registry.npmjs.org/@types/connect-redis/-/connect-redis-0.0.23.tgz",
       "integrity": "sha512-+yKa9EQJ7YZIWjTKbCdXhqYSpirGf7Cc0o5QTFrkWORneFHVu3QOopRUi6E/ye41QGMom+cj1/kvWFHamHTADA==",
+      "dev": true,
       "dependencies": {
         "@types/express": "*",
         "@types/express-session": "*",
@@ -6299,12 +6301,14 @@
     "node_modules/@types/content-disposition": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
-      "integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA=="
+      "integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA==",
+      "devOptional": true
     },
     "node_modules/@types/cookies": {
       "version": "0.7.7",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
       "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
+      "devOptional": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -6316,6 +6320,7 @@
       "version": "2.8.13",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
       "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -6325,6 +6330,7 @@
       "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
       "deprecated": "This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.",
+      "dev": true,
       "dependencies": {
         "dotenv": "*"
       }
@@ -6360,6 +6366,7 @@
       "version": "1.17.5",
       "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.17.5.tgz",
       "integrity": "sha512-l0DhkvNVfyUPEEis8fcwbd46VptfA/jmMwHfob2TfDMf3HyPLiB9mKD71LXhz5TMUobODXPD27zXSwtFQLHm+w==",
+      "dev": true,
       "dependencies": {
         "@types/express": "*"
       }
@@ -6377,6 +6384,7 @@
       "version": "15.0.2",
       "resolved": "https://registry.npmjs.org/@types/graphql-upload/-/graphql-upload-15.0.2.tgz",
       "integrity": "sha512-dK4GN/JbMmgHbsKZaUWVYwaLMCwIR0QMBcFz+jb4xj/cRLq1yo2VfnoFvnP5yCw7W4IgGgW7JRwEvM4jn0ahlA==",
+      "dev": true,
       "dependencies": {
         "@types/express": "*",
         "@types/koa": "*",
@@ -6402,7 +6410,8 @@
     "node_modules/@types/http-assert": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.3.tgz",
-      "integrity": "sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA=="
+      "integrity": "sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA==",
+      "devOptional": true
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
@@ -6412,7 +6421,8 @@
     "node_modules/@types/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
+      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==",
+      "devOptional": true
     },
     "node_modules/@types/ioredis": {
       "version": "5.0.0",
@@ -6440,6 +6450,7 @@
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
       "integrity": "sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -6447,7 +6458,8 @@
     "node_modules/@types/keygrip": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
-      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
+      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==",
+      "devOptional": true
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
@@ -6461,6 +6473,7 @@
       "version": "2.13.5",
       "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.5.tgz",
       "integrity": "sha512-HSUOdzKz3by4fnqagwthW/1w/yJspTgppyyalPVbgZf8jQWvdIXcVW5h2DGtw4zYntOaeRGx49r1hxoPWrD4aA==",
+      "devOptional": true,
       "dependencies": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
@@ -6476,6 +6489,7 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
       "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
+      "devOptional": true,
       "dependencies": {
         "@types/koa": "*"
       }
@@ -6500,7 +6514,8 @@
     "node_modules/@types/marked": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.8.tgz",
-      "integrity": "sha512-HVNzMT5QlWCOdeuBsgXP8EZzKUf0+AXzN+sLmjvaB3ZlLqO+e4u0uXrdw9ub69wBKFs+c6/pA4r9sy6cCDvImw=="
+      "integrity": "sha512-HVNzMT5QlWCOdeuBsgXP8EZzKUf0+AXzN+sLmjvaB3ZlLqO+e4u0uXrdw9ub69wBKFs+c6/pA4r9sy6cCDvImw==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
@@ -6603,6 +6618,7 @@
       "version": "2.8.32",
       "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.32.tgz",
       "integrity": "sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -11404,6 +11420,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-8.0.0.tgz",
       "integrity": "sha512-+Lk6iSKajdGw+7XYxUkwIzreJ2G1JFlYOdnKJv5PzwFLVsoJYBpCuS7WPIUSNT1IbQaEWT1nhYU63Ud03DyzLA==",
+      "dev": true,
       "engines": {
         "node": "^14.17.0 || >=16.0.0"
       }
@@ -20110,6 +20127,7 @@
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/entities/user.ts
+++ b/src/entities/user.ts
@@ -214,6 +214,10 @@ export class User extends BaseEntity {
         status: DONATION_STATUS.VERIFIED,
       })
       .andWhere(`donation."recurringDonationId" IS NULL`)
+      .cache(
+        `user-donationsCount-normal-${this.id}`,
+        Number(process.env.USER_STATS_CACHE_TIME || 60000),
+      )
       .getCount();
 
     // Count for recurring donations
@@ -222,6 +226,10 @@ export class User extends BaseEntity {
     )
       .where(`recurring_donation."donorId" = :donorId`, { donorId: this.id })
       .andWhere('recurring_donation.totalUsdStreamed > 0')
+      .cache(
+        `user-donationsCount-recurring-${this.id}`,
+        Number(process.env.USER_STATS_CACHE_TIME || 60000),
+      )
       .getCount();
 
     // Sum of both counts
@@ -236,6 +244,10 @@ export class User extends BaseEntity {
       .andWhere(
         `project.statusId = ${ProjStatus.active} AND project.reviewStatus = :reviewStatus`,
         { reviewStatus: ReviewStatus.Listed },
+      )
+      .cache(
+        `user-likedProjectsCount-recurring-${this.id}`,
+        Number(process.env.USER_STATS_CACHE_TIME || 60000),
       )
       .getCount();
 

--- a/src/repositories/powerBoostingRepository.ts
+++ b/src/repositories/powerBoostingRepository.ts
@@ -165,7 +165,11 @@ export const findPowerBoostingsCountByUserId = async (
     .leftJoin('powerBoosting.user', 'user')
     .addSelect(publicSelectionFields)
     .where(`percentage > 0`)
-    .andWhere(`"userId" =${userId}`);
+    .andWhere(`"userId" =${userId}`)
+    .cache(
+      `findPowerBoostingsCountByUserId-recurring-${userId}`,
+      Number(process.env.USER_STATS_CACHE_TIME || 60000),
+    );
   return query.getCount();
 };
 

--- a/src/services/donationService.ts
+++ b/src/services/donationService.ts
@@ -198,9 +198,6 @@ export const updateTotalDonationsOfProject = async (
     `,
       [projectId],
     );
-
-    // we want to update the project donation summary view after updating the total donations
-    refreshProjectDonationSummaryView();
   } catch (e) {
     logger.error('updateTotalDonationsOfAProject error', e);
   }


### PR DESCRIPTION
No calculated function from any entity should be without cache.
Removed refreshProjectDonationSummaryView from the updateTotal donations of project. That is a really common function. Let the cronjob take do the update every 10 minutes.

Related to https://github.com/Giveth/impact-graph/issues/1535