### PR TITLE
prevent causes to hold causes

### DIFF
--- a/src/resolvers/causeResolver.ts
+++ b/src/resolvers/causeResolver.ts
@@ -307,6 +307,14 @@ export class CauseResolver {
       );
     }
 
+    // Validate that none of the projects are of type 'cause'
+    const projectsOfTypeCause = projects.filter(p => p.projectType === 'cause');
+    if (projectsOfTypeCause.length > 0) {
+      throw new Error(
+        'Cannot add causes to a cause. Only regular projects can be added to causes.',
+      );
+    }
+
     // Get existing cause-project relationships
     const existingCauseProjects = await CauseProject.find({
       where: { causeId: project.id },
@@ -455,6 +463,16 @@ export class CauseResolver {
       if (projects.length !== projectIds.length) {
         throw new Error(
           i18n.__(translationErrorMessagesKeys.INVALID_PROJECT_IDS),
+        );
+      }
+
+      // Validate that none of the projects are of type 'cause'
+      const projectsOfTypeCause = projects.filter(
+        p => p.projectType === 'cause',
+      );
+      if (projectsOfTypeCause.length > 0) {
+        throw new Error(
+          'Cannot add causes to a cause. Only regular projects can be added to causes.',
         );
       }
 


### PR DESCRIPTION
Related to issue: https://github.com/orgs/Giveth/projects/26/views/2?sliceBy%5Bvalue%5D=CarlosQ96&pane=issue&itemId=121657331&issue=Giveth%7Cimpact-graph%7C2067

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent adding a cause as a sub-project of another cause when creating or updating causes. This ensures causes cannot be nested within other causes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->