### PR TITLE
fix: add pagination for QF Round listed projects

### DIFF
--- a/src/server/adminJs/tabs/components/ProjectsInQfRound.tsx
+++ b/src/server/adminJs/tabs/components/ProjectsInQfRound.tsx
@@ -1,14 +1,32 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { withTheme } from 'styled-components';
-import { Section, Label, Link } from '@adminjs/design-system';
+import { Section, Label, Link, Button, Box } from '@adminjs/design-system';
 
 const ProjectsInQfRound = props => {
-  const projects = props?.record?.params?.projects;
+  const projects = props?.record?.params?.projects || [];
+  const projectsPerPage = 5;
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // Calculate total pages
+  const totalPages = Math.ceil(projects.length / projectsPerPage);
+
+  // Get projects for the current page
+  const startIndex = (currentPage - 1) * projectsPerPage;
+  const endIndex = startIndex + projectsPerPage;
+  const currentProjects = projects.slice(startIndex, endIndex);
+
+  // Handle page change
+  const handlePageChange = newPage => {
+    if (newPage > 0 && newPage <= totalPages) {
+      setCurrentPage(newPage);
+    }
+  };
 
   return (
     <div>
       <Label>Related Projects</Label>
       <Section>
+<<<<<<< Updated upstream
         {projects.map(project => {
           const { id, title, slug } = project;
           const projectLink = `/admin/resources/Project/records/${id}/show`;
@@ -26,7 +44,74 @@ const ProjectsInQfRound = props => {
             </div>
           );
         })}
+=======
+        {currentProjects.length > 0
+          ? currentProjects.map(project => {
+              const { id, title, slug } = project;
+              const projectLink = `/admin/resources/Project/records/${id}/show`;
+              return (
+                <div key={id}>
+                  <br />
+                  <Section>
+                    <h1>{title}</h1>
+                    <h2>{slug}</h2>
+                    <br />
+                    <Link href={projectLink || ''} target="_blank">
+                      {projectLink}
+                    </Link>
+                  </Section>
+                </div>
+              );
+            })
+          : 'No related projects found.'}
+>>>>>>> Stashed changes
       </Section>
+
+      {totalPages > 1 && (
+        <Box display="flex" justifyContent="center" mt="20px">
+          <Button
+            variant="primary"
+            disabled={currentPage === 1}
+            onClick={() => handlePageChange(currentPage - 1)}
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11 6L1 6M1 6L6 1M1 6L6 11"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              />
+            </svg>
+          </Button>
+          <Box mx="10px" alignSelf="center">
+            Page {currentPage} of {totalPages}
+          </Box>
+          <Button
+            variant="primary"
+            disabled={currentPage === totalPages}
+            onClick={() => handlePageChange(currentPage + 1)}
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M1 6L11 6M11 6L6 1M11 6L6 11"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              />
+            </svg>
+          </Button>
+        </Box>
+      )}
       <br />
     </div>
   );

--- a/src/server/adminJs/tabs/components/ProjectsInQfRound.tsx
+++ b/src/server/adminJs/tabs/components/ProjectsInQfRound.tsx
@@ -26,25 +26,6 @@ const ProjectsInQfRound = props => {
     <div>
       <Label>Related Projects</Label>
       <Section>
-<<<<<<< Updated upstream
-        {projects.map(project => {
-          const { id, title, slug } = project;
-          const projectLink = `/admin/resources/Project/records/${id}/show`;
-          return (
-            <div key={id}>
-              <br />
-              <Section>
-                <h1>{title}</h1>
-                <h2>{slug}</h2>
-                <br />
-                <Link href={projectLink || ''} target="_blank">
-                  {projectLink}
-                </Link>
-              </Section>
-            </div>
-          );
-        })}
-=======
         {currentProjects.length > 0
           ? currentProjects.map(project => {
               const { id, title, slug } = project;
@@ -64,7 +45,6 @@ const ProjectsInQfRound = props => {
               );
             })
           : 'No related projects found.'}
->>>>>>> Stashed changes
       </Section>
 
       {totalPages > 1 && (

--- a/src/server/adminJs/tabs/components/ProjectsInQfRound.tsx
+++ b/src/server/adminJs/tabs/components/ProjectsInQfRound.tsx
@@ -58,6 +58,7 @@ const ProjectsInQfRound = props => {
               width="12"
               height="12"
               viewBox="0 0 12 12"
+              aria-label="Previous page"
               fill="none"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -81,6 +82,7 @@ const ProjectsInQfRound = props => {
               height="12"
               viewBox="0 0 12 12"
               fill="none"
+              aria-label="Next page"
               xmlns="http://www.w3.org/2000/svg"
             >
               <path


### PR DESCRIPTION
Related to https://github.com/Giveth/impact-graph/issues/1029#issuecomment-2120666083

I couldn't make the pagination on the server side since I can't interact with DB within a component, it throws this error related to not supporting decorators. I will get back to it and try to search more and optimize it.
For now the pagination is on client side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pagination functionality to display a limited number of projects per page. Users can now navigate between pages using previous and next buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->