### PR TITLE
add filter condition to remove endaoment projects from recently updated query sort

### DIFF
--- a/src/repositories/projectRepository.ts
+++ b/src/repositories/projectRepository.ts
@@ -23,6 +23,7 @@ import { ProjectStatusHistory } from '../entities/projectStatusHistory';
 import { Reaction } from '../entities/reaction';
 import { SocialProfile } from '../entities/socialProfile';
 import { PreviousRoundRank } from '../entities/previousRoundRank';
+import { ORGANIZATION_LABELS } from '../entities/organization';
 
 export const findProjectById = (projectId: number): Promise<Project | null> => {
   // return Project.findOne({ id: projectId });
@@ -196,7 +197,11 @@ export const filterProjectsQuery = (params: FilterProjectQueryInputParams) => {
       query.orderBy('project.creationDate', OrderDirection.DESC);
       break;
     case SortingField.RecentlyUpdated:
-      query.orderBy('project.updatedAt', OrderDirection.DESC);
+      query
+        .orderBy('project.updatedAt', OrderDirection.DESC)
+        .andWhere('organization.label != :label', {
+          label: ORGANIZATION_LABELS.ENDAOMENT,
+        });
       break;
     case SortingField.Oldest:
       query.orderBy('project.creationDate', OrderDirection.ASC);


### PR DESCRIPTION
fix for https://github.com/Giveth/impact-graph/issues/1919

not sure how to test it locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined project filtering logic when sorting by recently updated projects
	- Excluded specific organization-labeled projects from recent updates view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->