### PR TITLE
fix: add createDraftDonation Test Cases to prevent Users from Donatin…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "giveth-graphql-api",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "giveth-graphql-api",
-      "version": "1.24.3",
+      "version": "1.24.4",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
#743 

I have done the following changes for the Issue.

1. Not allow users to create a draft to donate to his/her own Project.
2. I am not sure but I added a check whether the projectId to which the user is donating is valid.
3. Added Test Cases to check Users aren't able to donate to their own project.
4. Added a test case to check Users can't donate to Invalid Project ID's.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for creating draft donations, ensuring the associated project exists.
	- Implemented a rule preventing donors from creating donations to their own projects, improving donation integrity.

- **Bug Fixes**
	- Added error handling for invalid project IDs and self-donation attempts, providing clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->