### PR TITLE
Fetch cause data by slug

### DIFF
--- a/src/entities/project.ts
+++ b/src/entities/project.ts
@@ -196,7 +196,7 @@ export class Project extends BaseEntity {
   @Column({ nullable: true })
   latestUpdateCreationDate: Date;
 
-  @Field(_type => Organization)
+  @Field(_type => Organization, { nullable: true })
   @ManyToOne(_type => Organization)
   @JoinTable()
   organization: Organization;

--- a/src/resolvers/causeResolver.ts
+++ b/src/resolvers/causeResolver.ts
@@ -127,6 +127,22 @@ export class CauseResolver {
     }
   }
 
+  @Query(() => Cause, { nullable: true })
+  async causeBySlug(@Arg('slug') slug: string): Promise<Cause | null> {
+    try {
+      const causeFindId = await Cause.findOne({ where: { slug } });
+      if (!causeFindId) {
+        return null;
+      }
+      const cause = await findCauseById(causeFindId.id);
+      return cause || null;
+    } catch (e) {
+      SentryLogger.captureException(e);
+      logger.error('causeBySlug() error', { error: e, causeSlug: slug });
+      throw e;
+    }
+  }
+
   @Query(() => Boolean)
   async isValidCauseTitle(@Arg('title') title: string): Promise<boolean> {
     return validateCauseTitle(title);

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -2797,3 +2797,38 @@ export const causeByIdQuery = `
     }
   }
 `;
+
+export const causeBySlugQuery = `
+  query CauseBySlug($slug: String!) {
+    causeBySlug(slug: $slug) {
+      id
+      title
+      description
+      chainId
+      fundingPoolAddress
+      causeId
+      mainCategory
+      subCategories
+      status
+      listingStatus
+      totalRaised
+      totalDistributed
+      totalDonated
+      givPower
+      givBack
+      activeProjectsCount
+      createdAt
+      updatedAt
+      owner {
+        id
+        walletAddress
+        name
+      }
+      projects {
+        id
+        title
+        slug
+      }
+    }
+  }
+`;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new query to fetch a cause by its slug.

- **Bug Fixes**
  - The organization field in project queries and mutations can now be null, improving flexibility in the GraphQL schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->