### PR TITLE
Add qfStrategy to qfRounds

### DIFF
--- a/migration/1736719823637-MarkRoundsStrategy.ts
+++ b/migration/1736719823637-MarkRoundsStrategy.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MarkRoundsStrategy1736719823637 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "qf_strategy_enum" AS ENUM ('cocm', 'regular');
+    `);
+
+    await queryRunner.query(`
+            ALTER TABLE "qf_round"
+            ADD COLUMN "qfStrategy" "qf_strategy_enum" DEFAULT 'regular';
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "qf_round"
+            DROP COLUMN "qfStrategy";
+        `);
+    await queryRunner.query(`
+            DROP TYPE "qf_strategy_enum";
+        `);
+  }
+}

--- a/src/entities/qfRound.ts
+++ b/src/entities/qfRound.ts
@@ -1,4 +1,11 @@
-import { Field, ID, ObjectType, Int, Float } from 'type-graphql';
+import {
+  Field,
+  ID,
+  ObjectType,
+  Int,
+  Float,
+  registerEnumType,
+} from 'type-graphql';
 import {
   PrimaryGeneratedColumn,
   Column,
@@ -12,6 +19,15 @@ import {
 } from 'typeorm';
 import { Project } from './project';
 import { Donation } from './donation';
+
+export enum QfStrategyEnum {
+  Cocm = 'cocm',
+  Regular = 'regular',
+}
+
+registerEnumType(QfStrategyEnum, {
+  name: 'QfStrategyEnum', // Name to expose in GraphQL schema
+});
 
 @Entity()
 @ObjectType()
@@ -88,6 +104,15 @@ export class QfRound extends BaseEntity {
   @Field(_type => Date)
   @Column()
   endDate: Date;
+
+  @Field(_type => QfStrategyEnum, { nullable: true })
+  @Column({
+    type: 'enum',
+    enum: QfStrategyEnum,
+    default: QfStrategyEnum.Regular,
+    nullable: true,
+  })
+  qfStrategy?: QfStrategyEnum;
 
   @Field(_type => String, { nullable: true })
   @Column('text', { nullable: true })

--- a/src/server/adminJs/tabs/qfRoundTab.ts
+++ b/src/server/adminJs/tabs/qfRoundTab.ts
@@ -311,6 +311,15 @@ export const qfRoundTab = {
           show: adminJs.bundle('./components/ProjectsInQfRound'),
         },
       },
+      qfStrategy: {
+        isVisible: {
+          filter: false,
+          list: false,
+          show: true,
+          new: true,
+          edit: true,
+        },
+      },
       bannerBgImage: {
         isVisible: {
           filter: false,


### PR DESCRIPTION
For determining what to show in the UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new strategy field for rounds, allowing categorization between 'cocm' and 'regular' strategies.
- **Database Changes**
  - Introduced a new column `qfStrategy` to the rounds table.
  - Created an enum to support different round strategies.
- **Admin Interface**
  - Updated admin panel to support viewing and editing the new round strategy field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->