### PR TITLE
Implement QF Rounds sorting and enhance related tests

### DIFF
--- a/src/repositories/qfRoundRepository.test.ts
+++ b/src/repositories/qfRoundRepository.test.ts
@@ -536,6 +536,7 @@ function findQfRoundsTestCases() {
   beforeEach(async () => {
     // Clear QF round references from donations and delete all QF rounds
     await QfRound.query('UPDATE donation SET "qfRoundId" = NULL');
+    await QfRound.query('DELETE FROM qf_round_history');
     await QfRound.query('DELETE FROM project_qf_rounds_qf_round');
     await QfRound.query('DELETE FROM qf_round');
 

--- a/src/repositories/qfRoundRepository.test.ts
+++ b/src/repositories/qfRoundRepository.test.ts
@@ -13,6 +13,7 @@ import {
   deactivateExpiredQfRounds,
   findQfRoundById,
   findQfRoundBySlug,
+  findQfRounds,
   getExpiredActiveQfRounds,
   getProjectDonationsSqrtRootSum,
   getQfRoundTotalSqrtRootSumSquared,
@@ -46,6 +47,7 @@ describe(
 );
 describe('findQfRoundById test cases', findQfRoundByIdTestCases);
 describe('findQfRoundBySlug test cases', findQfRoundBySlugTestCases);
+describe('findQfRounds test cases', findQfRoundsTestCases);
 
 function findUsersWithoutMBDScoreInActiveAroundTestCases() {
   it('should find users without score that donated in the round', async () => {
@@ -522,5 +524,250 @@ function findQfRoundBySlugTestCases() {
   it('should return null if id is invalid', async () => {
     const result = await findQfRoundById(99999999);
     assert.isNull(result);
+  });
+}
+
+function findQfRoundsTestCases() {
+  let qfRound1: QfRound;
+  let qfRound2: QfRound;
+  let qfRound3: QfRound;
+  let qfRound4: QfRound;
+
+  beforeEach(async () => {
+    // Clear QF round references from donations and delete all QF rounds
+    await QfRound.query('UPDATE donation SET "qfRoundId" = NULL');
+    await QfRound.query('DELETE FROM project_qf_rounds_qf_round');
+    await QfRound.query('DELETE FROM qf_round');
+
+    // Create test QF rounds with different priorities and end dates
+    const now = new Date();
+
+    qfRound1 = QfRound.create({
+      isActive: false,
+      name: 'Round 1',
+      slug: 'round-1',
+      allocatedFund: 1000,
+      minimumPassportScore: 8,
+      beginDate: now,
+      endDate: new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000), // 5 days from now
+      priority: 3,
+    });
+    await qfRound1.save();
+
+    qfRound2 = QfRound.create({
+      isActive: false,
+      name: 'Round 2',
+      slug: 'round-2',
+      allocatedFund: 2000,
+      minimumPassportScore: 8,
+      beginDate: now,
+      endDate: new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000), // 3 days from now
+      priority: 5,
+    });
+    await qfRound2.save();
+
+    qfRound3 = QfRound.create({
+      isActive: false,
+      name: 'Round 3',
+      slug: 'round-3',
+      allocatedFund: 3000,
+      minimumPassportScore: 8,
+      beginDate: now,
+      endDate: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000), // 7 days from now
+      priority: 5, // Same priority as qfRound2
+    });
+    await qfRound3.save();
+
+    qfRound4 = QfRound.create({
+      isActive: false,
+      name: 'Round 4',
+      slug: 'round-4',
+      allocatedFund: 4000,
+      minimumPassportScore: 8,
+      beginDate: now,
+      endDate: new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000), // 2 days from now
+      priority: 1, // Lowest priority
+    });
+    await qfRound4.save();
+  });
+
+  afterEach(async () => {
+    // Clean up test QF rounds
+    if (qfRound1) await QfRound.delete({ id: qfRound1.id });
+    if (qfRound2) await QfRound.delete({ id: qfRound2.id });
+    if (qfRound3) await QfRound.delete({ id: qfRound3.id });
+    if (qfRound4) await QfRound.delete({ id: qfRound4.id });
+  });
+
+  it('should return all QF rounds sorted by priority when sortBy is priority', async () => {
+    const result = await findQfRounds({ sortBy: 'priority' });
+
+    assert.isArray(result);
+    assert.equal(result.length, 4);
+
+    // Should be sorted by priority DESC, then by endDate ASC
+    // Priority 5: qfRound2 (3 days), qfRound3 (7 days)
+    // Priority 3: qfRound1 (5 days)
+    // Priority 1: qfRound4 (2 days)
+    assert.equal(result[0].id, qfRound2.id); // priority 5, closest endDate
+    assert.equal(result[1].id, qfRound3.id); // priority 5, further endDate
+    assert.equal(result[2].id, qfRound1.id); // priority 3
+    assert.equal(result[3].id, qfRound4.id); // priority 1
+  });
+
+  it('should return all QF rounds sorted by id DESC when no sortBy is provided', async () => {
+    const result = await findQfRounds({});
+
+    assert.isArray(result);
+    assert.equal(result.length, 4);
+
+    // Should be sorted by id DESC (newest first)
+    const sortedByIds = result.map(r => r.id).sort((a, b) => b - a);
+    assert.deepEqual(
+      result.map(r => r.id),
+      sortedByIds,
+    );
+  });
+
+  it('should return all QF rounds sorted by id DESC when sortBy is roundId', async () => {
+    const result = await findQfRounds({ sortBy: 'roundId' });
+
+    assert.isArray(result);
+    assert.equal(result.length, 4);
+
+    // Should be sorted by id DESC (newest first)
+    const sortedByIds = result.map(r => r.id).sort((a, b) => b - a);
+    assert.deepEqual(
+      result.map(r => r.id),
+      sortedByIds,
+    );
+  });
+
+  it('should return QF round by slug when slug is provided', async () => {
+    const result = await findQfRounds({ slug: 'round-2' });
+
+    assert.isArray(result);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, qfRound2.id);
+    assert.equal(result[0].slug, 'round-2');
+  });
+
+  it('should return empty array when slug does not exist', async () => {
+    const result = await findQfRounds({ slug: 'non-existent-round' });
+
+    assert.isArray(result);
+    assert.equal(result.length, 0);
+  });
+
+  it('should handle QF rounds with same priority and same endDate', async () => {
+    // Create additional QF round with same priority and endDate as qfRound2
+    const sameEndDate = qfRound2.endDate;
+    const qfRound5 = QfRound.create({
+      isActive: false,
+      name: 'Round 5',
+      slug: 'round-5',
+      allocatedFund: 5000,
+      minimumPassportScore: 8,
+      beginDate: new Date(),
+      endDate: sameEndDate,
+      priority: 5, // Same priority as qfRound2
+    });
+    await qfRound5.save();
+
+    try {
+      const result = await findQfRounds({ sortBy: 'priority' });
+
+      assert.isArray(result);
+      assert.equal(result.length, 5);
+
+      // All priority 5 rounds should come before priority 3 and 1
+      const priority5Rounds = result.slice(0, 3); // qfRound2, qfRound3, qfRound5
+      const priority3Rounds = result.slice(3, 4); // qfRound1
+      const priority1Rounds = result.slice(4); // qfRound4
+
+      // All priority 5 rounds should have priority 5
+      priority5Rounds.forEach(round => {
+        assert.equal(round.priority, 5);
+      });
+
+      // Priority 3 rounds should have priority 3
+      priority3Rounds.forEach(round => {
+        assert.equal(round.priority, 3);
+      });
+
+      // Priority 1 rounds should have priority 1
+      priority1Rounds.forEach(round => {
+        assert.equal(round.priority, 1);
+      });
+
+      // Among priority 5 rounds, should be sorted by endDate ASC
+      // qfRound2 and qfRound5 have same endDate, qfRound3 has later endDate
+      const priority5Ids = priority5Rounds.map(r => r.id);
+      assert.include(priority5Ids, qfRound2.id);
+      assert.include(priority5Ids, qfRound5.id);
+      assert.include(priority5Ids, qfRound3.id);
+    } finally {
+      // Clean up additional QF round
+      await QfRound.delete({ id: qfRound5.id });
+    }
+  });
+
+  it('should handle QF rounds with null priority values', async () => {
+    // Create QF round with null priority (0)
+    const qfRoundNullPriority = QfRound.create({
+      isActive: false,
+      name: 'Round Null Priority',
+      slug: 'round-null-priority',
+      allocatedFund: 6000,
+      minimumPassportScore: 8,
+      beginDate: new Date(),
+      endDate: new Date(Date.now() + 1 * 24 * 60 * 60 * 1000), // 1 day from now
+      priority: 0, // Use 0 instead of null for lowest priority
+    });
+    await qfRoundNullPriority.save();
+
+    try {
+      const result = await findQfRounds({ sortBy: 'priority' });
+
+      assert.isArray(result);
+      assert.equal(result.length, 5);
+
+      // Priority 0 should be treated as lowest priority
+      // Should come after all higher priority rounds
+      const lastRound = result[result.length - 1];
+      assert.equal(lastRound.id, qfRoundNullPriority.id);
+      assert.equal(lastRound.priority, 0);
+    } finally {
+      // Clean up additional QF round
+      await QfRound.delete({ id: qfRoundNullPriority.id });
+    }
+  });
+
+  it('should handle QF rounds with undefined sortBy parameter', async () => {
+    const result = await findQfRounds({ sortBy: undefined });
+
+    assert.isArray(result);
+    assert.equal(result.length, 4);
+
+    // Should default to id DESC sorting
+    const sortedByIds = result.map(r => r.id).sort((a, b) => b - a);
+    assert.deepEqual(
+      result.map(r => r.id),
+      sortedByIds,
+    );
+  });
+
+  it('should handle QF rounds with invalid sortBy parameter', async () => {
+    const result = await findQfRounds({ sortBy: 'invalid' });
+
+    assert.isArray(result);
+    assert.equal(result.length, 4);
+
+    // Should default to id DESC sorting
+    const sortedByIds = result.map(r => r.id).sort((a, b) => b - a);
+    assert.deepEqual(
+      result.map(r => r.id),
+      sortedByIds,
+    );
   });
 }

--- a/src/repositories/qfRoundRepository.ts
+++ b/src/repositories/qfRoundRepository.ts
@@ -25,13 +25,23 @@ const qfRoundsCacheDuration =
 
 export const findQfRounds = async ({
   slug,
+  sortBy,
 }: {
   slug?: string;
+  sortBy?: string;
 }): Promise<QfRound[]> => {
-  const query = QfRound.createQueryBuilder('qf_round').addOrderBy(
-    'qf_round.id',
-    'DESC',
-  );
+  const query = QfRound.createQueryBuilder('qf_round');
+
+  // Apply sorting based on sortBy parameter
+  if (sortBy === 'priority') {
+    // Priority sorting: highest priority first, then closest endAt date
+    query
+      .addOrderBy('qf_round.priority', 'DESC')
+      .addOrderBy('qf_round.endDate', 'ASC');
+  } else {
+    // Default sorting: by id in descending order
+    query.addOrderBy('qf_round.id', 'DESC');
+  }
   if (slug) {
     query.where('slug = :slug', { slug });
     const res = await query.getOne();

--- a/src/resolvers/projectResolver.test.ts
+++ b/src/resolvers/projectResolver.test.ts
@@ -6485,6 +6485,8 @@ function projectResolverQfRoundsPrioritySortingTestCases() {
 
   beforeEach(async () => {
     // Clean up existing data
+    await QfRound.query('UPDATE donation SET "qfRoundId" = NULL');
+    await QfRound.query('DELETE FROM qf_round_history');
     await QfRound.query('DELETE FROM project_qf_rounds_qf_round');
     await QfRound.delete({});
 

--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -1013,6 +1013,8 @@ export class ProjectResolver {
     @Info() info: GraphQLResolveInfo,
     @Arg('userRemoved', _type => Boolean, { nullable: true })
     userRemoved?: boolean,
+    @Arg('qfRoundsSortBy', _type => String, { nullable: true })
+    qfRoundsSortBy?: string,
   ) {
     const fields = graphqlFields(info);
 
@@ -1073,6 +1075,16 @@ export class ProjectResolver {
         user,
       );
     }
+    if (fields.qfRounds) {
+      query = query.leftJoinAndSelect('project.qfRounds', 'qfRounds');
+
+      // Apply Priority sorting if requested
+      if (qfRoundsSortBy === 'priority') {
+        query = query
+          .addOrderBy('qfRounds.priority', 'DESC')
+          .addOrderBy('qfRounds.endDate', 'ASC');
+      }
+    }
 
     const project = await query.getOne();
 
@@ -1106,6 +1118,8 @@ export class ProjectResolver {
     @Info() info: GraphQLResolveInfo,
     @Arg('userRemoved', _type => Boolean, { nullable: true })
     userRemoved?: boolean,
+    @Arg('qfRoundsSortBy', _type => String, { nullable: true })
+    qfRoundsSortBy?: string,
   ) {
     const minimalProject = await findProjectIdBySlug(slug);
     if (!minimalProject) {
@@ -1172,6 +1186,13 @@ export class ProjectResolver {
     }
     if (fields.qfRounds) {
       query = query.leftJoinAndSelect('project.qfRounds', 'qfRounds');
+
+      // Apply Priority sorting if requested
+      if (qfRoundsSortBy === 'priority') {
+        query = query
+          .addOrderBy('qfRounds.priority', 'DESC')
+          .addOrderBy('qfRounds.endDate', 'ASC');
+      }
     }
     if (fields.projectFuturePower) {
       query = query.leftJoinAndSelect(

--- a/src/resolvers/qfRoundResolver.test.ts
+++ b/src/resolvers/qfRoundResolver.test.ts
@@ -945,6 +945,7 @@ function qfRoundsPrioritySortingTestCases() {
   beforeEach(async () => {
     // Clear QF round references from donations and delete all QF rounds
     await QfRound.query('UPDATE donation SET "qfRoundId" = NULL');
+    await QfRound.query('DELETE FROM qf_round_history');
     await QfRound.query('DELETE FROM project_qf_rounds_qf_round');
     await QfRound.query('DELETE FROM qf_round');
 

--- a/src/resolvers/qfRoundResolver.test.ts
+++ b/src/resolvers/qfRoundResolver.test.ts
@@ -21,6 +21,7 @@ import {
   qfRoundStatsQuery,
   scoreUserAddressMutation,
   qfRoundSmartSelectQuery,
+  qfRoundsQuery,
 } from '../../test/graphqlQueries';
 import { generateRandomString } from '../utils/utils';
 import { OrderDirection } from './projectResolver';
@@ -31,6 +32,10 @@ describe('Fetch qfRoundStats test cases', fetchQfRoundStatesTestCases);
 describe('Fetch archivedQFRounds test cases', fetchArchivedQFRoundsTestCases);
 describe('update scoreUserAddress test cases', scoreUserAddressTestCases);
 describe('QF Round Smart Select test cases', qfRoundSmartSelectTestCases);
+describe(
+  'QF Rounds Priority Sorting test cases',
+  qfRoundsPrioritySortingTestCases,
+);
 
 function scoreUserAddressTestCases() {
   it('should score the address with new model mocks score', async () => {
@@ -929,5 +934,229 @@ function qfRoundSmartSelectTestCases() {
     ); // 100 + 200 + 50
     assert.equal(result.data.data.qfRoundSmartSelect.uniqueDonors, 2); // 2 unique users
     assert.equal(result.data.data.qfRoundSmartSelect.donationsCount, 3); // 3 donations
+  });
+}
+
+function qfRoundsPrioritySortingTestCases() {
+  let qfRound1: QfRound;
+  let qfRound2: QfRound;
+  let qfRound3: QfRound;
+
+  beforeEach(async () => {
+    // Clear QF round references from donations and delete all QF rounds
+    await QfRound.query('UPDATE donation SET "qfRoundId" = NULL');
+    await QfRound.query('DELETE FROM project_qf_rounds_qf_round');
+    await QfRound.query('DELETE FROM qf_round');
+
+    // Create test qfRounds with different priorities and end dates
+    const now = new Date();
+    qfRound1 = QfRound.create({
+      isActive: false,
+      name: 'Round 1',
+      slug: generateRandomString(10),
+      allocatedFund: 1000,
+      minimumPassportScore: 8,
+      beginDate: now,
+      endDate: new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000), // 5 days from now
+      priority: 3,
+    });
+    await qfRound1.save();
+
+    qfRound2 = QfRound.create({
+      isActive: false,
+      name: 'Round 2',
+      slug: generateRandomString(10),
+      allocatedFund: 2000,
+      minimumPassportScore: 8,
+      beginDate: now,
+      endDate: new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000), // 3 days from now
+      priority: 5,
+    });
+    await qfRound2.save();
+
+    qfRound3 = QfRound.create({
+      isActive: false,
+      name: 'Round 3',
+      slug: generateRandomString(10),
+      allocatedFund: 3000,
+      minimumPassportScore: 8,
+      beginDate: now,
+      endDate: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000), // 7 days from now
+      priority: 5, // Same priority as qfRound2
+    });
+    await qfRound3.save();
+  });
+
+  afterEach(async () => {
+    // Clean up the test QF rounds
+    if (qfRound1) {
+      await QfRound.delete({ id: qfRound1.id });
+    }
+    if (qfRound2) {
+      await QfRound.delete({ id: qfRound2.id });
+    }
+    if (qfRound3) {
+      await QfRound.delete({ id: qfRound3.id });
+    }
+  });
+
+  it('should return qfRounds sorted by priority when sortBy is priority', async () => {
+    // Test Priority sorting
+    const result = await axios.post(graphqlUrl, {
+      query: qfRoundsQuery,
+      variables: {
+        sortBy: 'priority',
+      },
+    });
+
+    assert.isArray(result.data.data.qfRounds);
+    assert.equal(result.data.data.qfRounds.length, 3);
+
+    // Should be sorted by priority DESC, then by endDate ASC
+    // qfRound2 and qfRound3 have priority 5, qfRound1 has priority 3
+    // Among priority 5, qfRound2 should come first (endDate is closer)
+    assert.equal(result.data.data.qfRounds[0].id, qfRound2.id); // priority 5, endDate closest
+    assert.equal(result.data.data.qfRounds[1].id, qfRound3.id); // priority 5, endDate further
+    assert.equal(result.data.data.qfRounds[2].id, qfRound1.id); // priority 3
+  });
+
+  it('should return qfRounds sorted by id DESC when no sortBy is provided', async () => {
+    // Test default sorting (by id DESC)
+    const result = await axios.post(graphqlUrl, {
+      query: qfRoundsQuery,
+      variables: {},
+    });
+
+    assert.isArray(result.data.data.qfRounds);
+    assert.equal(result.data.data.qfRounds.length, 3);
+
+    // Should be sorted by id DESC (newest first)
+    assert.equal(result.data.data.qfRounds[0].id, qfRound3.id); // Latest created
+    assert.equal(result.data.data.qfRounds[1].id, qfRound2.id);
+    assert.equal(result.data.data.qfRounds[2].id, qfRound1.id); // Oldest created
+  });
+
+  it('should return qfRounds sorted by id DESC when sortBy is roundId', async () => {
+    // Test explicit roundId sorting (same as default)
+    const result = await axios.post(graphqlUrl, {
+      query: qfRoundsQuery,
+      variables: {
+        sortBy: 'roundId',
+      },
+    });
+
+    assert.isArray(result.data.data.qfRounds);
+    assert.equal(result.data.data.qfRounds.length, 3);
+
+    // Should be sorted by id DESC (newest first)
+    assert.equal(result.data.data.qfRounds[0].id, qfRound3.id); // Latest created
+    assert.equal(result.data.data.qfRounds[1].id, qfRound2.id);
+    assert.equal(result.data.data.qfRounds[2].id, qfRound1.id); // Oldest created
+  });
+
+  it('should handle qfRounds with same priority and same endDate', async () => {
+    // Create additional qfRounds with same priority and endDate
+    const now = new Date();
+    const sameEndDate = new Date(now.getTime() + 4 * 24 * 60 * 60 * 1000); // 4 days from now
+
+    const qfRound4 = QfRound.create({
+      isActive: false,
+      name: 'Round 4',
+      slug: generateRandomString(10),
+      allocatedFund: 4000,
+      minimumPassportScore: 8,
+      beginDate: now,
+      endDate: sameEndDate,
+      priority: 5, // Same priority as qfRound2 and qfRound3
+    });
+    await qfRound4.save();
+
+    const qfRound5 = QfRound.create({
+      isActive: false,
+      name: 'Round 5',
+      slug: generateRandomString(10),
+      allocatedFund: 5000,
+      minimumPassportScore: 8,
+      beginDate: now,
+      endDate: sameEndDate, // Same endDate as qfRound4
+      priority: 5, // Same priority
+    });
+    await qfRound5.save();
+
+    try {
+      const result = await axios.post(graphqlUrl, {
+        query: qfRoundsQuery,
+        variables: {
+          sortBy: 'priority',
+        },
+      });
+
+      assert.isArray(result.data.data.qfRounds);
+      assert.equal(result.data.data.qfRounds.length, 5);
+
+      // Should be sorted by priority DESC, then by endDate ASC
+      // All priority 5 rounds should come before priority 3
+      const priority5Rounds = result.data.data.qfRounds.slice(0, 4);
+      const priority3Rounds = result.data.data.qfRounds.slice(4);
+
+      // All priority 5 rounds should have priority 5
+      priority5Rounds.forEach(round => {
+        assert.equal(round.priority, 5);
+      });
+
+      // Priority 3 rounds should have priority 3
+      priority3Rounds.forEach(round => {
+        assert.equal(round.priority, 3);
+      });
+
+      // Among priority 5 rounds, should be sorted by endDate ASC
+      // qfRound2 (3 days), qfRound4 (4 days), qfRound5 (4 days), qfRound3 (7 days)
+      assert.equal(result.data.data.qfRounds[0].id, qfRound2.id.toString()); // 3 days
+      // qfRound4 and qfRound5 have same endDate, so order is not guaranteed
+      const remainingPriority5 = result.data.data.qfRounds.slice(1, 4);
+      const remainingIds = remainingPriority5.map(r => r.id);
+      assert.include(remainingIds, qfRound4.id.toString());
+      assert.include(remainingIds, qfRound5.id.toString());
+      assert.include(remainingIds, qfRound3.id.toString());
+    } finally {
+      // Clean up additional QF rounds
+      await QfRound.delete({ id: qfRound4.id });
+      await QfRound.delete({ id: qfRound5.id });
+    }
+  });
+
+  it('should handle qfRounds with null priority values', async () => {
+    // Create qfRound with null priority
+    const qfRoundNullPriority = QfRound.create({
+      name: 'Round Null Priority',
+      slug: generateRandomString(10),
+      allocatedFund: 6000,
+      minimumPassportScore: 8,
+      beginDate: new Date(),
+      endDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000), // 2 days from now
+      priority: 0, // Use 0 instead of null for lowest priority
+    });
+    await qfRoundNullPriority.save();
+
+    try {
+      const result = await axios.post(graphqlUrl, {
+        query: qfRoundsQuery,
+        variables: {
+          sortBy: 'priority',
+        },
+      });
+
+      assert.isArray(result.data.data.qfRounds);
+      assert.equal(result.data.data.qfRounds.length, 4); // 3 existing + 1 new
+
+      // Priority 0 should be treated as lowest priority
+      // Should come after all higher priority rounds
+      const lastRound =
+        result.data.data.qfRounds[result.data.data.qfRounds.length - 1];
+      assert.equal(lastRound.id, qfRoundNullPriority.id.toString());
+    } finally {
+      // Clean up additional QF round
+      await QfRound.delete({ id: qfRoundNullPriority.id });
+    }
   });
 }

--- a/src/resolvers/qfRoundResolver.ts
+++ b/src/resolvers/qfRoundResolver.ts
@@ -8,6 +8,7 @@ import {
   ObjectType,
   Query,
   Resolver,
+  registerEnumType,
 } from 'type-graphql';
 import { Service } from 'typedi';
 import { Max, Min } from 'class-validator';
@@ -25,6 +26,15 @@ import {
 } from '../repositories/qfRoundRepository';
 import { QfRound } from '../entities/qfRound';
 import { OrderDirection } from './projectResolver';
+
+export enum QfRoundsSortType {
+  roundId = 'roundId',
+  priority = 'priority',
+}
+
+registerEnumType(QfRoundsSortType, {
+  name: 'QfRoundsSortType',
+});
 import { getGitcoinAdapter } from '../adapters/adaptersFactory';
 import { logger } from '../utils/logger';
 import { i18n, translationErrorMessagesKeys } from '../utils/errorMessages';
@@ -130,6 +140,12 @@ export class QfRoundsArgs {
 
   @Field(_type => Boolean, { nullable: true })
   activeOnly?: boolean;
+
+  @Field(_type => QfRoundsSortType, {
+    nullable: true,
+    defaultValue: QfRoundsSortType.roundId,
+  })
+  sortBy?: QfRoundsSortType;
 }
 
 @Resolver(_of => User)
@@ -137,13 +153,13 @@ export class QfRoundResolver {
   @Query(_returns => [QfRound], { nullable: true })
   async qfRounds(
     @Args()
-    { slug, activeOnly }: QfRoundsArgs,
+    { slug, activeOnly, sortBy }: QfRoundsArgs,
   ) {
     if (activeOnly) {
       const activeQfRound = await findActiveQfRound();
       return activeQfRound ? [activeQfRound] : [];
     }
-    return findQfRounds({ slug });
+    return findQfRounds({ slug, sortBy });
   }
 
   @Query(_returns => [QFArchivedRounds], { nullable: true })

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -47,6 +47,26 @@ export const scoreUserAddressMutation = `
   }
 `;
 
+export const qfRoundsQuery = `
+  query (
+    $slug: String
+    $activeOnly: Boolean
+    $sortBy: QfRoundsSortType
+  ) {
+    qfRounds(
+      slug: $slug
+      activeOnly: $activeOnly
+      sortBy: $sortBy
+    ) {
+      id
+      name
+      priority
+      endDate
+      isActive
+    }
+  }
+`;
+
 export const createDraftDonationMutation = `
   mutation (
     $networkId: Float!
@@ -1164,9 +1184,11 @@ export const getQfRoundHistoryQuery = `
 export const fetchProjectBySlugQuery = `
   query (
     $slug: String!
+    $qfRoundsSortBy: String
   ) {
     projectBySlug(
       slug: $slug
+      qfRoundsSortBy: $qfRoundsSortBy
     ) {
       id
       title
@@ -1235,6 +1257,8 @@ export const fetchProjectBySlugQuery = `
       qfRounds {
         id
         name
+        priority
+        endDate
         isActive
       }
       status {
@@ -1748,10 +1772,14 @@ export const projectByIdQuery = `
   query(
       $id: Float!,
       $connectedWalletUserId: Int,
+      $userRemoved: Boolean,
+      $qfRoundsSortBy: String
   ){
     projectById(
      id:$id,
-     connectedWalletUserId: $connectedWalletUserId){
+     connectedWalletUserId: $connectedWalletUserId,
+     userRemoved: $userRemoved,
+     qfRoundsSortBy: $qfRoundsSortBy){
       id
       slug,
       verified
@@ -1792,6 +1820,13 @@ export const projectByIdQuery = `
           banner
           description
         }
+      }
+      qfRounds {
+        id
+        name
+        priority
+        endDate
+        isActive
       }
       adminUser {
         firstName


### PR DESCRIPTION
- Added sorting functionality to the `findQfRounds` method, allowing results to be sorted by priority or by ID.
- Updated the GraphQL schema to include a `sortBy` argument for the `qfRounds` query.
- Created comprehensive test cases for QF Rounds sorting, ensuring correct behavior for various sorting scenarios, including handling of same priority and end dates.
- Enhanced project resolver to support sorting of associated QF Rounds by priority when queried.

related to: #2145 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optional QF rounds sorting: by priority (highest first; tie-breaker by end date) or by newest first.
  - Project queries accept a sort parameter for associated QF rounds.
  - QF rounds responses now include priority and end date.
  - New query to fetch QF rounds with sorting support.

- **Tests**
  - Comprehensive tests added validating sorting, filtering, edge cases, and resolver behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->