### PR TITLE
add a default value for etc mordor url

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -320,7 +320,9 @@ export function getProvider(networkId: number) {
   let options;
   switch (networkId) {
     case NETWORK_IDS.MORDOR_ETC_TESTNET:
-      url = process.env.MORDOR_ETC_TESTNET as string;
+      url =
+        (process.env.MORDOR_ETC_TESTNET as string) ||
+        `https://rpc.mordor.etccooperative.org/`;
       break;
     case NETWORK_IDS.ETC:
       url = process.env.ETC_NODE_HTTP_URL as string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling for the `MORDOR_ETC_TESTNET` case, ensuring a default URL is used if the environment variable is not defined.

- **Bug Fixes**
	- Enhanced robustness to prevent potential failures when the environment variable for `MORDOR_ETC_TESTNET` is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->