### PR TITLE
Fix: returning QF tag to the user bookmarked projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "giveth-graphql-api",
-  "version": "1.24.1",
+  "version": "1.24.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "giveth-graphql-api",
-      "version": "1.24.1",
+      "version": "1.24.3",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -2068,6 +2068,7 @@ export class ProjectResolver {
       .leftJoinAndSelect('project.status', 'status')
       .leftJoinAndSelect('project.addresses', 'addresses')
       .leftJoinAndSelect('project.organization', 'organization')
+      .leftJoinAndSelect('project.qfRounds', 'qfRounds')
       .leftJoin('project.adminUser', 'user')
       .addSelect(publicSelectionFields) // aliased selection
       .where(

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -1222,6 +1222,7 @@ export const fetchLikedProjectsQuery = `
       take: $take
       skip: $skip
     ) {
+
       projects {
         id
         title
@@ -1265,6 +1266,11 @@ export const fetchLikedProjectsQuery = `
         }
         organization {
           label
+        }
+        qfRound {
+          id
+          name
+          isActive
         }
         totalReactions
         totalDonations

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -1267,11 +1267,6 @@ export const fetchLikedProjectsQuery = `
         organization {
           label
         }
-        qfRound {
-          id
-          name
-          isActive
-        }
         totalReactions
         totalDonations
         totalTraceDonations


### PR DESCRIPTION
This PR is for this issue:[ QF project card is not being shown on projects in an active QF round from the "bookmarked projects" view #4512](https://github.com/Giveth/giveth-dapps-v2/issues/4512)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced project data retrieval by including associated `qfRounds` in project queries, allowing for richer data display.
	- Updated the `fetchLikedProjectsQuery` to include additional details about projects, improving the query's detail and overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->