### PR TITLE
fix: issue with adminJs authentication when user has hash as null

### DIFF
--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -75,8 +75,16 @@ export const fetchAdminAndValidatePassword = async (params: {
 }): Promise<User | undefined> => {
   const { password, email } = params;
   const user = await findAdminUserByEmail(email);
-  if (user && (await bcrypt.compare(password, user.encryptedPassword))) {
-    return user;
+
+  if (user?.encryptedPassword == null) return;
+
+  try {
+    if (await bcrypt.compare(password, user.encryptedPassword)) {
+      return user;
+    }
+    return;
+  } catch (e) {
+    logger.error('fetchAdminAndValidatePassword() error', e);
+    return;
   }
-  return;
 };


### PR DESCRIPTION
Here is how to reproduce the bug

Connect to admin panel using a user  record that has `encryptedPassword = null AND role != 'restricted'`

In that case the app crashes showing this page

![Screenshot 2024-07-04 at 09 53 22 (2)](https://github.com/Giveth/impact-graph/assets/59566186/d73adc84-60de-4c9b-9793-2b8e94025141)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved password validation by ensuring the `encryptedPassword` is checked before comparison, preventing potential errors.
	- Enhanced error logging for better debugging and issue resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->