### PR TITLE
Default power balance snapshot 

### DIFF
--- a/src/adapters/givPowerBalanceAggregator/givPowerBalanceAggregatorAdapterMock.ts
+++ b/src/adapters/givPowerBalanceAggregator/givPowerBalanceAggregatorAdapterMock.ts
@@ -10,6 +10,18 @@ import { convertTimeStampToSeconds } from '../../utils/utils';
 export class GivPowerBalanceAggregatorAdapterMock
   implements IGivPowerBalanceAggregator
 {
+  private excludedAddresses: Set<string> = new Set();
+
+  addExcludedAddresses(addresses: string[]): void {
+    addresses.forEach(address => {
+      this.excludedAddresses.add(address);
+    });
+  }
+
+  clearExcludedAddresses(): void {
+    this.excludedAddresses.clear();
+  }
+
   async getAddressesBalance(
     params: BalancesAtTimestampInputParams,
   ): Promise<BalanceResponse[]> {
@@ -21,14 +33,16 @@ export class GivPowerBalanceAggregatorAdapterMock
         'addresses length can not be greater than NUMBER_OF_BALANCE_AGGREGATOR_BATCH that is defined in .env',
       );
     }
-    return _.uniq(params.addresses).map(address => {
-      return {
-        address,
-        balance: 13, // Just an example balance
-        updatedAt: new Date('2023-08-10T16:18:02.655Z'),
-        networks: [100],
-      };
-    });
+    return _.uniq(params.addresses)
+      .filter(address => !this.excludedAddresses.has(address))
+      .map(address => {
+        return {
+          address,
+          balance: 13, // Just an example balance
+          updatedAt: new Date('2023-08-10T16:18:02.655Z'),
+          networks: [100],
+        };
+      });
   }
 
   async getLatestBalances(


### PR DESCRIPTION
Set default zero for power balance snapshot on no return from balance aggregator
Ref #1655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to manage excluded addresses for balance calculations, allowing dynamic exclusion during queries.
  
- **Bug Fixes**
  - Enhanced test coverage to ensure that users excluded from the balance aggregator correctly receive zero snapshot balances.

- **Refactor**
  - Improved address management in balance processing by utilizing a `Set` to ensure unique wallet addresses and enhance efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->