### PR TITLE
Fix total power rank distinct by projectType and introduce fetch powe…

### DIFF
--- a/src/resolvers/projectPowerResolver.ts
+++ b/src/resolvers/projectPowerResolver.ts
@@ -1,5 +1,8 @@
-import { Arg, Query, Resolver, Int } from 'type-graphql';
-import { getPowerAmountRank } from '../repositories/projectPowerViewRepository';
+import { Arg, Query, Resolver, Int, Float } from 'type-graphql';
+import {
+  getPowerAmount,
+  getPowerAmountRank,
+} from '../repositories/projectPowerViewRepository';
 import { ProjectPowerView } from '../views/projectPowerView';
 
 @Resolver(_of => ProjectPowerView)
@@ -10,5 +13,12 @@ export class ProjectPowerResolver {
     @Arg('projectId', _type => Int, { nullable: true }) projectId: number,
   ): Promise<number> {
     return await getPowerAmountRank(powerAmount, projectId);
+  }
+
+  @Query(_returns => Float, { nullable: true })
+  async projectPowerAmount(
+    @Arg('projectId', _type => Int, { nullable: false }) projectId: number,
+  ): Promise<number | null> {
+    return await getPowerAmount(projectId);
   }
 }


### PR DESCRIPTION
- https://github.com/Giveth/impact-graph/issues/2073

Let me write here more for you @alireza-sharifpour:

I checked how FE is calculating this. FE first fetch project booster data:

https://github.com/Giveth/giveth-dapps-v2/blob/e3a7ed8526d5089b1121775a0000c67331b20247/src/context/project.context.tsx#L212

then it fetch users address from it.

Then it use those address and query thegraph.com query:

https://thegraph.com/explorer/subgraphs/BGkr8hzRGb8UK3GoDni6QTBmiPVeCioqawJ96BRxjsvs?view=Query&chain=arbitrum-one#query-subgraph

then when it fetch those data use all data bellow in same function to calculate `powerAmount`.

After it knows that value it fetch `powerRank` from that value and `projectId` value.

I introduced one API route: 

```
query {
  projectPowerAmount(projectId: PROJECT_ID)
}
```

and calculation you can see inside this PR inside function `getPowerAmount`. **NOTICE**: maybe I mismatched something, but if you see FE:

<img width="1746" height="343" alt="Screenshot 2025-08-08 at 11 47 40" src="https://github.com/user-attachments/assets/8d666794-1933-4821-871a-21c8c43d7e87" />

and new function `getPowerAmount`:

<img width="609" height="301" alt="Screenshot 2025-08-08 at 11 47 44" src="https://github.com/user-attachments/assets/0aa46d20-7347-4cf1-8e71-c0e90ae2aa3c" />

 I got same amount of the _powerAmount_.
 
 Please everyone check this new function on the BE.
 
 **ALSO** I needed to adjust existing function `getPowerAmountRank` to get values based on the `projectType` id that isn't changed it will count rank by all data inside project table, there wouldn't be distinct between _projects_ and _causes_.
 
 Please everyone check this function: `getPowerAmount`, mostly generated with AI!!!
 
 One benefit of this PR that I didn't need to change `last_snapshot_project_power_view`, no new migration.
 
 And if this is ok @alireza-sharifpour fix tests :D and add new one for new function :D