### PR TITLE
fix linkedin scope

### DIFF
--- a/src/adapters/oauth2/linkedinAdapter.ts
+++ b/src/adapters/oauth2/linkedinAdapter.ts
@@ -19,7 +19,7 @@ export class LinkedinAdapter implements SocialNetworkOauth2AdapterInterface {
      */
 
     // https://docs.microsoft.com/en-us/linkedin/shared/authentication/getting-access?context=linkedin%2Fcontext#open-permissions-consumer
-    const scope = 'r_liteprofile';
+    const scope = 'profile';
     return `https://www.linkedin.com/oauth/v2/authorization?client_id=${clientId}&redirect_uri=${redirectUrl}&response_type=code&scope=${scope}&state=${trackId}`;
   }
 


### PR DESCRIPTION
https://github.com/Giveth/giveth-dapps-v2/issues/4493#issuecomment-2565812145

https://community.auth0.com/t/the-linkedin-login-is-deprecated-updating-to-the-new-scopes-is-necessary/113696
 The `r_liteprofile` is deprecated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated LinkedIn OAuth2 authentication scope to improve compatibility with the platform's authentication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->