### PR TITLE
use networkId instead of optimism-only flag

### DIFF
--- a/src/repositories/donationRepository.ts
+++ b/src/repositories/donationRepository.ts
@@ -137,7 +137,7 @@ export const findDonationById = async (
 export const donationsTotalAmountPerDateRange = async (
   fromDate?: string,
   toDate?: string,
-  fromOptimismOnly?: boolean,
+  networkId?: number,
   onlyVerified?: boolean,
 ): Promise<number> => {
   const query = Donation.createQueryBuilder('donation')
@@ -152,8 +152,8 @@ export const donationsTotalAmountPerDateRange = async (
     query.andWhere(`donation."createdAt" <= '${toDate}'`);
   }
 
-  if (fromOptimismOnly) {
-    query.andWhere(`donation."transactionNetworkId" = 10`);
+  if (networkId) {
+    query.andWhere(`donation."transactionNetworkId" = ${networkId}`);
   }
 
   if (onlyVerified) {
@@ -165,7 +165,7 @@ export const donationsTotalAmountPerDateRange = async (
   const donationsUsdAmount = await query
     .cache(
       `donationsTotalAmountPerDateRange-${fromDate || ''}-${toDate || ''}-${
-        fromOptimismOnly || 'all'
+        networkId || 'all'
       }-${onlyVerified || 'all'}`,
       300000,
     )
@@ -177,7 +177,7 @@ export const donationsTotalAmountPerDateRange = async (
 export const donationsTotalAmountPerDateRangeByMonth = async (
   fromDate?: string,
   toDate?: string,
-  fromOptimismOnly?: boolean,
+  networkId?: number,
   onlyVerified?: boolean,
 ): Promise<ResourcesTotalPerMonthAndYear[]> => {
   const query = Donation.createQueryBuilder('donation')
@@ -195,8 +195,8 @@ export const donationsTotalAmountPerDateRangeByMonth = async (
     query.andWhere(`donation."createdAt" <= '${toDate}'`);
   }
 
-  if (fromOptimismOnly) {
-    query.andWhere(`donation."transactionNetworkId" = 10`);
+  if (networkId) {
+    query.andWhere(`donation."transactionNetworkId" = ${networkId}`);
   }
 
   if (onlyVerified) {
@@ -212,7 +212,7 @@ export const donationsTotalAmountPerDateRangeByMonth = async (
   query.cache(
     `donationsTotalAmountPerDateRangeByMonth-${fromDate || ''}-${
       toDate || ''
-    }-${fromOptimismOnly || 'all'}-${onlyVerified || 'all'}`,
+    }-${networkId || 'all'}-${onlyVerified || 'all'}`,
     300000,
   );
 
@@ -222,7 +222,7 @@ export const donationsTotalAmountPerDateRangeByMonth = async (
 export const donationsNumberPerDateRange = async (
   fromDate?: string,
   toDate?: string,
-  fromOptimismOnly?: boolean,
+  networkId?: number,
   onlyVerified?: boolean,
 ): Promise<number> => {
   const query = Donation.createQueryBuilder('donation')
@@ -237,8 +237,8 @@ export const donationsNumberPerDateRange = async (
     query.andWhere(`donation."createdAt" <= '${toDate}'`);
   }
 
-  if (fromOptimismOnly) {
-    query.andWhere(`donation."transactionNetworkId" = 10`);
+  if (networkId) {
+    query.andWhere(`donation."transactionNetworkId" = ${networkId}`);
   }
 
   if (onlyVerified) {
@@ -250,7 +250,7 @@ export const donationsNumberPerDateRange = async (
   const donationsUsdAmount = await query
     .cache(
       `donationsTotalNumberPerDateRange-${fromDate || ''}-${toDate || ''}--${
-        fromOptimismOnly || 'all'
+        networkId || 'all'
       }-${onlyVerified || 'all'}`,
       300000,
     )
@@ -262,7 +262,7 @@ export const donationsNumberPerDateRange = async (
 export const donationsTotalNumberPerDateRangeByMonth = async (
   fromDate?: string,
   toDate?: string,
-  fromOptimismOnly?: boolean,
+  networkId?: number,
   onlyVerified?: boolean,
 ): Promise<ResourcesTotalPerMonthAndYear[]> => {
   const query = Donation.createQueryBuilder('donation')
@@ -279,8 +279,8 @@ export const donationsTotalNumberPerDateRangeByMonth = async (
     query.andWhere(`donation."createdAt" <= '${toDate}'`);
   }
 
-  if (fromOptimismOnly) {
-    query.andWhere(`donation."transactionNetworkId" = 10`);
+  if (networkId) {
+    query.andWhere(`donation."transactionNetworkId" = ${networkId}`);
   }
 
   if (onlyVerified) {
@@ -296,7 +296,7 @@ export const donationsTotalNumberPerDateRangeByMonth = async (
   query.cache(
     `donationsTotalNumberPerDateRangeByMonth-${fromDate || ''}-${
       toDate || ''
-    }-${fromOptimismOnly || 'all'}-${onlyVerified || 'all'}`,
+    }-${networkId || 'all'}-${onlyVerified || 'all'}`,
     300000,
   );
 
@@ -306,7 +306,7 @@ export const donationsTotalNumberPerDateRangeByMonth = async (
 export const donorsCountPerDate = async (
   fromDate?: string,
   toDate?: string,
-  fromOptimismOnly?: boolean,
+  networkId?: number,
 ): Promise<number> => {
   const query = Donation.createQueryBuilder('donation')
     .select(
@@ -323,13 +323,13 @@ export const donorsCountPerDate = async (
     query.andWhere(`donation."createdAt" <= '${toDate}'`);
   }
 
-  if (fromOptimismOnly) {
-    query.andWhere(`donation."transactionNetworkId" = 10`);
+  if (networkId) {
+    query.andWhere(`donation."transactionNetworkId" = ${networkId}`);
   }
 
   query.cache(
     `donorsCountPerDate-${fromDate || ''}-${toDate || ''}-${
-      fromOptimismOnly || 'all'
+      networkId || 'all'
     }`,
     300000,
   );
@@ -374,7 +374,7 @@ WHERE d."createdAt" BETWEEN $1 AND $2
 export const donorsCountPerDateByMonthAndYear = async (
   fromDate?: string,
   toDate?: string,
-  fromOptimismOnly?: boolean,
+  networkId?: number,
 ): Promise<ResourcesTotalPerMonthAndYear[]> => {
   const query = Donation.createQueryBuilder('donation')
     .select(
@@ -390,8 +390,8 @@ export const donorsCountPerDateByMonthAndYear = async (
     query.andWhere(`donation."createdAt" <= '${toDate}'`);
   }
 
-  if (fromOptimismOnly) {
-    query.andWhere(`donation."transactionNetworkId" = 10`);
+  if (networkId) {
+    query.andWhere(`donation."transactionNetworkId" = ${networkId}`);
   }
 
   query.groupBy('year, month');
@@ -400,7 +400,7 @@ export const donorsCountPerDateByMonthAndYear = async (
 
   query.cache(
     `donorsCountPerDateByMonthAndYear-${fromDate || ''}-${toDate || ''}-${
-      fromOptimismOnly || 'all'
+      networkId || 'all'
     }`,
     300000,
   );

--- a/src/repositories/projectRepository.ts
+++ b/src/repositories/projectRepository.ts
@@ -434,7 +434,7 @@ export const userIsOwnerOfProject = async (
 export const totalProjectsPerDate = async (
   fromDate?: string,
   toDate?: string,
-  includesOptimism?: boolean,
+  networkId?: number,
   onlyListed?: boolean,
   onlyVerified?: boolean,
 ): Promise<number> => {
@@ -456,17 +456,17 @@ export const totalProjectsPerDate = async (
     query.andWhere(`project."reviewStatus" = 'Listed'`);
   }
 
-  if (includesOptimism) {
+  if (networkId) {
     query.innerJoin(
       `project.addresses`,
       'addresses',
-      'addresses."networkId" = 10',
+      `addresses."networkId" = ${networkId}`,
     );
   }
 
   query.cache(
     `totalProjectPerDate-${fromDate || ''}-${toDate || ''}-${
-      includesOptimism || 'all'
+      networkId || 'all'
     }-${onlyVerified || 'all'}-${onlyListed || 'all'}`,
     300000,
   );
@@ -477,7 +477,7 @@ export const totalProjectsPerDate = async (
 export const totalProjectsPerDateByMonthAndYear = async (
   fromDate?: string,
   toDate?: string,
-  includesOptimism?: boolean,
+  networkId?: number,
   onlyListed?: boolean,
   onlyVerified?: boolean,
 ): Promise<ResourcesTotalPerMonthAndYear[]> => {
@@ -501,11 +501,11 @@ export const totalProjectsPerDateByMonthAndYear = async (
     query.andWhere(`project."reviewStatus" = 'Listed'`);
   }
 
-  if (includesOptimism) {
+  if (networkId) {
     query.innerJoin(
       `project.addresses`,
       'addresses',
-      'addresses."networkId" = 10',
+      `addresses."networkId" = ${networkId}`,
     );
   }
 
@@ -514,7 +514,7 @@ export const totalProjectsPerDateByMonthAndYear = async (
   query.addOrderBy('month', 'ASC');
   query.cache(
     `totalProjectsPerDateByMonthAndYear-${fromDate || ''}-${toDate || ''}-${
-      includesOptimism || 'all'
+      networkId || 'all'
     }-${onlyVerified || 'all'}-${onlyListed || 'all'}`,
     300000,
   );

--- a/src/resolvers/donationResolver.ts
+++ b/src/resolvers/donationResolver.ts
@@ -264,7 +264,7 @@ export class DonationResolver {
   async totalDonationsPerCategory(
     @Arg('fromDate', { nullable: true }) fromDate?: string,
     @Arg('toDate', { nullable: true }) toDate?: string,
-    @Arg('fromOptimismOnly', { nullable: true }) fromOptimismOnly?: boolean,
+    @Arg('networkId', { nullable: true }) networkId?: number,
     @Arg('onlyVerified', { nullable: true }) onlyVerified?: boolean,
   ): Promise<MainCategoryDonations[] | []> {
     try {
@@ -294,11 +294,11 @@ export class DonationResolver {
         query.where(`donations."createdAt" <= '${toDate}'`);
       }
 
-      if (fromOptimismOnly) {
+      if (networkId) {
         if (fromDate || toDate) {
-          query.andWhere(`donations."transactionNetworkId" = 10`);
+          query.andWhere(`donations."transactionNetworkId" = ${networkId}`);
         } else {
-          query.where(`donations."transactionNetworkId" = 10`);
+          query.where(`donations."transactionNetworkId" = ${networkId}`);
         }
       }
 
@@ -318,7 +318,7 @@ export class DonationResolver {
     // fromDate and toDate should be in this format YYYYMMDD HH:mm:ss
     @Arg('fromDate', { nullable: true }) fromDate?: string,
     @Arg('toDate', { nullable: true }) toDate?: string,
-    @Arg('fromOptimismOnly', { nullable: true }) fromOptimismOnly?: boolean,
+    @Arg('networkId', { nullable: true }) networkId?: number,
     @Arg('onlyVerified', { nullable: true }) onlyVerified?: boolean,
   ): Promise<ResourcePerDateRange> {
     try {
@@ -329,14 +329,14 @@ export class DonationResolver {
       const total = await donationsTotalAmountPerDateRange(
         fromDate,
         toDate,
-        fromOptimismOnly,
+        networkId,
         onlyVerified,
       );
       const totalPerMonthAndYear =
         await donationsTotalAmountPerDateRangeByMonth(
           fromDate,
           toDate,
-          fromOptimismOnly,
+          networkId,
           onlyVerified,
         );
 
@@ -355,7 +355,7 @@ export class DonationResolver {
     // fromDate and toDate should be in this format YYYYMMDD HH:mm:ss
     @Arg('fromDate', { nullable: true }) fromDate?: string,
     @Arg('toDate', { nullable: true }) toDate?: string,
-    @Arg('fromOptimismOnly', { nullable: true }) fromOptimismOnly?: boolean,
+    @Arg('networkId', { nullable: true }) networkId?: number,
     @Arg('onlyVerified', { nullable: true }) onlyVerified?: boolean,
   ): Promise<ResourcePerDateRange> {
     try {
@@ -366,14 +366,14 @@ export class DonationResolver {
       const total = await donationsNumberPerDateRange(
         fromDate,
         toDate,
-        fromOptimismOnly,
+        networkId,
         onlyVerified,
       );
       const totalPerMonthAndYear =
         await donationsTotalNumberPerDateRangeByMonth(
           fromDate,
           toDate,
-          fromOptimismOnly,
+          networkId,
           onlyVerified,
         );
 
@@ -404,22 +404,18 @@ export class DonationResolver {
     // fromDate and toDate should be in this format YYYYMMDD HH:mm:ss
     @Arg('fromDate', { nullable: true }) fromDate?: string,
     @Arg('toDate', { nullable: true }) toDate?: string,
-    @Arg('fromOptimismOnly', { nullable: true }) fromOptimismOnly?: boolean,
+    @Arg('networkId', { nullable: true }) networkId?: number,
   ): Promise<ResourcePerDateRange> {
     try {
       validateWithJoiSchema(
         { fromDate, toDate },
         resourcePerDateReportValidator,
       );
-      const total = await donorsCountPerDate(
-        fromDate,
-        toDate,
-        fromOptimismOnly,
-      );
+      const total = await donorsCountPerDate(fromDate, toDate, networkId);
       const totalPerMonthAndYear = await donorsCountPerDateByMonthAndYear(
         fromDate,
         toDate,
-        fromOptimismOnly,
+        networkId,
       );
       return {
         total,

--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -1291,7 +1291,7 @@ export class ProjectResolver {
     @Arg('toDate', { nullable: true }) toDate?: string,
     @Arg('onlyListed', { nullable: true }) onlyListed?: boolean,
     @Arg('onlyVerified', { nullable: true }) onlyVerified?: boolean,
-    @Arg('includesOptimism', { nullable: true }) includesOptimism?: boolean,
+    @Arg('networkId', { nullable: true }) networkId?: number,
   ): Promise<ResourcePerDateRange> {
     try {
       validateWithJoiSchema(
@@ -1301,14 +1301,14 @@ export class ProjectResolver {
       const total = await totalProjectsPerDate(
         fromDate,
         toDate,
-        includesOptimism,
+        networkId,
         onlyListed,
         onlyVerified,
       );
       const totalPerMonthAndYear = await totalProjectsPerDateByMonthAndYear(
         fromDate,
         toDate,
-        includesOptimism,
+        networkId,
         onlyListed,
         onlyVerified,
       );

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -502,14 +502,14 @@ export const fetchNewProjectsPerDate = `
     $toDate: String
     $onlyListed: Boolean
     $onlyVerified: Boolean
-    $includesOptimism: Boolean
+    $networkId: Int
   ) {
     projectsPerDate(
       fromDate: $fromDate
       toDate: $toDate
       onlyListed: $onlyListed
       onlyVerified: $onlyVerified
-      includesOptimism: $includesOptimism
+      networkId: $networkId
     ) {
       total
       totalPerMonthAndYear {
@@ -524,13 +524,13 @@ export const fetchTotalDonationsPerCategoryPerDate = `
   query (
     $fromDate: String
     $toDate: String
-    $fromOptimismOnly: Boolean
+    $networkId: Int
     $onlyVerified: Boolean
   ) {
     totalDonationsPerCategory(
       fromDate: $fromDate
       toDate: $toDate
-      fromOptimismOnly: $fromOptimismOnly
+      networkId: $networkId
       onlyVerified: $onlyVerified
     ) {
       id
@@ -566,12 +566,12 @@ export const fetchTotalDonors = `
   query (
     $fromDate: String
     $toDate: String
-    $fromOptimismOnly: Boolean
+    $networkId: Int
   ) {
     totalDonorsCountPerDate(
       fromDate: $fromDate
       toDate: $toDate
-      fromOptimismOnly: $fromOptimismOnly
+      networkId: $networkId
     ) {
       total
       totalPerMonthAndYear {
@@ -586,13 +586,13 @@ export const fetchTotalDonationsUsdAmount = `
   query (
     $fromDate: String
     $toDate: String
-    $fromOptimismOnly: Boolean
+    $networkId: Int
     $onlyVerified: Boolean
   ) {
     donationsTotalUsdPerDate (
       fromDate: $fromDate
       toDate: $toDate
-      fromOptimismOnly: $fromOptimismOnly
+      networkId: $networkId
       onlyVerified: $onlyVerified
     ) {
       total
@@ -608,13 +608,13 @@ export const fetchTotalDonationsNumberPerDateRange = `
   query (
     $fromDate: String
     $toDate: String
-    $fromOptimismOnly: Boolean
+    $networkId: Int
     $onlyVerified: Boolean
   ) {
     totalDonationsNumberPerDate (
       fromDate: $fromDate
       toDate: $toDate
-      fromOptimismOnly: $fromOptimismOnly
+      networkId: $networkId
       onlyVerified: $onlyVerified
     ) {
       total


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `networkId` parameter for filtering donations and projects based on a specific network ID.
  
- **Refactor**
  - Replaced the boolean parameters `fromOptimismOnly` and `includesOptimism` with `networkId` across various donation and project-related functions.

- **Tests**
  - Updated GraphQL queries in test cases to use `networkId` instead of the previous boolean parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->