### PR TITLE
deactivate cause projectFlag on status changes

### DIFF
--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -2269,7 +2269,14 @@ export class ProjectResolver {
         }
       });
 
-      await CauseProject.update({ projectId }, { isIncluded: false });
+      if (project.projectType === 'project') {
+        await CauseProject.update({ projectId }, { isIncluded: false });
+      } else if (project.projectType === 'cause') {
+        await CauseProject.update(
+          { causeId: project.id },
+          { isIncluded: false },
+        );
+      }
 
       return true;
     } catch (error) {
@@ -2319,7 +2326,14 @@ export class ProjectResolver {
         }
       });
 
-      await CauseProject.update({ projectId }, { isIncluded: true });
+      if (project.projectType === 'project') {
+        await CauseProject.update({ projectId }, { isIncluded: true });
+      } else if (project.projectType === 'cause') {
+        await CauseProject.update(
+          { causeId: project.id },
+          { isIncluded: true },
+        );
+      }
 
       return true;
     } catch (error) {

--- a/src/server/adminJs/tabs/projectsTab.ts
+++ b/src/server/adminJs/tabs/projectsTab.ts
@@ -392,23 +392,44 @@ export const updateStatusOfProjects = async (
         await changeUserBoostingsAfterProjectCancelled({
           projectId: project.id,
         });
-        await CauseProject.update(
-          { projectId: project.id },
-          { isIncluded: false },
-        );
+        if (project.projectType === 'project') {
+          await CauseProject.update(
+            { projectId: project.id },
+            { isIncluded: false },
+          );
+        } else if (project.projectType === 'cause') {
+          await CauseProject.update(
+            { causeId: project.id },
+            { isIncluded: false },
+          );
+        }
       } else if (status === ProjStatus.active) {
         await getNotificationAdapter().projectReactivated({
           project: projectWithAdmin,
         });
-        await CauseProject.update(
-          { projectId: project.id },
-          { isIncluded: true },
-        );
+        if (project.projectType === 'project') {
+          await CauseProject.update(
+            { projectId: project.id },
+            { isIncluded: true },
+          );
+        } else if (project.projectType === 'cause') {
+          await CauseProject.update(
+            { causeId: project.id },
+            { isIncluded: true },
+          );
+        }
       } else if (status === ProjStatus.deactive) {
-        await CauseProject.update(
-          { projectId: project.id },
-          { isIncluded: false },
-        );
+        if (project.projectType === 'project') {
+          await CauseProject.update(
+            { projectId: project.id },
+            { isIncluded: false },
+          );
+        } else if (project.projectType === 'cause') {
+          await CauseProject.update(
+            { causeId: project.id },
+            { isIncluded: false },
+          );
+        }
         await getNotificationAdapter().projectDeactivated({
           project: projectWithAdmin,
         });
@@ -1245,10 +1266,12 @@ export const projectsTab = {
                 NOTIFICATIONS_EVENT_NAMES.PROJECT_UNVERIFIED,
               )
             ) {
-              await CauseProject.update(
-                { projectId: project.id },
-                { isIncluded: false },
-              );
+              if (project.projectType === 'project') {
+                await CauseProject.update(
+                  { projectId: project.id },
+                  { isIncluded: false },
+                );
+              }
               const verificationForm = await getVerificationFormByProjectId(
                 project.id,
               );
@@ -1264,17 +1287,6 @@ export const projectsTab = {
               statusChanges?.includes(NOTIFICATIONS_EVENT_NAMES.PROJECT_LISTED)
             ) {
               project.listed = true;
-              if (
-                project.listed =
-                  true &&
-                  project.projectType === 'project' &&
-                  project.statusId === ProjStatus.active
-              ) {
-                await CauseProject.update(
-                  { projectId: project.id },
-                  { isIncluded: true },
-                );
-              }
               await project.save();
             }
 
@@ -1301,10 +1313,17 @@ export const projectsTab = {
                 NOTIFICATIONS_EVENT_NAMES.PROJECT_CANCELLED,
               )
             ) {
-              await CauseProject.update(
-                { projectId: project.id },
-                { isIncluded: false },
-              );
+              if (project.projectType === 'project') {
+                await CauseProject.update(
+                  { projectId: project.id },
+                  { isIncluded: false },
+                );
+              } else if (project.projectType === 'cause') {
+                await CauseProject.update(
+                  { causeId: project.id },
+                  { isIncluded: false },
+                );
+              }
               await changeUserBoostingsAfterProjectCancelled({
                 projectId: project.id,
               });


### PR DESCRIPTION
Issues: https://github.com/orgs/Giveth/projects/26/views/2?pane=issue&itemId=111606495&issue=Giveth%7Cimpact-graph%7C1979

and 

https://github.com/orgs/Giveth/projects/26/views/2?pane=issue&itemId=111606802&issue=Giveth%7Cimpact-graph%7C1980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of project inclusion status with project status and verification changes. The inclusion flag now updates automatically when projects are cancelled, deactivated, activated, or unverified, ensuring more accurate project representation.  
  * Enhanced handling to correctly update project inclusion based on project type, distinguishing between standard projects and causes for more precise status management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->