### PR TITLE
Add filters and sorting to causes endpoint

### DIFF
--- a/migration/1750123930816-addGivPowerAndGivBackToCause.ts
+++ b/migration/1750123930816-addGivPowerAndGivBackToCause.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddGivPowerAndGivBackToCause1750123930816
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "cause"
+      ADD COLUMN "givPower" float NOT NULL DEFAULT 0,
+      ADD COLUMN "givBack" float NOT NULL DEFAULT 0;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "cause"
+      DROP COLUMN "givPower",
+      DROP COLUMN "givBack";
+    `);
+  }
+}

--- a/src/entities/cause.ts
+++ b/src/entities/cause.ts
@@ -118,6 +118,12 @@ export class Cause extends BaseEntity {
   })
   status: CauseStatus;
 
+  // This is needed to return the enum value as a string
+  @Field(() => String)
+  get statusValue(): string {
+    return this.status;
+  }
+
   @Field(_type => ListingStatus)
   @Column({
     type: 'enum',
@@ -125,6 +131,12 @@ export class Cause extends BaseEntity {
     default: ListingStatus.NotReviewed,
   })
   listingStatus: ListingStatus;
+
+  // This is needed to return the enum value as a string
+  @Field(() => String)
+  get listingStatusValue(): string {
+    return this.listingStatus;
+  }
 
   @Field(_type => [Project])
   @ManyToMany(_type => Project, project => project.causes)

--- a/src/entities/cause.ts
+++ b/src/entities/cause.ts
@@ -146,6 +146,14 @@ export class Cause extends BaseEntity {
   @Column('float', { default: 0 })
   totalDonated: number;
 
+  @Field(_type => Float)
+  @Column('float', { default: 0 })
+  givPower: number;
+
+  @Field(_type => Float)
+  @Column('float', { default: 0 })
+  givBack: number;
+
   @Field()
   @UpdateDateColumn()
   updatedAt: Date;

--- a/src/repositories/causeRepository.test.ts
+++ b/src/repositories/causeRepository.test.ts
@@ -58,9 +58,16 @@ describe('causeRepository test cases', () => {
       testUser,
       [testProject],
     );
+
+    // Update the cause to have Listed status for testing
+    await Cause.update(
+      { id: testCause.id },
+      { listingStatus: ListingStatus.Listed },
+    );
   });
 
   afterEach(async () => {
+    // Clean up in the correct order to avoid foreign key constraint violations
     // First clean up project-causes relationships
     await Cause.getRepository().query(
       'DELETE FROM "project_causes_cause" WHERE "causeId" IN (SELECT id FROM "cause" WHERE "title" LIKE $1)',
@@ -451,6 +458,11 @@ describe('causeRepository test cases', () => {
         testUser,
         [testProject],
       );
+      // Update the cause to have Listed status
+      await Cause.update(
+        { id: secondCause.id },
+        { listingStatus: ListingStatus.Listed },
+      );
 
       const causes = await findAllCauses();
       assert.equal(causes.length, 2);
@@ -476,6 +488,11 @@ describe('causeRepository test cases', () => {
         testUser,
         [testProject],
       );
+      // Update the cause to have Listed status
+      await Cause.update(
+        { id: secondCause.id },
+        { listingStatus: ListingStatus.Listed },
+      );
 
       const causes = await findAllCauses(1);
       assert.equal(causes.length, 1);
@@ -496,6 +513,11 @@ describe('causeRepository test cases', () => {
         createTestCauseData('test-cause-id-6', `0xuniquehash6${Date.now()}`),
         testUser,
         [testProject],
+      );
+      // Update the cause to have Listed status
+      await Cause.update(
+        { id: secondCause.id },
+        { listingStatus: ListingStatus.Listed },
       );
 
       const causes = await findAllCauses(1, 1);
@@ -522,6 +544,11 @@ describe('causeRepository test cases', () => {
         createTestCauseData('test-cause-id-7', `0xuniquehash7${Date.now()}`),
         testUser,
         [testProject],
+      );
+      // Update the cause to have Listed status
+      await Cause.update(
+        { id: secondCause.id },
+        { listingStatus: ListingStatus.Listed },
       );
 
       const causes = await findAllCauses();
@@ -550,6 +577,15 @@ describe('causeRepository test cases', () => {
         createTestCauseData('test-cause-id-9', `0xuniquehash9${Date.now()}`),
         testUser,
         [testProject],
+      );
+      // Update the causes to have Listed status
+      await Cause.update(
+        { id: secondCause.id },
+        { listingStatus: ListingStatus.Listed },
+      );
+      await Cause.update(
+        { id: thirdCause.id },
+        { listingStatus: ListingStatus.Listed },
       );
 
       const causes = await findAllCauses(2, 1);
@@ -582,15 +618,20 @@ describe('causeRepository test cases', () => {
             'test-cause-id-10',
             `0xuniquehash10${Date.now()}`,
           ),
-          chainId: 1, // Different chain ID
+          chainId: 100, // Different chain ID
         },
         testUser,
         [testProject],
       );
+      // Update the cause to have Listed status
+      await Cause.update(
+        { id: differentChainCause.id },
+        { listingStatus: ListingStatus.Listed },
+      );
 
-      const causes = await findAllCauses(undefined, undefined, 137); // Filter by chainId 137
+      const causes = await findAllCauses(undefined, undefined, 100); // Filter by chainId 100
       assert.equal(causes.length, 1);
-      assert.equal(causes[0].chainId, 137);
+      assert.equal(causes[0].chainId, 100);
 
       // Clean up different chain cause
       await Cause.getRepository().query(
@@ -615,6 +656,11 @@ describe('causeRepository test cases', () => {
         },
         testUser,
         [testProject],
+      );
+      // Update the cause to have Listed status
+      await Cause.update(
+        { id: searchableCause.id },
+        { listingStatus: ListingStatus.Listed },
       );
 
       const causes = await findAllCauses(
@@ -659,6 +705,15 @@ describe('causeRepository test cases', () => {
         },
         testUser,
         [testProject],
+      );
+      // Update the causes to have Listed status
+      await Cause.update(
+        { id: lowRaisedCause.id },
+        { listingStatus: ListingStatus.Listed },
+      );
+      await Cause.update(
+        { id: highRaisedCause.id },
+        { listingStatus: ListingStatus.Listed },
       );
 
       const causes = await findAllCauses(

--- a/src/repositories/causeRepository.test.ts
+++ b/src/repositories/causeRepository.test.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { CauseStatus } from '../entities/cause';
+import { CauseStatus, ListingStatus } from '../entities/cause';
 import { User } from '../entities/user';
 import { Project } from '../entities/project';
 import { Cause } from '../entities/cause';
@@ -13,6 +13,8 @@ import {
   deactivateCause,
   validateCauseTitle,
   findAllCauses,
+  CauseSortField,
+  SortDirection,
 } from './causeRepository';
 import {
   saveUserDirectlyToDb,
@@ -475,7 +477,7 @@ describe('causeRepository test cases', () => {
         [testProject],
       );
 
-      const causes = await findAllCauses(1, 0);
+      const causes = await findAllCauses(1);
       assert.equal(causes.length, 1);
 
       // Clean up second cause
@@ -514,7 +516,7 @@ describe('causeRepository test cases', () => {
       ]);
     });
 
-    it('should return causes in descending order by createdAt', async () => {
+    it('should return causes in descending order by createdAt by default', async () => {
       // Create a second cause
       const secondCause = await createCause(
         createTestCauseData('test-cause-id-7', `0xuniquehash7${Date.now()}`),
@@ -570,6 +572,180 @@ describe('causeRepository test cases', () => {
     it('should return empty array when no causes match offset', async () => {
       const causes = await findAllCauses(10, 100);
       assert.equal(causes.length, 0);
+    });
+
+    it('should filter by chainId', async () => {
+      // Create a cause with different chainId
+      const differentChainCause = await createCause(
+        {
+          ...createTestCauseData(
+            'test-cause-id-10',
+            `0xuniquehash10${Date.now()}`,
+          ),
+          chainId: 1, // Different chain ID
+        },
+        testUser,
+        [testProject],
+      );
+
+      const causes = await findAllCauses(undefined, undefined, 137); // Filter by chainId 137
+      assert.equal(causes.length, 1);
+      assert.equal(causes[0].chainId, 137);
+
+      // Clean up different chain cause
+      await Cause.getRepository().query(
+        'DELETE FROM "project_causes_cause" WHERE "causeId" = $1',
+        [differentChainCause.id],
+      );
+      await Cause.getRepository().query('DELETE FROM "cause" WHERE "id" = $1', [
+        differentChainCause.id,
+      ]);
+    });
+
+    it('should filter by search term', async () => {
+      // Create a cause with specific title
+      const searchableCause = await createCause(
+        {
+          ...createTestCauseData(
+            'test-cause-id-11',
+            `0xuniquehash11${Date.now()}`,
+          ),
+          title: 'Unique Searchable Title',
+          description: 'This is a unique description',
+        },
+        testUser,
+        [testProject],
+      );
+
+      const causes = await findAllCauses(
+        undefined,
+        undefined,
+        undefined,
+        'Unique Searchable',
+      );
+      assert.equal(causes.length, 1);
+      assert.equal(causes[0].id, searchableCause.id);
+
+      // Clean up searchable cause
+      await Cause.getRepository().query(
+        'DELETE FROM "project_causes_cause" WHERE "causeId" = $1',
+        [searchableCause.id],
+      );
+      await Cause.getRepository().query('DELETE FROM "cause" WHERE "id" = $1', [
+        searchableCause.id,
+      ]);
+    });
+
+    it('should sort by totalRaised', async () => {
+      // Create causes with different totalRaised values
+      const lowRaisedCause = await createCause(
+        {
+          ...createTestCauseData(
+            'test-cause-id-12',
+            `0xuniquehash12${Date.now()}`,
+          ),
+          totalRaised: 100,
+        },
+        testUser,
+        [testProject],
+      );
+      const highRaisedCause = await createCause(
+        {
+          ...createTestCauseData(
+            'test-cause-id-13',
+            `0xuniquehash13${Date.now()}`,
+          ),
+          totalRaised: 1000,
+        },
+        testUser,
+        [testProject],
+      );
+
+      const causes = await findAllCauses(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        CauseSortField.AMOUNT_RAISED,
+        SortDirection.DESC,
+      );
+      assert.equal(causes.length, 3); // Including the original testCause
+      assert.equal(causes[0].id, highRaisedCause.id); // Highest first
+      assert.equal(causes[1].id, lowRaisedCause.id);
+
+      // Clean up additional causes
+      await Cause.getRepository().query(
+        'DELETE FROM "project_causes_cause" WHERE "causeId" IN ($1, $2)',
+        [lowRaisedCause.id, highRaisedCause.id],
+      );
+      await Cause.getRepository().query(
+        'DELETE FROM "cause" WHERE "id" IN ($1, $2)',
+        [lowRaisedCause.id, highRaisedCause.id],
+      );
+    });
+
+    it('should filter by listing status', async () => {
+      // Update test cause to have a specific listing status
+      await Cause.update(
+        { id: testCause.id },
+        { listingStatus: ListingStatus.NotReviewed },
+      );
+
+      const causes = await findAllCauses(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        ListingStatus.NotReviewed,
+      );
+      assert.equal(causes.length, 1);
+      assert.equal(causes[0].listingStatus, ListingStatus.NotReviewed);
+
+      // Reset the listing status
+      await Cause.update(
+        { id: testCause.id },
+        { listingStatus: ListingStatus.Listed },
+      );
+    });
+
+    it('should return all causes when listingStatus is "all"', async () => {
+      // Create a cause with different listing status
+      const notListedCause = await createCause(
+        {
+          ...createTestCauseData(
+            'test-cause-id-14',
+            `0xuniquehash14${Date.now()}`,
+          ),
+        },
+        testUser,
+        [testProject],
+      );
+      await Cause.update(
+        { id: notListedCause.id },
+        { listingStatus: ListingStatus.NotListed },
+      );
+
+      const causes = await findAllCauses(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'all',
+      );
+      assert.equal(causes.length, 2); // Should return both causes
+
+      // Clean up not listed cause
+      await Cause.getRepository().query(
+        'DELETE FROM "project_causes_cause" WHERE "causeId" = $1',
+        [notListedCause.id],
+      );
+      await Cause.getRepository().query('DELETE FROM "cause" WHERE "id" = $1', [
+        notListedCause.id,
+      ]);
     });
   });
 });

--- a/src/repositories/causeRepository.ts
+++ b/src/repositories/causeRepository.ts
@@ -232,6 +232,9 @@ export const findAllCauses = async (
   if (sortBy) {
     const direction = sortDirection || SortDirection.DESC;
     queryBuilder.orderBy(`cause.${sortBy}`, direction);
+  } else {
+    // Default sort by newest
+    queryBuilder.orderBy('cause.createdAt', SortDirection.DESC);
   }
 
   // Apply pagination

--- a/src/repositories/causeRepository.ts
+++ b/src/repositories/causeRepository.ts
@@ -209,6 +209,7 @@ export const findAllCauses = async (
         listingStatus,
       });
     }
+    queryBuilder.where('1 = 1'); // Start with a default condition to avoid query errors
   } else {
     // Default to Listed status if no listing status specified
     queryBuilder.where('cause.listingStatus = :listingStatus', {

--- a/src/resolvers/causeResolver.test.ts
+++ b/src/resolvers/causeResolver.test.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai';
 import axios from 'axios';
 import sinon from 'sinon';
+import { In } from 'typeorm';
 import {
   saveUserDirectlyToDb,
   saveProjectDirectlyToDb,
@@ -18,6 +19,7 @@ import { Cause, ListingStatus } from '../entities/cause';
 import { Project } from '../entities/project';
 import { User } from '../entities/user';
 import * as verifyTransactionModule from '../utils/transactionVerification';
+import { CauseSortField, SortDirection } from '../repositories/causeRepository';
 
 beforeEach(async () => {
   // Mock verifyTransaction to return true in tests
@@ -576,6 +578,12 @@ describe('causes() test cases', () => {
       );
       causes.push(response.data.data.createCause);
     }
+
+    // Update all causes to have Listed status so they are returned by the causes query
+    await Cause.update(
+      { id: In(causes.map(c => c.id)) },
+      { listingStatus: ListingStatus.Listed },
+    );
   });
 
   afterEach(async () => {
@@ -735,8 +743,8 @@ describe('causes() test cases', () => {
     const response = await axios.post('http://localhost:4000/graphql', {
       query: causesQuery,
       variables: {
-        sortBy: 'AMOUNT_RAISED',
-        sortDirection: 'DESC',
+        sortBy: CauseSortField.AMOUNT_RAISED,
+        sortDirection: SortDirection.DESC,
       },
     });
 
@@ -756,8 +764,8 @@ describe('causes() test cases', () => {
     const response = await axios.post('http://localhost:4000/graphql', {
       query: causesQuery,
       variables: {
-        sortBy: 'AMOUNT_RAISED',
-        sortDirection: 'ASC',
+        sortBy: CauseSortField.AMOUNT_RAISED,
+        sortDirection: SortDirection.ASC,
       },
     });
 
@@ -777,8 +785,8 @@ describe('causes() test cases', () => {
     const response = await axios.post('http://localhost:4000/graphql', {
       query: causesQuery,
       variables: {
-        sortBy: 'GIVPOWER',
-        sortDirection: 'DESC',
+        sortBy: CauseSortField.GIVPOWER,
+        sortDirection: SortDirection.DESC,
       },
     });
 
@@ -798,8 +806,8 @@ describe('causes() test cases', () => {
     const response = await axios.post('http://localhost:4000/graphql', {
       query: causesQuery,
       variables: {
-        sortBy: 'GIVBACK',
-        sortDirection: 'DESC',
+        sortBy: CauseSortField.GIVBACK,
+        sortDirection: SortDirection.DESC,
       },
     });
 
@@ -819,8 +827,8 @@ describe('causes() test cases', () => {
     const response = await axios.post('http://localhost:4000/graphql', {
       query: causesQuery,
       variables: {
-        sortBy: 'PROJECT_COUNT',
-        sortDirection: 'DESC',
+        sortBy: CauseSortField.PROJECT_COUNT,
+        sortDirection: SortDirection.DESC,
       },
     });
 
@@ -841,13 +849,13 @@ describe('causes() test cases', () => {
     const response = await axios.post('http://localhost:4000/graphql', {
       query: causesQuery,
       variables: {
-        listingStatus: 'Not Reviewed',
+        listingStatus: ListingStatus.NotReviewed,
       },
     });
 
     const returnedCauses = response.data.data.causes;
     assert.equal(returnedCauses.length, 1);
-    assert.equal(returnedCauses[0].listingStatus, 'Not Reviewed');
+    assert.equal(returnedCauses[0].listingStatus, 'NotReviewed');
 
     // Reset the listing status
     await Cause.update(
@@ -897,8 +905,8 @@ describe('causes() test cases', () => {
       variables: {
         chainId: 137,
         searchTerm: 'Test Cause',
-        sortBy: 'AMOUNT_RAISED',
-        sortDirection: 'DESC',
+        sortBy: CauseSortField.AMOUNT_RAISED,
+        sortDirection: SortDirection.DESC,
         limit: 2,
       },
     });

--- a/src/resolvers/causeResolver.ts
+++ b/src/resolvers/causeResolver.ts
@@ -77,7 +77,7 @@ export class CauseResolver {
       nullable: true,
       description: 'Filter by listing status',
     })
-    listingStatus?: ListingStatus,
+    listingStatus?: ListingStatus | 'all',
   ): Promise<Cause[]> {
     try {
       // Apply default limit if none provided, or cap at maximum limit

--- a/src/resolvers/causeResolver.ts
+++ b/src/resolvers/causeResolver.ts
@@ -12,11 +12,13 @@ import {
   findCauseById,
   findAllCauses,
   validateTransactionHash,
+  CauseSortField,
+  SortDirection,
 } from '../repositories/causeRepository';
 import { verifyTransaction } from '../utils/transactionVerification';
 import { NETWORK_IDS } from '../provider';
 
-const DEFAULT_CAUSES_LIMIT = 10;
+const DEFAULT_CAUSES_LIMIT = 20;
 const MAX_CAUSES_LIMIT = 100;
 
 const getCauseCreationFeeTokenContractAddresses = (): {
@@ -51,6 +53,31 @@ export class CauseResolver {
       description: 'Number of causes to skip',
     })
     offset?: number,
+    @Arg('chainId', {
+      nullable: true,
+      description: 'Filter by chain ID',
+    })
+    chainId?: number,
+    @Arg('searchTerm', {
+      nullable: true,
+      description: 'Search term to filter causes by title or description',
+    })
+    searchTerm?: string,
+    @Arg('sortBy', {
+      nullable: true,
+      description: 'Field to sort by',
+    })
+    sortBy?: CauseSortField,
+    @Arg('sortDirection', {
+      nullable: true,
+      description: 'Sort direction',
+    })
+    sortDirection?: SortDirection,
+    @Arg('listingStatus', {
+      nullable: true,
+      description: 'Filter by listing status',
+    })
+    listingStatus?: ListingStatus,
   ): Promise<Cause[]> {
     try {
       // Apply default limit if none provided, or cap at maximum limit
@@ -58,7 +85,15 @@ export class CauseResolver {
         ? Math.min(limit, MAX_CAUSES_LIMIT)
         : DEFAULT_CAUSES_LIMIT;
 
-      const causes = await findAllCauses(effectiveLimit, offset);
+      const causes = await findAllCauses(
+        effectiveLimit,
+        offset,
+        chainId,
+        searchTerm,
+        sortBy,
+        sortDirection,
+        listingStatus,
+      );
       return causes;
     } catch (e) {
       SentryLogger.captureException(e);
@@ -68,6 +103,11 @@ export class CauseResolver {
         errorStack: e.stack,
         limit,
         offset,
+        chainId,
+        searchTerm,
+        sortBy,
+        sortDirection,
+        listingStatus,
       });
       return [];
     }

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -2692,6 +2692,8 @@ mutation CreateCause(
     totalRaised
     totalDistributed
     totalDonated
+    givPower
+    givBack
     activeProjectsCount
     createdAt
     updatedAt
@@ -2710,8 +2712,24 @@ query IsValidCauseTitle($title: String!) {
 }`;
 
 export const causesQuery = `
-  query Causes($limit: Float, $offset: Float) {
-    causes(limit: $limit, offset: $offset) {
+  query Causes(
+    $limit: Int, 
+    $offset: Int, 
+    $chainId: Int, 
+    $searchTerm: String, 
+    $sortBy: CauseSortField, 
+    $sortDirection: SortDirection, 
+    $listingStatus: ListingStatus
+  ) {
+    causes(
+      limit: $limit, 
+      offset: $offset, 
+      chainId: $chainId, 
+      searchTerm: $searchTerm, 
+      sortBy: $sortBy, 
+      sortDirection: $sortDirection, 
+      listingStatus: $listingStatus
+    ) {
       id
       title
       description
@@ -2725,12 +2743,15 @@ export const causesQuery = `
       totalRaised
       totalDistributed
       totalDonated
+      givPower
+      givBack
       activeProjectsCount
       createdAt
       updatedAt
       owner {
         id
         walletAddress
+        name
       }
       projects {
         id
@@ -2757,12 +2778,15 @@ export const causeByIdQuery = `
       totalRaised
       totalDistributed
       totalDonated
+      givPower
+      givBack
       activeProjectsCount
       createdAt
       updatedAt
       owner {
         id
         walletAddress
+        name
       }
       projects {
         id

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -2713,13 +2713,13 @@ query IsValidCauseTitle($title: String!) {
 
 export const causesQuery = `
   query Causes(
-    $limit: Int, 
-    $offset: Int, 
-    $chainId: Int, 
+    $limit: Float, 
+    $offset: Float, 
+    $chainId: Float, 
     $searchTerm: String, 
-    $sortBy: CauseSortField, 
-    $sortDirection: SortDirection, 
-    $listingStatus: ListingStatus
+    $sortBy: String, 
+    $sortDirection: String, 
+    $listingStatus: String
   ) {
     causes(
       limit: $limit, 


### PR DESCRIPTION
related to #1978

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added two new fields, `givPower` and `givBack`, to causes, now visible in queries and mutations.
  - Enhanced the causes list with new filtering options (by blockchain ID, search term, and listing status) and sorting options (by amount raised, givPower, givBack, projects count, and creation date).
  - Increased the default number of causes returned in queries from 10 to 20.

- **Bug Fixes**
  - Improved consistency and reliability in test data setup for listing status and filtering scenarios.

- **Tests**
  - Expanded test coverage for filtering, sorting, and new fields in cause-related queries and mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->