### PR TITLE
Fix date filters for recurringdonation stats

### DIFF
--- a/src/repositories/recurringDonationRepository.ts
+++ b/src/repositories/recurringDonationRepository.ts
@@ -106,7 +106,8 @@ export const updateRecurringDonationFromTheStreamDonations = async (
         SELECT COALESCE(SUM(d."amount"), 0)
         FROM donation as d
         WHERE d."recurringDonationId" = $1
-      )
+      ),
+      "updatedAt" = NOW()
       WHERE "id" = $1
     `,
       [recurringDonationId],

--- a/src/services/recurringDonationService.ts
+++ b/src/services/recurringDonationService.ts
@@ -529,13 +529,13 @@ export const recurringDonationsStreamedCUsdTotal = async (
   ).select('COALESCE(SUM(recurringDonation.totalUsdStreamed), 0)', 'total');
 
   if (fromDate) {
-    query.andWhere('recurringDonation.createdAt >= :fromDate', {
+    query.andWhere('recurringDonation.updatedAt >= :fromDate', {
       fromDate: new Date(fromDate),
     });
   }
 
   if (toDate) {
-    query.andWhere('recurringDonation.createdAt <= :toDate', {
+    query.andWhere('recurringDonation.updatedAt <= :toDate', {
       toDate: new Date(toDate),
     });
   }
@@ -572,16 +572,16 @@ export const recurringDonationsStreamedCUsdTotalPerMonth = async (
 ): Promise<ResourcesTotalPerMonthAndYear[]> => {
   const query = RecurringDonation.createQueryBuilder('recurringDonation')
     .select('SUM(recurringDonation.totalUsdStreamed)', 'total')
-    .addSelect("TO_CHAR(recurringDonation.createdAt, 'YYYY/MM')", 'date');
+    .addSelect("TO_CHAR(recurringDonation.updatedAt, 'YYYY/MM')", 'date');
 
   if (fromDate) {
-    query.andWhere('recurringDonation.createdAt >= :fromDate', {
+    query.andWhere('recurringDonation.updatedAt >= :fromDate', {
       fromDate: new Date(fromDate),
     });
   }
 
   if (toDate) {
-    query.andWhere('recurringDonation.createdAt <= :toDate', {
+    query.andWhere('recurringDonation.updatedAt <= :toDate', {
       toDate: new Date(toDate),
     });
   }
@@ -627,13 +627,13 @@ export const recurringDonationsTotalPerToken = async (params: {
     .having('SUM(recurringDonation.totalUsdStreamed) > 0');
 
   if (fromDate) {
-    query.andWhere('recurringDonation.createdAt >= :fromDate', {
+    query.andWhere('recurringDonation.updatedAt >= :fromDate', {
       fromDate: new Date(fromDate),
     });
   }
 
   if (toDate) {
-    query.andWhere('recurringDonation.createdAt <= :toDate', {
+    query.andWhere('recurringDonation.updatedAt <= :toDate', {
       toDate: new Date(toDate),
     });
   }


### PR DESCRIPTION
Issue: https://github.com/orgs/Giveth/projects/9/views/1?sliceBy%5Bvalue%5D=CarlosQ96&pane=issue&itemId=85803313&issue=Giveth%7Canalytics-dashboard%7C42

Basically the filters in our queries used the createdAt however this would excluded the data expected from the streams in the stats. We should use the updatedAt parameter because the stream is updated on every new mini donation in our db, totals will make sense now and won't be excluded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced tracking of recurring donation updates with a new timestamp field.
	- Improved logic for handling recurring donations, focusing on the `updatedAt` timestamp for data queries.

- **Bug Fixes**
	- Refined error handling and logging for donation creation, ensuring clearer insights into failures.

- **Refactor**
	- Updated conditions and parameters in donation-related functions for improved accuracy and robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->