### PR TITLE
Pinata fix cleaning up files

### DIFF
--- a/src/services/cronJobs/generateSitemapOnFrontend.ts
+++ b/src/services/cronJobs/generateSitemapOnFrontend.ts
@@ -332,19 +332,8 @@ export const updateSitemapInDB = async (
   const sitemapRepo = AppDataSource.getDataSource().getRepository(SitemapUrl);
 
   try {
-    // Fetch the last entry
-    const lastEntry = await sitemapRepo
-      .createQueryBuilder('sitemap_url')
-      .orderBy('sitemap_url.created_at', 'DESC')
-      .getOne();
-
-    // Delete old Pinata files before updating
-    if (lastEntry) {
-      await deleteOldPinataFiles(lastEntry.sitemap_urls);
-    }
-
     // Create or update the latest entry
-    const newEntry = lastEntry ? lastEntry : new SitemapUrl();
+    const newEntry = new SitemapUrl();
     newEntry.sitemap_urls = {
       sitemapProjectsURL,
       sitemapUsersURL,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Sitemaps now include a creation timestamp, offering clearer information about when they were generated.
- **Refactor**
	- Improved the process for managing and cleaning up outdated sitemap data to ensure only the most current entries are maintained.
	- Updated the cleanup logic for old pins to enhance efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->