### PR TITLE
Update create donation to accept qf round id

### DIFF
--- a/migration/1756933581757-addQfRoundErrorMessageToDonation.ts
+++ b/migration/1756933581757-addQfRoundErrorMessageToDonation.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddQfRoundErrorMessageToDonation1756933581757
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('donation');
+    const qfRoundErrorMessageColumn = table?.findColumnByName(
+      'qfRoundErrorMessage',
+    );
+
+    if (!qfRoundErrorMessageColumn) {
+      await queryRunner.addColumn(
+        'donation',
+        new TableColumn({
+          name: 'qfRoundErrorMessage',
+          type: 'text',
+          isNullable: true,
+        }),
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('donation', 'qfRoundErrorMessage');
+  }
+}

--- a/src/entities/donation.ts
+++ b/src/entities/donation.ts
@@ -103,6 +103,10 @@ export class Donation extends BaseEntity {
   @Column('text', { nullable: true })
   verifyErrorMessage: string;
 
+  @Field({ nullable: true })
+  @Column('text', { nullable: true })
+  qfRoundErrorMessage: string;
+
   @Field()
   @Column('boolean', { default: false })
   speedup: boolean;

--- a/src/entities/donation.ts
+++ b/src/entities/donation.ts
@@ -189,6 +189,7 @@ export class Donation extends BaseEntity {
   @ManyToOne(_type => QfRound, { eager: true })
   qfRound: QfRound;
 
+  @Field({ nullable: true })
   @RelationId((donation: Donation) => donation.qfRound)
   @Column({ nullable: true })
   qfRoundId: number;

--- a/src/repositories/qfRoundRepository.ts
+++ b/src/repositories/qfRoundRepository.ts
@@ -202,7 +202,9 @@ export const findUsersWithoutMBDScoreInActiveAround = async (): Promise<
 };
 
 export const findQfRoundById = async (id: number): Promise<QfRound | null> => {
-  return QfRound.createQueryBuilder('qf_round').where(`id = ${id}`).getOne();
+  return QfRound.createQueryBuilder('qf_round')
+    .where('qf_round.id = :id', { id })
+    .getOne();
 };
 
 export const findQfRoundBySlug = async (

--- a/src/resolvers/donationResolver.test.ts
+++ b/src/resolvers/donationResolver.test.ts
@@ -3744,7 +3744,7 @@ function createDonationTestCases() {
     await qfRound.save();
   });
 
-  it('should throw error when roundId does not exist', async () => {
+  it('should create donation without QF round when roundId does not exist', async () => {
     const project = await saveProjectDirectlyToDb(createProjectData());
     const user = await User.create({
       walletAddress: generateRandomEtheriumAddress(),
@@ -3774,14 +3774,23 @@ function createDonationTestCases() {
       },
     );
 
-    assert.isOk(saveDonationResponse.data.errors);
+    assert.isOk(saveDonationResponse.data.data.createDonation);
+    const donation = await Donation.findOne({
+      where: {
+        id: saveDonationResponse.data.data.createDonation,
+      },
+    });
+
+    assert.isNotNull(donation);
+    // Should not be assigned to QF round due to validation error
+    assert.isNull(donation?.qfRoundId);
     assert.equal(
-      saveDonationResponse.data.errors[0].message,
-      'QF round not found',
+      donation?.qfRoundErrorMessage,
+      'QF round not found - excluded from QF round',
     );
   });
 
-  it('should throw error when QF round is not active', async () => {
+  it('should create donation without QF round when QF round is not active', async () => {
     const project = await saveProjectDirectlyToDb(createProjectData());
     const qfRound = await QfRound.create({
       isActive: false, // Inactive QF round
@@ -3825,14 +3834,23 @@ function createDonationTestCases() {
       },
     );
 
-    assert.isOk(saveDonationResponse.data.errors);
+    assert.isOk(saveDonationResponse.data.data.createDonation);
+    const donation = await Donation.findOne({
+      where: {
+        id: saveDonationResponse.data.data.createDonation,
+      },
+    });
+
+    assert.isNotNull(donation);
+    // Should not be assigned to QF round due to validation error
+    assert.isNull(donation?.qfRoundId);
     assert.equal(
-      saveDonationResponse.data.errors[0].message,
-      'QF round is not active',
+      donation?.qfRoundErrorMessage,
+      'QF round is not active - excluded from QF round',
     );
   });
 
-  it('should throw error when QF round is outside date range', async () => {
+  it('should create donation without QF round when QF round is outside date range', async () => {
     const project = await saveProjectDirectlyToDb(createProjectData());
     const qfRound = await QfRound.create({
       isActive: true,
@@ -3876,14 +3894,23 @@ function createDonationTestCases() {
       },
     );
 
-    assert.isOk(saveDonationResponse.data.errors);
+    assert.isOk(saveDonationResponse.data.data.createDonation);
+    const donation = await Donation.findOne({
+      where: {
+        id: saveDonationResponse.data.data.createDonation,
+      },
+    });
+
+    assert.isNotNull(donation);
+    // Should not be assigned to QF round due to validation error
+    assert.isNull(donation?.qfRoundId);
     assert.equal(
-      saveDonationResponse.data.errors[0].message,
-      'QF round is not currently active',
+      donation?.qfRoundErrorMessage,
+      'QF round is not currently active - excluded from QF round',
     );
   });
 
-  it('should throw error when project is not part of the QF round', async () => {
+  it('should create donation without QF round when project is not part of the QF round', async () => {
     const project = await saveProjectDirectlyToDb(createProjectData());
     const qfRound = await QfRound.create({
       isActive: true,
@@ -3925,10 +3952,19 @@ function createDonationTestCases() {
       },
     );
 
-    assert.isOk(saveDonationResponse.data.errors);
+    assert.isOk(saveDonationResponse.data.data.createDonation);
+    const donation = await Donation.findOne({
+      where: {
+        id: saveDonationResponse.data.data.createDonation,
+      },
+    });
+
+    assert.isNotNull(donation);
+    // Should not be assigned to QF round due to validation error
+    assert.isNull(donation?.qfRoundId);
     assert.equal(
-      saveDonationResponse.data.errors[0].message,
-      'Project is not part of the specified QF round',
+      donation?.qfRoundErrorMessage,
+      'Project is not part of the specified QF round - excluded from QF round',
     );
 
     // Clean up
@@ -4071,7 +4107,7 @@ function createDonationTestCases() {
     await specificQfRound.save();
   });
 
-  it('should fail to create donation when QF round is not eligible for the network', async () => {
+  it('should create donation without QF round when QF round is not eligible for the network', async () => {
     const project = await saveProjectDirectlyToDb(createProjectData());
 
     // Create QF round that only allows XDAI network (100)
@@ -4119,10 +4155,19 @@ function createDonationTestCases() {
       },
     );
 
-    assert.isOk(saveDonationResponse.data.errors);
+    assert.isOk(saveDonationResponse.data.data.createDonation);
+    const donation = await Donation.findOne({
+      where: {
+        id: saveDonationResponse.data.data.createDonation,
+      },
+    });
+
+    assert.isNotNull(donation);
+    // Should not be assigned to QF round due to validation error
+    assert.isNull(donation?.qfRoundId);
     assert.equal(
-      saveDonationResponse.data.errors[0].message,
-      'QF round is not eligible for this network',
+      donation?.qfRoundErrorMessage,
+      'QF round is not eligible for this network - excluded from QF round',
     );
 
     // Clean up

--- a/src/resolvers/donationResolver.ts
+++ b/src/resolvers/donationResolver.ts
@@ -21,7 +21,7 @@ import { Donation, DONATION_STATUS, SortField } from '../entities/donation';
 import { ApolloContext } from '../types/ApolloContext';
 import { Project, ProjStatus } from '../entities/project';
 import { Token } from '../entities/token';
-import { publicSelectionFields, User } from '../entities/user';
+import { publicSelectionFields } from '../entities/user';
 import SentryLogger from '../sentryLogger';
 import { i18n, translationErrorMessagesKeys } from '../utils/errorMessages';
 import { NETWORK_IDS } from '../provider';
@@ -277,7 +277,7 @@ class SwapTransactionInput {
   metadata?: Record<string, any>;
 }
 
-@Resolver(_of => User)
+@Resolver(_of => Donation)
 export class DonationResolver {
   private readonly donationRepository: Repository<Donation>;
 

--- a/src/resolvers/donationResolver.ts
+++ b/src/resolvers/donationResolver.ts
@@ -953,6 +953,9 @@ export class DonationResolver {
         if (now < qfRound.beginDate || now > qfRound.endDate) {
           throw new Error('QF round is not currently active');
         }
+        if (!qfRound.isEligibleNetwork(networkId)) {
+          throw new Error('QF round is not eligible for this network');
+        }
         // Check if project is in the QF round
         const projectInQfRound = project.qfRounds?.some(
           qr => qr.id === roundId,

--- a/src/resolvers/donationResolver.ts
+++ b/src/resolvers/donationResolver.ts
@@ -64,6 +64,7 @@ import { findProjectById } from '../repositories/projectRepository';
 import { AppDataSource } from '../orm';
 import { getChainvineReferralInfoForDonation } from '../services/chainvineReferralService';
 import { relatedActiveQfRoundForProject } from '../services/qfRoundService';
+import { findQfRoundById } from '../repositories/qfRoundRepository';
 import { detectAddressChainType } from '../utils/networks';
 import { ChainType } from '../types/network';
 import { getAppropriateNetworkId } from '../services/chains';
@@ -855,6 +856,7 @@ export class DonationResolver {
     relevantDonationTxHash?: string,
     @Arg('swapData', { nullable: true }) swapData?: SwapTransactionInput,
     @Arg('fromTokenAmount', { nullable: true }) fromTokenAmount?: number,
+    @Arg('roundId', { nullable: true }) roundId?: number,
   ): Promise<number> {
     const logData = {
       amount,
@@ -871,6 +873,7 @@ export class DonationResolver {
       swapData,
       isSwap: !!swapData,
       fromTokenAmount,
+      roundId,
     };
     logger.debug(
       'createDonation() resolver has been called with this data',
@@ -904,6 +907,7 @@ export class DonationResolver {
         useDonationBox,
         relevantDonationTxHash,
         fromTokenAmount,
+        roundId,
       };
       try {
         validateWithJoiSchema(validaDataInput, createDonationQueryValidator);
@@ -935,6 +939,29 @@ export class DonationResolver {
           ),
         );
       }
+
+      // Validate QF round if provided
+      if (roundId) {
+        const qfRound = await findQfRoundById(roundId);
+        if (!qfRound) {
+          throw new Error('QF round not found');
+        }
+        if (!qfRound.isActive) {
+          throw new Error('QF round is not active');
+        }
+        const now = new Date();
+        if (now < qfRound.beginDate || now > qfRound.endDate) {
+          throw new Error('QF round is not currently active');
+        }
+        // Check if project is in the QF round
+        const projectInQfRound = project.qfRounds?.some(
+          qr => qr.id === roundId,
+        );
+        if (!projectInQfRound) {
+          throw new Error('Project is not part of the specified QF round');
+        }
+      }
+
       const ownProject = project.adminUserId === donorUser.id;
       if (ownProject) {
         throw new Error("Donor can't donate to his/her own project.");
@@ -1073,13 +1100,22 @@ export class DonationResolver {
           logger.error('get chainvine wallet address error', e);
         }
       }
-      const activeQfRoundForProject =
-        await relatedActiveQfRoundForProject(projectId);
-      if (
-        activeQfRoundForProject &&
-        activeQfRoundForProject.isEligibleNetwork(networkId)
-      ) {
-        donation.qfRound = activeQfRoundForProject;
+      // Set QF round - use provided roundId if available, otherwise auto-select
+      if (roundId) {
+        const qfRound = await findQfRoundById(roundId);
+        if (qfRound) {
+          donation.qfRound = qfRound;
+        }
+      } else {
+        // Auto-select active QF round for project (existing behavior)
+        const activeQfRoundForProject =
+          await relatedActiveQfRoundForProject(projectId);
+        if (
+          activeQfRoundForProject &&
+          activeQfRoundForProject.isEligibleNetwork(networkId)
+        ) {
+          donation.qfRound = activeQfRoundForProject;
+        }
       }
       if (draftDonationEnabled && draftDonationId) {
         const draftDonation = await DraftDonation.findOne({

--- a/src/utils/validators/graphqlQueryValidators.ts
+++ b/src/utils/validators/graphqlQueryValidators.ts
@@ -203,6 +203,7 @@ export const createDonationQueryValidator = Joi.object({
   relevantDonationTxHash: Joi.string().allow(null, ''),
   swapData: swapTransactionValidator.allow(null, ''),
   fromTokenAmount: Joi.number().greater(0).allow(null),
+  roundId: Joi.number().integer().min(1).allow(null),
 });
 
 export const createDraftDonationQueryValidator = Joi.object({

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -13,6 +13,7 @@ export const createDonationMutation = `
     $safeTransactionId: String
     $swapData: SwapTransactionInput
     $fromTokenAmount: Float
+    $roundId: Float
   ) {
     createDonation(
       transactionId: $transactionId
@@ -28,6 +29,7 @@ export const createDonationMutation = `
       safeTransactionId: $safeTransactionId
       swapData: $swapData
       fromTokenAmount: $fromTokenAmount
+      roundId: $roundId
     )
   }
 `;
@@ -793,6 +795,12 @@ export const fetchAllDonationsQuery = `
         anonymous
         valueUsd
         amount
+        qfRoundId
+        qfRound {
+          id
+          name
+          slug
+        }
         recurringDonation{
           id
           txHash
@@ -856,7 +864,8 @@ export const fetchDonationsByUserIdQuery = `
         project {
           id
         }
-       qfRound {
+        qfRoundId
+        qfRound {
           id
           name
           isActive


### PR DESCRIPTION
related to #2140 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optionally provide a roundId when creating a donation; donations now include qfRoundId and round details in queries.
  - Donations may record a non-blocking round error message when round selection is invalid.

- **Validation**
  - Clear errors for missing, inactive, out-of-range rounds, or when a project isn’t in the specified round.
  - Explicit roundId takes priority over auto-selection; auto-selection remains when omitted.

- **Tests**
  - Added comprehensive tests for explicit, auto-selected, and error scenarios (note: test block duplicated). 

- **Chores**
  - Migration added to persist the round error message field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->