### PR TITLE
add filtering, sorting and pagination to the qf round projects query

### DIFF
--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -382,11 +382,11 @@ class GetProjectsArgs {
 @Service()
 @ArgsType()
 class QfProjectsArgs {
-  @Field(_type => Int, { defaultValue: 0, nullable: true })
+  @Field(_type => Int, { defaultValue: 0 })
   @Min(0)
   skip: number;
 
-  @Field(_type => Int, { defaultValue: 10, nullable: true })
+  @Field(_type => Int, { defaultValue: 10 })
   @Min(0)
   @Max(50)
   limit: number;

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -1823,8 +1823,8 @@ export const getProjectsAcceptTokensQuery = `
 `;
 
 export const qfProjectsQuery = `
-  query($qfRoundId: Int!) {
-    qfProjects(qfRoundId: $qfRoundId) {
+  query($qfRoundId: Int!, $skip: Int, $limit: Int, $searchTerm: String, $filters: [FilterField!], $sortingBy: SortingField) {
+    qfProjects(qfRoundId: $qfRoundId, skip: $skip, limit: $limit, searchTerm: $searchTerm, filters: $filters, sortingBy: $sortingBy) {
       projects {
         projectId
         title


### PR DESCRIPTION
related to: #2152 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - QF projects list supports pagination (limit/skip), filtering, search, and multiple sorting modes (Quality Score, Newest, Most Funded, Active Round Raised Funds).
  - Responses include totalCount (sourced from data) and optional per-project QF round stats.

- **API**
  - GraphQL qfProjects accepts skip, limit, searchTerm, filters, and sortingBy parameters.

- **Tests**
  - Comprehensive tests cover pagination, filtering (including verified), search by title, sorting modes, per-round stats, and combined scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->