### PR TITLE
QF Multi: Adding smart Round select by projectId and networkId

### DIFF
--- a/src/resolvers/qfRoundResolver.test.ts
+++ b/src/resolvers/qfRoundResolver.test.ts
@@ -349,7 +349,7 @@ function qfSmartSelectSuccessTestCases() {
     });
 
     assert.isOk(result.data.data);
-    assert.isNull(result.data.errors);
+    assert.isUndefined(result.data.errors);
 
     const selectedRound = result.data.data.qfSmartSelect;
 
@@ -374,7 +374,7 @@ function qfSmartSelectSuccessTestCases() {
     });
 
     assert.isOk(result.data.data);
-    assert.isNull(result.data.errors);
+    assert.isUndefined(result.data.errors);
 
     const selectedRound = result.data.data.qfSmartSelect;
 

--- a/src/resolvers/resolvers.ts
+++ b/src/resolvers/resolvers.ts
@@ -14,7 +14,7 @@ import { GivPowerTestingResolver } from './givPowerTestingResolver';
 import { ProjectPowerResolver } from './projectPowerResolver';
 import { CampaignResolver } from './campaignResolver';
 import { ChainvineResolver } from './chainvineResolver';
-import { QfRoundResolver } from './qfRoundResolver';
+import { QfRoundResolver, QfSmartSelectResolver } from './qfRoundResolver';
 import { QfRoundHistoryResolver } from './qfRoundHistoryResolver';
 import { ProjectUserInstantPowerViewResolver } from './instantPowerResolver';
 import { AnchorContractAddressResolver } from './anchorContractAddressResolver';
@@ -50,6 +50,7 @@ export const getResolvers = (): Function[] => {
 
     CampaignResolver,
     QfRoundResolver,
+    QfSmartSelectResolver,
     QfRoundHistoryResolver,
 
     AnchorContractAddressResolver,

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -45,6 +45,24 @@ export const scoreUserAddressMutation = `
   }
 `;
 
+export const qfSmartSelectQuery = `
+  query (
+    $networkId: Int!
+    $projectId: Int!
+  ) {
+    qfSmartSelect(
+      networkId: $networkId
+      projectId: $projectId
+    ) {
+      id
+      name
+      matchingPoolAmount
+      eligibleNetworks
+      allocatedFundUSD
+    }
+  }
+`;
+
 export const createDraftDonationMutation = `
   mutation (
     $networkId: Float!


### PR DESCRIPTION
!!!MISSING priority condition!!!
- https://github.com/Giveth/impact-graph/issues/2146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Smart QF Round selection query (qfSmartSelect) returning the best active round for a project on a given network: id, name, matching pool amount, eligible networks, and USD allocation.
  * Added backend selection logic to choose the most appropriate active round per network and project; returns a clear error when none are eligible.

* **Tests**
  * Added tests covering successful selection across networks and error handling when no eligible rounds exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->