### PR TITLE
fix: minimumPassportScore issue when typing float number on adminJS

### DIFF
--- a/src/entities/qfRound.ts
+++ b/src/entities/qfRound.ts
@@ -66,7 +66,7 @@ export class QfRound extends BaseEntity {
   maximumReward: number;
 
   @Field(_type => Number)
-  @Column()
+  @Column('real')
   minimumPassportScore: number;
 
   @Field(_type => Float, { nullable: true })


### PR DESCRIPTION
minimumPassportScore on admin panel must accept `real` type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the data type for the `minimumPassportScore` property to enhance precision and performance in data handling.
  
- **Bug Fixes**
	- Improved data storage and retrieval for the `minimumPassportScore`, ensuring more accurate representation of floating-point numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->