### PR TITLE
Add QF round projects endpoint

### DIFF
--- a/src/repositories/projectRepository.test.ts
+++ b/src/repositories/projectRepository.test.ts
@@ -56,7 +56,7 @@ import { QfRound } from '../entities/qfRound';
 import { Reaction } from '../entities/reaction';
 import { SocialProfile } from '../entities/socialProfile';
 import { ProjectSocialMediaType } from '../types/projectSocialMediaType';
-import { ReviewStatus } from '../entities/project';
+import { ReviewStatus, ProjStatus } from '../entities/project';
 
 describe(
   'findProjectByWalletAddress test cases',
@@ -742,7 +742,7 @@ function findQfRoundProjectsTestCases() {
       title: 'Active Project',
       slug: `active-project-${timestamp}`,
       adminUserId: user.id,
-      statusId: 5, // ProjStatus.active
+      statusId: ProjStatus.active,
       reviewStatus: ReviewStatus.Listed,
     });
     activeProject.qfRounds = [qfRound];
@@ -754,7 +754,7 @@ function findQfRoundProjectsTestCases() {
       title: 'Cancelled Project',
       slug: `cancelled-project-${timestamp}`,
       adminUserId: user.id,
-      statusId: 7, // ProjStatus.cancelled
+      statusId: ProjStatus.cancelled,
       reviewStatus: ReviewStatus.Listed,
     });
     cancelledProject.qfRounds = [qfRound];
@@ -766,7 +766,7 @@ function findQfRoundProjectsTestCases() {
       title: 'Not Reviewed Project',
       slug: `not-reviewed-project-${timestamp}`,
       adminUserId: user.id,
-      statusId: 5, // ProjStatus.active
+      statusId: ProjStatus.active,
       reviewStatus: ReviewStatus.NotReviewed,
     });
     notReviewedProject.qfRounds = [qfRound];

--- a/src/repositories/projectRepository.test.ts
+++ b/src/repositories/projectRepository.test.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import moment from 'moment';
+import { In } from 'typeorm';
 import {
   findProjectById,
   findProjectBySlug,
@@ -7,6 +8,7 @@ import {
   findProjectByWalletAddress,
   findProjectsByIdArray,
   findProjectsBySlugArray,
+  findQfRoundProjects,
   projectsWithoutUpdateAfterTimeFrame,
   removeProjectAndRelatedEntities,
   updateProjectWithVerificationForm,
@@ -50,9 +52,11 @@ import { FeaturedUpdate } from '../entities/featuredUpdate';
 import { ProjectAddress } from '../entities/projectAddress';
 import { ProjectSocialMedia } from '../entities/projectSocialMedia';
 import { ProjectStatusHistory } from '../entities/projectStatusHistory';
+import { QfRound } from '../entities/qfRound';
 import { Reaction } from '../entities/reaction';
 import { SocialProfile } from '../entities/socialProfile';
 import { ProjectSocialMediaType } from '../types/projectSocialMediaType';
+import { ReviewStatus } from '../entities/project';
 
 describe(
   'findProjectByWalletAddress test cases',
@@ -91,6 +95,8 @@ describe(
   'removeProjectAndRelatedEntities test cases',
   removeProjectAndRelatedEntitiesTestCase,
 );
+
+describe('findQfRoundProjects test cases', findQfRoundProjectsTestCases);
 
 function projectsWithoutUpdateAfterTimeFrameTestCases() {
   it('should return projects created a long time ago', async () => {
@@ -601,5 +607,277 @@ function removeProjectAndRelatedEntitiesTestCase() {
     relatedEntities.forEach(entity => {
       assert.isNull(entity);
     });
+  });
+}
+
+function findQfRoundProjectsTestCases() {
+  it('should return projects for a specific QF round', async () => {
+    // Create a QF round
+    const qfRound = QfRound.create({
+      isActive: true,
+      name: 'Test QF Round',
+      slug: `test-qf-round-${Date.now()}`,
+      allocatedFund: 100000,
+      minimumPassportScore: 8,
+      beginDate: new Date(),
+      endDate: moment().add(10, 'days').toDate(),
+    });
+    await qfRound.save();
+
+    // Create users
+    const user1 = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+    const user2 = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+
+    // Create projects and associate them with the QF round
+    const timestamp = Date.now();
+    const project1 = await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: 'QF Project 1',
+      slug: `qf-project-1-${timestamp}`,
+      adminUserId: user1.id,
+      verified: true,
+      isGivbackEligible: true,
+    });
+    project1.qfRounds = [qfRound];
+    await project1.save();
+
+    const project2 = await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: 'QF Project 2',
+      slug: `qf-project-2-${timestamp}`,
+      adminUserId: user2.id,
+      verified: false,
+      isGivbackEligible: true,
+    });
+    project2.qfRounds = [qfRound];
+    await project2.save();
+
+    // Test the repository function
+    const projects = await findQfRoundProjects(qfRound.id);
+
+    assert.isOk(projects);
+    assert.equal(projects.length, 2);
+
+    // Verify project 1 data
+    const project1Data = projects.find(p => p.id === project1.id);
+    assert.isOk(project1Data);
+    if (project1Data) {
+      assert.equal(project1Data.title, 'QF Project 1');
+      assert.equal(project1Data.slug, `qf-project-1-${timestamp}`);
+      assert.equal(project1Data.verified, true);
+      assert.equal(project1Data.isGivbackEligible, true);
+      assert.equal(project1Data.projectType, 'project');
+      assert.equal(project1Data.adminUserId, user1.id);
+      assert.isOk(project1Data.adminUser);
+      assert.equal(project1Data.adminUser.id, user1.id);
+      assert.isOk(project1Data.status);
+      assert.isOk(project1Data.organization);
+      assert.isOk(project1Data.addresses);
+      assert.isOk(project1Data.qfRounds);
+      assert.equal(project1Data.qfRounds.length, 1);
+      assert.equal(project1Data.qfRounds[0].id, qfRound.id);
+    }
+
+    // Verify project 2 data
+    const project2Data = projects.find(p => p.id === project2.id);
+    assert.isOk(project2Data);
+    if (project2Data) {
+      assert.equal(project2Data.title, 'QF Project 2');
+      assert.equal(project2Data.slug, `qf-project-2-${timestamp}`);
+      assert.equal(project2Data.verified, false);
+      assert.equal(project2Data.isGivbackEligible, true);
+      assert.equal(project2Data.adminUserId, user2.id);
+      assert.equal(project2Data.adminUser.id, user2.id);
+    }
+
+    // Cleanup
+    await removeProjectAndRelatedEntities(project1.id);
+    await removeProjectAndRelatedEntities(project2.id);
+    await QfRound.delete({ id: qfRound.id });
+    await User.delete({ id: In([user1.id, user2.id]) });
+  });
+
+  it('should return empty array when no projects are associated with QF round', async () => {
+    // Create a QF round
+    const qfRound = QfRound.create({
+      isActive: true,
+      name: 'Empty QF Round',
+      slug: `empty-qf-round-${Date.now()}`,
+      allocatedFund: 50000,
+      minimumPassportScore: 8,
+      beginDate: new Date(),
+      endDate: moment().add(10, 'days').toDate(),
+    });
+    await qfRound.save();
+
+    // Test the repository function
+    const projects = await findQfRoundProjects(qfRound.id);
+
+    assert.isOk(projects);
+    assert.equal(projects.length, 0);
+
+    // Cleanup
+    await QfRound.delete({ id: qfRound.id });
+  });
+
+  it('should only return active and listed projects', async () => {
+    // Create a QF round
+    const qfRound = QfRound.create({
+      isActive: true,
+      name: 'Filtered QF Round',
+      slug: `filtered-qf-round-${Date.now()}`,
+      allocatedFund: 75000,
+      minimumPassportScore: 8,
+      beginDate: new Date(),
+      endDate: moment().add(10, 'days').toDate(),
+    });
+    await qfRound.save();
+
+    const user = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+
+    const timestamp = Date.now();
+    // Create an active and listed project
+    const activeProject = await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: 'Active Project',
+      slug: `active-project-${timestamp}`,
+      adminUserId: user.id,
+      statusId: 5, // ProjStatus.active
+      reviewStatus: ReviewStatus.Listed,
+    });
+    activeProject.qfRounds = [qfRound];
+    await activeProject.save();
+
+    // Create a cancelled project (should not be returned)
+    const cancelledProject = await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: 'Cancelled Project',
+      slug: `cancelled-project-${timestamp}`,
+      adminUserId: user.id,
+      statusId: 7, // ProjStatus.cancelled
+      reviewStatus: ReviewStatus.Listed,
+    });
+    cancelledProject.qfRounds = [qfRound];
+    await cancelledProject.save();
+
+    // Create a not reviewed project (should not be returned)
+    const notReviewedProject = await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: 'Not Reviewed Project',
+      slug: `not-reviewed-project-${timestamp}`,
+      adminUserId: user.id,
+      statusId: 5, // ProjStatus.active
+      reviewStatus: ReviewStatus.NotReviewed,
+    });
+    notReviewedProject.qfRounds = [qfRound];
+    await notReviewedProject.save();
+
+    // Test the repository function
+    const projects = await findQfRoundProjects(qfRound.id);
+
+    assert.isOk(projects);
+    assert.equal(projects.length, 1);
+    assert.equal(projects[0].id, activeProject.id);
+
+    // Cleanup
+    await removeProjectAndRelatedEntities(activeProject.id);
+    await removeProjectAndRelatedEntities(cancelledProject.id);
+    await removeProjectAndRelatedEntities(notReviewedProject.id);
+    await QfRound.delete({ id: qfRound.id });
+    await User.delete({ id: user.id });
+  });
+
+  it('should include power data in the results', async () => {
+    // Create a QF round
+    const qfRound = QfRound.create({
+      isActive: true,
+      name: 'Power QF Round',
+      slug: `power-qf-round-${Date.now()}`,
+      allocatedFund: 100000,
+      minimumPassportScore: 8,
+      beginDate: new Date(),
+      endDate: moment().add(10, 'days').toDate(),
+    });
+    await qfRound.save();
+
+    const user = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+
+    const project = await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: 'Power Project',
+      slug: `power-project-${Date.now()}`,
+      adminUserId: user.id,
+    });
+    project.qfRounds = [qfRound];
+    await project.save();
+
+    // Test the repository function
+    const projects = await findQfRoundProjects(qfRound.id);
+
+    assert.isOk(projects);
+    assert.equal(projects.length, 1);
+
+    const projectData = projects[0];
+    assert.isOk(projectData);
+    // Note: Power data might be null if no power views exist, which is expected
+    // The test verifies that the query includes the power joins
+
+    // Cleanup
+    await removeProjectAndRelatedEntities(project.id);
+    await QfRound.delete({ id: qfRound.id });
+    await User.delete({ id: user.id });
+  });
+
+  it('should order projects by creation date descending', async () => {
+    // Create a QF round
+    const qfRound = QfRound.create({
+      isActive: true,
+      name: 'Order QF Round',
+      slug: `order-qf-round-${Date.now()}`,
+      allocatedFund: 100000,
+      minimumPassportScore: 8,
+      beginDate: new Date(),
+      endDate: moment().add(10, 'days').toDate(),
+    });
+    await qfRound.save();
+
+    const user = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+
+    // Create projects with different creation dates
+    const olderProject = await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: 'Older Project',
+      slug: `older-project-${Date.now()}`,
+      adminUserId: user.id,
+      creationDate: moment().subtract(1, 'day').toDate(),
+    });
+    olderProject.qfRounds = [qfRound];
+    await olderProject.save();
+
+    const newerProject = await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: 'Newer Project',
+      slug: `newer-project-${Date.now()}`,
+      adminUserId: user.id,
+      creationDate: moment().subtract(1, 'hour').toDate(),
+    });
+    newerProject.qfRounds = [qfRound];
+    await newerProject.save();
+
+    // Test the repository function
+    const projects = await findQfRoundProjects(qfRound.id);
+
+    assert.isOk(projects);
+    assert.equal(projects.length, 2);
+
+    // Should be ordered by creation date descending (newest first)
+    assert.equal(projects[0].id, newerProject.id);
+    assert.equal(projects[1].id, olderProject.id);
+
+    // Cleanup
+    await removeProjectAndRelatedEntities(olderProject.id);
+    await removeProjectAndRelatedEntities(newerProject.id);
+    await QfRound.delete({ id: qfRound.id });
+    await User.delete({ id: user.id });
   });
 }

--- a/src/repositories/projectRepository.ts
+++ b/src/repositories/projectRepository.ts
@@ -666,7 +666,6 @@ export const findQfRoundProjects = async (
     .leftJoinAndSelect('project.status', 'status')
     .leftJoinAndSelect('project.organization', 'organization')
     .leftJoinAndSelect('project.addresses', 'addresses')
-    .leftJoinAndSelect('project.qfRounds', 'qfRounds')
     .leftJoin('project.adminUser', 'user')
     .addSelect(publicSelectionFields)
     .leftJoin('project.projectPower', 'projectPower')
@@ -678,10 +677,11 @@ export const findQfRoundProjects = async (
     ])
     .innerJoinAndSelect(
       'project.qfRounds',
-      'qf_rounds',
-      'qf_rounds.id = :qfRoundId',
+      'qfRounds',
+      'qfRounds.id = :qfRoundId',
       { qfRoundId },
     )
+    .distinct(true)
     .where('project.statusId = :statusId', { statusId: ProjStatus.active })
     .andWhere('project.reviewStatus = :reviewStatus', {
       reviewStatus: ReviewStatus.Listed,

--- a/src/resolvers/projectResolver.test.ts
+++ b/src/resolvers/projectResolver.test.ts
@@ -3,12 +3,16 @@ import 'mocha';
 import axios from 'axios';
 import moment from 'moment';
 import { ArgumentValidationError } from 'type-graphql';
+import { In } from 'typeorm';
+import { removeProjectAndRelatedEntities } from '../repositories/projectRepository';
 import {
+  createDonationData,
   createProjectData,
   generateRandomEtheriumAddress,
   generateRandomSolanaAddress,
   generateTestAccessToken,
   graphqlUrl,
+  saveDonationDirectlyToDb,
   saveFeaturedProjectDirectlyToDb,
   saveProjectDirectlyToDb,
   saveUserDirectlyToDb,
@@ -37,6 +41,7 @@ import {
   getTokensDetailsQuery,
   projectByIdQuery,
   projectsByUserIdQuery,
+  qfProjectsQuery,
   updateProjectQuery,
   walletAddressIsPurpleListed,
   walletAddressIsValid,
@@ -56,6 +61,7 @@ import {
   RevokeSteps,
 } from '../entities/project';
 import { Category } from '../entities/category';
+import { Donation } from '../entities/donation';
 import { Reaction } from '../entities/reaction';
 import { ProjectStatus } from '../entities/projectStatus';
 import { User } from '../entities/user';
@@ -188,6 +194,8 @@ describe(
   'leftJoinAndMapMany Cause test cases --->',
   leftJoinAndMapManyCauseTestCases,
 );
+
+describe('qfProjects test cases --->', qfProjectsTestCases);
 
 function projectsPerDateTestCases() {
   it('should projects created in a time range', async () => {
@@ -5996,5 +6004,310 @@ function leftJoinAndMapManyCauseTestCases() {
     assert.equal(projects[0].causeProjects.length, 1);
     assert.equal(projects[0].causeProjects[0].projectId, project.id);
     assert.equal(projects[0].causeProjects[0].causeId, cause.id);
+  });
+}
+
+function qfProjectsTestCases() {
+  it('should return projects for a specific QF round', async () => {
+    // Create a QF round
+    const qfRound = QfRound.create({
+      isActive: true,
+      name: 'Test QF Round',
+      slug: `test-qf-round-${Date.now()}`,
+      allocatedFund: 100000,
+      minimumPassportScore: 8,
+      beginDate: new Date(),
+      endDate: moment().add(10, 'days').toDate(),
+    });
+    await qfRound.save();
+
+    // Create users
+    const user1 = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+    user1.name = 'User 1';
+    await user1.save();
+
+    const user2 = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+    user2.name = 'User 2';
+    await user2.save();
+
+    // Create projects and associate them with the QF round
+    const timestamp = Date.now();
+    const project1 = await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: 'QF Project 1',
+      slug: `qf-project-1-${timestamp}`,
+      adminUserId: user1.id,
+      statusId: 5, // ProjStatus.active
+      reviewStatus: ReviewStatus.Listed,
+      verified: true,
+      isGivbackEligible: true,
+    });
+    project1.qfRounds = [qfRound];
+    await project1.save();
+
+    const project2 = await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: 'QF Project 2',
+      slug: `qf-project-2-${timestamp}`,
+      adminUserId: user2.id,
+      statusId: 5, // ProjStatus.active
+      reviewStatus: ReviewStatus.Listed,
+      verified: false,
+      isGivbackEligible: true,
+    });
+    project2.qfRounds = [qfRound];
+    await project2.save();
+
+    // Create some donations for QF round stats
+    const donation1 = await saveDonationDirectlyToDb(
+      {
+        ...createDonationData(),
+        valueUsd: 100,
+        qfRoundId: qfRound.id,
+        status: 'verified',
+      },
+      user1.id,
+      project1.id,
+    );
+
+    const donation2 = await saveDonationDirectlyToDb(
+      {
+        ...createDonationData(),
+        valueUsd: 200,
+        qfRoundId: qfRound.id,
+        status: 'verified',
+      },
+      user2.id,
+      project2.id,
+    );
+
+    // Test the query
+    const result = await axios.post(graphqlUrl, {
+      query: qfProjectsQuery,
+      variables: {
+        qfRoundId: qfRound.id,
+      },
+    });
+
+    assert.isOk(result);
+    assert.isOk(result.data.data.qfProjects);
+    assert.equal(result.data.data.qfProjects.totalCount, 2);
+    assert.equal(result.data.data.qfProjects.projects.length, 2);
+
+    const projects = result.data.data.qfProjects.projects;
+
+    // Verify project 1 data (find by title since IDs might be different)
+    const project1Data = projects.find(p => p.title === 'QF Project 1');
+    assert.isOk(project1Data);
+    assert.equal(project1Data.title, 'QF Project 1');
+    assert.equal(project1Data.slug, `qf-project-1-${timestamp}`);
+    assert.equal(project1Data.verified, true);
+    assert.equal(project1Data.isGivbacksEligible, true);
+    assert.equal(project1Data.projectType, 'project');
+    assert.isOk(project1Data.admin);
+    assert.equal(project1Data.admin.id, user1.id);
+    assert.equal(project1Data.admin.name, user1.name);
+    assert.isOk(project1Data.status);
+    assert.isOk(project1Data.organization);
+    assert.isOk(project1Data.qfRounds);
+    assert.equal(project1Data.qfRounds.length, 1);
+    assert.equal(project1Data.qfRounds[0].id, qfRound.id);
+    assert.isOk(project1Data.qfRoundStats);
+    assert.equal(project1Data.qfRoundStats.roundId, qfRound.id);
+
+    // Verify project 2 data (find by title since IDs might be different)
+    const project2Data = projects.find(p => p.title === 'QF Project 2');
+    assert.isOk(project2Data);
+    assert.equal(project2Data.title, 'QF Project 2');
+    assert.equal(project2Data.slug, `qf-project-2-${timestamp}`);
+    assert.equal(project2Data.verified, false);
+    assert.equal(project2Data.isGivbacksEligible, true);
+    assert.equal(project2Data.admin.id, user2.id);
+    assert.equal(project2Data.admin.name, user2.name);
+
+    // Cleanup
+    await removeProjectAndRelatedEntities(project1.id);
+    await removeProjectAndRelatedEntities(project2.id);
+    await QfRound.delete({ id: qfRound.id });
+    await User.delete({ id: In([user1.id, user2.id]) });
+    await Donation.delete({ id: In([donation1.id, donation2.id]) });
+  });
+
+  it('should return empty array when no projects are associated with QF round', async () => {
+    // Create a QF round
+    const qfRound = QfRound.create({
+      isActive: true,
+      name: 'Empty QF Round',
+      slug: `empty-qf-round-${Date.now()}`,
+      allocatedFund: 50000,
+      minimumPassportScore: 8,
+      beginDate: new Date(),
+      endDate: moment().add(10, 'days').toDate(),
+    });
+    await qfRound.save();
+
+    // Test the query
+    const result = await axios.post(graphqlUrl, {
+      query: qfProjectsQuery,
+      variables: {
+        qfRoundId: qfRound.id,
+      },
+    });
+
+    assert.isOk(result);
+    assert.isOk(result.data.data.qfProjects);
+    assert.equal(result.data.data.qfProjects.totalCount, 0);
+    assert.equal(result.data.data.qfProjects.projects.length, 0);
+
+    // Cleanup
+    await QfRound.delete({ id: qfRound.id });
+  });
+
+  it('should only return active and listed projects', async () => {
+    // Create a QF round
+    const qfRound = QfRound.create({
+      isActive: true,
+      name: 'Filtered QF Round',
+      slug: `filtered-qf-round-${Date.now()}`,
+      allocatedFund: 75000,
+      minimumPassportScore: 8,
+      beginDate: new Date(),
+      endDate: moment().add(10, 'days').toDate(),
+    });
+    await qfRound.save();
+
+    const user = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+
+    const timestamp = Date.now();
+    // Create an active and listed project
+    const activeProject = await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: 'Active Project',
+      slug: `active-project-${timestamp}`,
+      adminUserId: user.id,
+      statusId: ProjStatus.active,
+      reviewStatus: ReviewStatus.Listed,
+    });
+    activeProject.qfRounds = [qfRound];
+    await activeProject.save();
+
+    // Create a cancelled project (should not be returned)
+    const cancelledProject = await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: 'Cancelled Project',
+      slug: `cancelled-project-${timestamp}`,
+      adminUserId: user.id,
+      statusId: ProjStatus.cancelled,
+      reviewStatus: ReviewStatus.Listed,
+    });
+    cancelledProject.qfRounds = [qfRound];
+    await cancelledProject.save();
+
+    // Create a not reviewed project (should not be returned)
+    const notReviewedProject = await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: 'Not Reviewed Project',
+      slug: `not-reviewed-project-${timestamp}`,
+      adminUserId: user.id,
+      statusId: ProjStatus.active,
+      reviewStatus: ReviewStatus.NotReviewed,
+    });
+    notReviewedProject.qfRounds = [qfRound];
+    await notReviewedProject.save();
+
+    // Test the query
+    const result = await axios.post(graphqlUrl, {
+      query: qfProjectsQuery,
+      variables: {
+        qfRoundId: qfRound.id,
+      },
+    });
+
+    assert.isOk(result);
+    assert.isOk(result.data.data.qfProjects);
+    assert.equal(result.data.data.qfProjects.totalCount, 1);
+    assert.equal(result.data.data.qfProjects.projects.length, 1);
+    assert.equal(
+      result.data.data.qfProjects.projects[0].projectId,
+      activeProject.id,
+    );
+
+    // Cleanup
+    await removeProjectAndRelatedEntities(activeProject.id);
+    await removeProjectAndRelatedEntities(cancelledProject.id);
+    await removeProjectAndRelatedEntities(notReviewedProject.id);
+    await QfRound.delete({ id: qfRound.id });
+    await User.delete({ id: user.id });
+  });
+
+  it('should handle QF round stats correctly', async () => {
+    // Create a QF round
+    const qfRound = QfRound.create({
+      isActive: true,
+      name: 'Stats QF Round',
+      slug: `stats-qf-round-${Date.now()}`,
+      allocatedFund: 200000,
+      minimumPassportScore: 8,
+      beginDate: new Date(),
+      endDate: moment().add(10, 'days').toDate(),
+    });
+    await qfRound.save();
+
+    const user1 = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+    const user2 = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+
+    const timestamp = Date.now();
+    const project = await saveProjectDirectlyToDb({
+      ...createProjectData(),
+      title: 'Stats Project',
+      slug: `stats-project-${timestamp}`,
+      adminUserId: user1.id,
+    });
+    project.qfRounds = [qfRound];
+    await project.save();
+
+    // Create donations from different users
+    const donation1 = await saveDonationDirectlyToDb(
+      {
+        ...createDonationData(),
+        valueUsd: 150,
+        qfRoundId: qfRound.id,
+        status: 'verified',
+      },
+      user1.id,
+      project.id,
+    );
+
+    const donation2 = await saveDonationDirectlyToDb(
+      {
+        ...createDonationData(),
+        valueUsd: 250,
+        qfRoundId: qfRound.id,
+        status: 'verified',
+      },
+      user2.id,
+      project.id,
+    );
+
+    // Test the query
+    const result = await axios.post(graphqlUrl, {
+      query: qfProjectsQuery,
+      variables: {
+        qfRoundId: qfRound.id,
+      },
+    });
+
+    assert.isOk(result);
+    const projectData = result.data.data.qfProjects.projects[0];
+    assert.isOk(projectData.qfRoundStats);
+    assert.equal(projectData.qfRoundStats.roundId, qfRound.id);
+    assert.equal(projectData.qfRoundStats.totalRaisedInRound, 400); // 150 + 250
+    assert.equal(projectData.qfRoundStats.totalDonorsInRound, 2); // 2 unique donors
+
+    // Cleanup
+    await removeProjectAndRelatedEntities(project.id);
+    await QfRound.delete({ id: qfRound.id });
+    await User.delete({ id: In([user1.id, user2.id]) });
+    await Donation.delete({ id: In([donation1.id, donation2.id]) });
   });
 }

--- a/src/resolvers/projectResolver.test.ts
+++ b/src/resolvers/projectResolver.test.ts
@@ -6037,7 +6037,7 @@ function qfProjectsTestCases() {
       title: 'QF Project 1',
       slug: `qf-project-1-${timestamp}`,
       adminUserId: user1.id,
-      statusId: 5, // ProjStatus.active
+      statusId: ProjStatus.active,
       reviewStatus: ReviewStatus.Listed,
       verified: true,
       isGivbackEligible: true,
@@ -6050,7 +6050,7 @@ function qfProjectsTestCases() {
       title: 'QF Project 2',
       slug: `qf-project-2-${timestamp}`,
       adminUserId: user2.id,
-      statusId: 5, // ProjStatus.active
+      statusId: ProjStatus.active,
       reviewStatus: ReviewStatus.Listed,
       verified: false,
       isGivbackEligible: true,

--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -2536,48 +2536,48 @@ export class ProjectResolver {
     try {
       const projects = await findQfRoundProjects(qfRoundId);
 
+      // Compute round-wide stats once (applies to all projects)
+      const anyRound = projects[0]?.qfRounds?.find(qr => qr.id === qfRoundId);
+      const commonStats = anyRound
+        ? await getQfRoundStats(anyRound)
+        : undefined;
+
       // Transform projects to QfProject format
-      const qfProjects: QfProject[] = await Promise.all(
-        projects.map(async project => {
-          // Get QF round stats for this specific round
-          const qfRound = project.qfRounds?.find(qr => qr.id === qfRoundId);
-          let qfRoundStats: QfRoundStats | undefined;
-
-          if (qfRound) {
-            const stats = await getQfRoundStats(qfRound);
-            qfRoundStats = {
+      const qfProjects: QfProject[] = projects.map(project => {
+        const qfRoundStats = commonStats
+          ? {
               roundId: qfRoundId,
-              totalRaisedInRound: stats.totalDonationUsd,
-              totalDonorsInRound: stats.uniqueDonors,
-            };
-          }
+              totalRaisedInRound: commonStats.totalDonationUsd,
+              totalDonorsInRound: commonStats.uniqueDonors,
+              // donationsCount: commonStats.donationsCount, // if added to type
+            }
+          : undefined;
 
-          return {
-            projectId: project.id,
-            title: project.title,
-            descriptionSummary: project.descriptionSummary,
-            description: project.description,
-            image: project.image,
-            totalRaisedUsd: project.totalDonations,
-            verified: project.verified,
-            isGivbacksEligible: project.isGivbackEligible,
-            slug: project.slug,
-            admin: project.adminUser,
-            status: project.status,
-            reviewStatus: project.reviewStatus,
-            projectType: project.projectType,
-            projectInstantPower: project.projectInstantPower,
-            updatedAt: project.updatedAt,
-            creationDate: project.creationDate,
-            latestUpdateCreationDate: project.latestUpdateCreationDate,
-            organization: project.organization,
-            activeProjectsCount: project.activeProjectsCount,
-            addresses: project.addresses,
-            qfRounds: project.qfRounds,
-            qfRoundStats,
-          };
-        }),
-      );
+        return {
+          projectId: project.id,
+          title: project.title,
+          descriptionSummary: project.descriptionSummary,
+          description: project.description,
+          image: project.image,
+          totalRaisedUsd: project.totalDonations,
+          verified: project.verified,
+          isGivbacksEligible: project.isGivbackEligible,
+          slug: project.slug,
+          admin: project.adminUser,
+          status: project.status,
+          reviewStatus: project.reviewStatus,
+          projectType: project.projectType,
+          projectInstantPower: project.projectInstantPower,
+          updatedAt: project.updatedAt,
+          creationDate: project.creationDate,
+          latestUpdateCreationDate: project.latestUpdateCreationDate,
+          organization: project.organization,
+          activeProjectsCount: project.activeProjectsCount,
+          addresses: project.addresses,
+          qfRounds: project.qfRounds,
+          qfRoundStats,
+        };
+      });
 
       return {
         projects: qfProjects,

--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -7,6 +7,8 @@ import {
   ArgsType,
   Ctx,
   Field,
+  Float,
+  ID,
   Info,
   InputType,
   Int,
@@ -48,6 +50,9 @@ import { ApolloContext } from '../types/ApolloContext';
 import { publicSelectionFields, User } from '../entities/user';
 import { Context } from '../context';
 import SentryLogger from '../sentryLogger';
+import { ProjectAddress } from '../entities/projectAddress';
+import { QfRound } from '../entities/qfRound';
+import { ProjectInstantPowerView } from '../views/projectInstantPowerView';
 import {
   errorMessages,
   i18n,
@@ -111,8 +116,12 @@ import { PROJECT_UPDATE_CONTENT_MAX_LENGTH } from '../constants/validators';
 import { calculateGivbackFactor } from '../services/givbackService';
 import { ProjectBySlugResponse } from './types/projectResolver';
 import { ChainType } from '../types/network';
-import { findActiveQfRound } from '../repositories/qfRoundRepository';
+import {
+  findActiveQfRound,
+  getQfRoundStats,
+} from '../repositories/qfRoundRepository';
 import { getAllProjectsRelatedToActiveCampaigns } from '../services/campaignService';
+import { findQfRoundProjects } from '../repositories/projectRepository';
 import { getAppropriateNetworkId } from '../services/chains';
 import {
   addBulkProjectSocialMedia,
@@ -154,6 +163,96 @@ class TopProjects {
 class ProjectUpdatesResponse {
   @Field(_type => [ProjectUpdate])
   projectUpdates: ProjectUpdate[];
+}
+
+@ObjectType()
+class QfRoundStats {
+  @Field(_type => Int)
+  roundId: number;
+
+  @Field(_type => Float)
+  totalRaisedInRound: number;
+
+  @Field(_type => Int)
+  totalDonorsInRound: number;
+}
+
+@ObjectType()
+class QfProject {
+  @Field(_type => ID)
+  projectId: number;
+
+  @Field()
+  title: string;
+
+  @Field({ nullable: true })
+  descriptionSummary?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  image?: string;
+
+  @Field(_type => Float)
+  totalRaisedUsd: number;
+
+  @Field()
+  verified: boolean;
+
+  @Field()
+  isGivbacksEligible: boolean;
+
+  @Field({ nullable: true })
+  slug?: string;
+
+  @Field(_type => User, { nullable: true })
+  admin: User;
+
+  @Field(_type => ProjectStatus)
+  status: ProjectStatus;
+
+  @Field()
+  reviewStatus: string;
+
+  @Field()
+  projectType: string;
+
+  @Field(_type => ProjectInstantPowerView, { nullable: true })
+  projectInstantPower?: ProjectInstantPowerView;
+
+  @Field({ nullable: true })
+  updatedAt?: Date;
+
+  @Field({ nullable: true })
+  creationDate?: Date;
+
+  @Field({ nullable: true })
+  latestUpdateCreationDate?: Date;
+
+  @Field(_type => Organization, { nullable: true })
+  organization?: Organization;
+
+  @Field(_type => Int, { nullable: true })
+  activeProjectsCount?: number;
+
+  @Field(_type => [ProjectAddress], { nullable: true })
+  addresses?: ProjectAddress[];
+
+  @Field(_type => [QfRound], { nullable: true })
+  qfRounds?: QfRound[];
+
+  @Field(_type => QfRoundStats, { nullable: true })
+  qfRoundStats?: QfRoundStats;
+}
+
+@ObjectType()
+class QfProjectsResponse {
+  @Field(_type => [QfProject])
+  projects: QfProject[];
+
+  @Field(_type => Int)
+  totalCount: number;
 }
 
 export enum OrderDirection {
@@ -2428,5 +2527,66 @@ export class ProjectResolver {
     }
 
     return true;
+  }
+
+  @Query(_returns => QfProjectsResponse)
+  async qfProjects(
+    @Arg('qfRoundId', _type => Int) qfRoundId: number,
+  ): Promise<QfProjectsResponse> {
+    try {
+      const projects = await findQfRoundProjects(qfRoundId);
+
+      // Transform projects to QfProject format
+      const qfProjects: QfProject[] = await Promise.all(
+        projects.map(async project => {
+          // Get QF round stats for this specific round
+          const qfRound = project.qfRounds?.find(qr => qr.id === qfRoundId);
+          let qfRoundStats: QfRoundStats | undefined;
+
+          if (qfRound) {
+            const stats = await getQfRoundStats(qfRound);
+            qfRoundStats = {
+              roundId: qfRoundId,
+              totalRaisedInRound: stats.totalDonationUsd,
+              totalDonorsInRound: stats.uniqueDonors,
+            };
+          }
+
+          return {
+            projectId: project.id,
+            title: project.title,
+            descriptionSummary: project.descriptionSummary,
+            description: project.description,
+            image: project.image,
+            totalRaisedUsd: project.totalDonations,
+            verified: project.verified,
+            isGivbacksEligible: project.isGivbackEligible,
+            slug: project.slug,
+            admin: project.adminUser,
+            status: project.status,
+            reviewStatus: project.reviewStatus,
+            projectType: project.projectType,
+            projectInstantPower: project.projectInstantPower,
+            updatedAt: project.updatedAt,
+            creationDate: project.creationDate,
+            latestUpdateCreationDate: project.latestUpdateCreationDate,
+            organization: project.organization,
+            activeProjectsCount: project.activeProjectsCount,
+            addresses: project.addresses,
+            qfRounds: project.qfRounds,
+            qfRoundStats,
+          };
+        }),
+      );
+
+      return {
+        projects: qfProjects,
+        totalCount: qfProjects.length,
+      };
+    } catch (error) {
+      logger.error('projectResolver.qfProjects() error', error);
+      SentryLogger.captureException(error);
+      throw error;
+    }
   }
 }

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -1822,6 +1822,62 @@ export const getProjectsAcceptTokensQuery = `
   }
 `;
 
+export const qfProjectsQuery = `
+  query($qfRoundId: Int!) {
+    qfProjects(qfRoundId: $qfRoundId) {
+      projects {
+        projectId
+        title
+        descriptionSummary
+        description
+        image
+        totalRaisedUsd
+        verified
+        isGivbacksEligible
+        slug
+        admin {
+          id
+          name
+          walletAddress
+        }
+        status {
+          id
+          name
+        }
+        reviewStatus
+        projectType
+        projectInstantPower {
+          totalPower
+          powerRank
+        }
+        updatedAt
+        creationDate
+        latestUpdateCreationDate
+        organization {
+          id
+          name
+        }
+        activeProjectsCount
+        addresses {
+          address
+          networkId
+        }
+        qfRounds {
+          id
+          slug
+          isActive
+        }
+        qfRoundStats {
+          roundId
+          totalRaisedInRound
+          totalDonorsInRound
+        }
+      }
+      totalCount
+    }
+  }
+`;
+
 export const getCauseAcceptTokensQuery = `
   query(
       $causeId: Float!,


### PR DESCRIPTION
related to: #2152 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a query to fetch projects for a specific QF round, returning project details, per-round totals (raised amount, donor count), power metrics, organization and address info; results are limited to active/listed projects and ordered newest-first with a total count.

- Tests
  - Added comprehensive end-to-end and repository tests covering results, empty states, filtering, ordering, joined data, and per-round statistics.

- Chores
  - Improved cleanup to remove related QF round links when projects are deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->