### PR TITLE
Fix cause/project title inserting

### DIFF
--- a/src/resolvers/causeResolver.ts
+++ b/src/resolvers/causeResolver.ts
@@ -1,5 +1,6 @@
 import { Arg, Ctx, Mutation, Query, Resolver } from 'type-graphql';
 import slugify from 'slugify';
+import { convert } from 'html-to-text';
 import {
   Cause,
   ReviewStatus,
@@ -352,6 +353,7 @@ export class CauseResolver {
     project.updatedAt = new Date();
     project.listed = null;
     project.reviewStatus = ReviewStatus.NotReviewed;
+    project.title = convert(newProjectData.title);
 
     await project.save();
     await project.reload();
@@ -545,7 +547,7 @@ export class CauseResolver {
       });
 
       const causeData = {
-        title: title.trim(),
+        title: convert(title.trim()),
         description: description.trim(),
         chainId,
         slug,

--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -20,6 +20,7 @@ import graphqlFields from 'graphql-fields';
 import { SelectQueryBuilder } from 'typeorm/query-builder/SelectQueryBuilder';
 import { ObjectLiteral } from 'typeorm/common/ObjectLiteral';
 import { GraphQLResolveInfo } from 'graphql/type';
+import { convert } from 'html-to-text';
 import { Reaction } from '../entities/reaction';
 import {
   Cause,
@@ -1204,6 +1205,7 @@ export class ProjectResolver {
     project.updatedAt = new Date();
     project.listed = null;
     project.reviewStatus = ReviewStatus.NotReviewed;
+    project.title = convert(newProjectData.title);
 
     await project.save();
     await project.reload();
@@ -1487,6 +1489,7 @@ export class ProjectResolver {
 
     const project = Project.create({
       ...projectInput,
+      title: convert(projectInput.title),
       categories: categories as Category[],
       organization: organization as Organization,
       image,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cause and project titles are now automatically converted to plain text, ensuring that any HTML markup is removed when creating or updating causes and projects. This improves the consistency and safety of displayed titles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->