### PR TITLE
Add chaintype and solana networks to tokenTab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "giveth-graphql-api",
-  "version": "1.25.3",
+  "version": "1.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "giveth-graphql-api",
-      "version": "1.25.3",
+      "version": "1.25.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/src/server/adminJs/tabs/tokenTab.ts
+++ b/src/server/adminJs/tabs/tokenTab.ts
@@ -7,6 +7,7 @@ import { AdminJsRequestInterface } from '../adminJs-types';
 import { Organization } from '../../../entities/organization';
 import { logger } from '../../../utils/logger';
 import { findTokenByTokenId } from '../../../repositories/tokenRepository';
+import { ChainType } from '../../../types/network';
 
 // generates orderly permutations and maps then into an array which is later flatten into 1 dimension
 // Current length is the length of selected items from the total items
@@ -210,6 +211,18 @@ export const generateTokenTab = async () => {
               value: NETWORK_IDS.MORDOR_ETC_TESTNET,
               label: 'Ethereum Classic Testnet',
             },
+            {
+              value: NETWORK_IDS.SOLANA_MAINNET,
+              label: 'SOLANA MAINNET',
+            },
+            {
+              value: NETWORK_IDS.SOLANA_TESTNET,
+              label: 'SOLANA TESTNET',
+            },
+            {
+              value: NETWORK_IDS.SOLANA_DEVNET,
+              label: 'SOLANA DEVNET',
+            },
           ],
         },
         symbol: { isVisible: true },
@@ -224,6 +237,14 @@ export const generateTokenTab = async () => {
             list: false,
             filter: true,
           },
+        },
+        chainType: {
+          isVisible: true,
+          availableValues: [
+            { value: ChainType.EVM, label: 'EVM' },
+            { value: ChainType.SOLANA, label: 'SOLANA' },
+            { value: ChainType.STELLAR, label: 'STELLAR' },
+          ],
         },
         coingeckoId: {
           isVisible: {


### PR DESCRIPTION
Missing admin Functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new network options for the Solana blockchain: `SOLANA_MAINNET`, `SOLANA_TESTNET`, and `SOLANA_DEVNET`.
	- Added a `chainType` property to categorize tokens by blockchain technology, including options for `EVM`, `SOLANA`, and `STELLAR`. 

These enhancements improve user experience by providing more flexibility in selecting networks and classifying tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->