### PR TITLE
fix: filter unique donors based on passport score and knownAsSybilAdd…

### DIFF
--- a/migration/1717930067669-AddIsDataAnalysisDoneToQFRound.ts
+++ b/migration/1717930067669-AddIsDataAnalysisDoneToQFRound.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddIsDataAnalysisDoneToQFRound1717930067669
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        ALTER TABLE "qf_round" ADD COLUMN IF NOT EXISTS "isDataAnalysisDone" BOOLEAN DEFAULT FALSE;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        ALTER TABLE "qf_round" DROP COLUMN IF EXISTS "isDataAnalysisDone";
+    `);
+  }
+}

--- a/src/entities/qfRound.ts
+++ b/src/entities/qfRound.ts
@@ -93,6 +93,10 @@ export class QfRound extends BaseEntity {
   @Column('text', { array: true, default: [] })
   sponsorsImgs: string[];
 
+  @Field(_type => Boolean)
+  @Column({ default: false })
+  isDataAnalysisDone: boolean;
+
   @UpdateDateColumn()
   updatedAt: Date;
 

--- a/src/repositories/qfRoundRepository.ts
+++ b/src/repositories/qfRoundRepository.ts
@@ -98,6 +98,7 @@ export const findArchivedQfRounds = async (
   const fullRounds = await QfRound.createQueryBuilder('qfRound')
     .where('"isActive" = false')
     .leftJoin('qfRound.donations', 'donation')
+    .leftJoin('donation.user', 'user')
     .select('qfRound.id', 'id')
     .addSelect('qfRound.name', 'name')
     .addSelect('qfRound.slug', 'slug')
@@ -105,7 +106,10 @@ export const findArchivedQfRounds = async (
     .addSelect('qfRound.endDate', 'endDate')
     .addSelect('qfRound.eligibleNetworks', 'eligibleNetworks')
     .addSelect('SUM(donation.amount)', 'totalDonations')
-    .addSelect('COUNT(DISTINCT donation.fromWalletAddress)', 'uniqueDonors')
+    .addSelect(
+      'COUNT(DISTINCT CASE WHEN user.passportScore >= qfRound.minimumPassportScore AND user.knownAsSybilAddress = FALSE THEN donation.fromWalletAddress ELSE NULL END)',
+      'uniqueDonors',
+    )
     .addSelect('qfRound.allocatedFund', 'allocatedFund')
     .addSelect('qfRound.allocatedFundUSD', 'allocatedFundUSD')
     .addSelect('qfRound.allocatedTokenSymbol', 'allocatedTokenSymbol')

--- a/src/repositories/qfRoundRepository.ts
+++ b/src/repositories/qfRoundRepository.ts
@@ -87,6 +87,9 @@ export class QFArchivedRounds {
 
   @Field(_type => String, { nullable: true })
   uniqueDonors: string;
+
+  @Field(_type => Boolean)
+  isDataAnalysisDone: boolean;
 }
 
 export const findArchivedQfRounds = async (
@@ -112,6 +115,7 @@ export const findArchivedQfRounds = async (
     .addSelect('qfRound.isActive', 'isActive')
     .addSelect('qfRound.endDate', 'endDate')
     .addSelect('qfRound.eligibleNetworks', 'eligibleNetworks')
+    .addSelect('qfRound.isDataAnalysisDone', 'isDataAnalysisDone')
     .addSelect('SUM(donation.amount)', 'totalDonations')
     .addSelect(
       'COUNT(DISTINCT CASE WHEN user.passportScore >= qfRound.minimumPassportScore AND user.knownAsSybilAddress = FALSE THEN donation.fromWalletAddress ELSE NULL END)',

--- a/src/server/adminJs/tabs/components/QFRoundSponsorsImgs.tsx
+++ b/src/server/adminJs/tabs/components/QFRoundSponsorsImgs.tsx
@@ -162,9 +162,10 @@ const Label = styled.label`
 
 const Container = styled.div`
   background-color: white;
-  border-radius: 0.75rem; /* Equivalent to rounded */
+  border-radius: 0.75rem;
   width: 100%;
-  margin: auto;
+  margin-inline: auto;
+  margin-bottom: 2rem;
 `;
 
 const FileContainer = styled.div`
@@ -172,22 +173,22 @@ const FileContainer = styled.div`
   display: flex;
   margin-top: 1rem;
   flex-direction: column;
-  padding: 1rem; /* Equivalent to p-4 */
-  color: #718096; /* Equivalent to text-gray-400 */
-  border: 1px solid #e2e8f0; /* Equivalent to border */
-  border-radius: 0.375rem; /* Equivalent to rounded */
+  padding: 1rem;
+  color: #718096;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.375rem;
 `;
 
 const DropZone = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
-  border: 1px dashed #e2e8f0; /* Equivalent to border-dashed */
-  border-radius: 0.375rem; /* Equivalent to rounded */
+  border: 1px dashed #e2e8f0;
+  border-radius: 0.375rem;
   cursor: pointer;
   &:hover {
-    border-color: #4a90e2; /* Equivalent to border-blue-400 */
-    box-shadow: 0 0 0 0.25rem #4a90e2; /* Equivalent to ring-4 */
+    border-color: #4a90e2;
+    box-shadow: 0 0 0 0.25rem #4a90e2;
   }
 `;
 

--- a/src/server/adminJs/tabs/qfRoundTab.ts
+++ b/src/server/adminJs/tabs/qfRoundTab.ts
@@ -155,10 +155,6 @@ async function validateQfRound(payload: {
 }) {
   if (!payload.id) return;
 
-  if (payload.isActive && payload.isDataAnalysisDone) {
-    payload.isDataAnalysisDone = false;
-  }
-
   const qfRoundId = Number(payload.id);
   const qfRound = await findQfRoundById(qfRoundId);
   if (!qfRound) {
@@ -196,6 +192,9 @@ async function validateQfRound(payload: {
         qfRound,
         add: false,
       });
+    }
+    if (payload.isDataAnalysisDone) {
+      payload.isDataAnalysisDone = false;
     }
   }
 }

--- a/src/server/adminJs/tabs/qfRoundTab.ts
+++ b/src/server/adminJs/tabs/qfRoundTab.ts
@@ -151,8 +151,13 @@ async function validateQfRound(payload: {
   endDate?: Date;
   beginDate?: Date;
   isActive?: boolean;
+  isDataAnalysisDone?: boolean;
 }) {
   if (!payload.id) return;
+
+  if (payload.isActive && payload.isDataAnalysisDone) {
+    payload.isDataAnalysisDone = false;
+  }
 
   const qfRoundId = Number(payload.id);
   const qfRound = await findQfRoundById(qfRoundId);
@@ -249,6 +254,15 @@ export const qfRoundTab = {
       },
       isActive: {
         isVisible: true,
+      },
+      isDataAnalysisDone: {
+        isVisible: {
+          filter: true,
+          list: false,
+          show: true,
+          new: true,
+          edit: true,
+        },
       },
       maximumReward: {
         isVisible: true,


### PR DESCRIPTION
Related to https://github.com/Giveth/giveth-dapps-v2/issues/4245

Added a condition to count only the unique donors that has 
- passportScore >= minimumPassportScore
- knownAsSybilAddress is false

cc: @CarlosQ96 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new field `isDataAnalysisDone` to the QF rounds, providing more detailed tracking of data analysis completion.

- **Enhancements**
  - Improved the calculation for `uniqueDonors` by including additional conditions based on user attributes.

- **Style**
  - Updated styling properties for components in the QF Round Sponsors Images section for better visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->