### PR TITLE
QF Multi: adding roundId to the draft donation and fixing stellar round pick up

### DIFF
--- a/migration/1757668523311-addMigrationRoundIdDraftDonations.ts
+++ b/migration/1757668523311-addMigrationRoundIdDraftDonations.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMigrationRoundIdDraftDonations1757668523311
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE draft_donation
+      ADD COLUMN IF NOT EXISTS "qfRoundId" integer;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE draft_donation
+      DROP COLUMN IF EXISTS "qfRoundId";
+    `);
+  }
+}

--- a/src/entities/draftDonation.ts
+++ b/src/entities/draftDonation.ts
@@ -139,4 +139,8 @@ export class DraftDonation extends BaseEntity {
   @Field(_type => Date)
   @Column({ nullable: true })
   expiresAt?: Date;
+
+  @Field({ nullable: true })
+  @Column({ nullable: true })
+  qfRoundId?: number;
 }

--- a/src/resolvers/donationResolver.test.ts
+++ b/src/resolvers/donationResolver.test.ts
@@ -3521,6 +3521,10 @@ function createDonationTestCases() {
       isActive: true,
     }).save();
 
+    // Add project to QF round
+    project.qfRounds = [qfRound];
+    await project.save();
+
     // Clear all draft donations
     await DraftDonation.clear();
 

--- a/src/resolvers/donationResolver.test.ts
+++ b/src/resolvers/donationResolver.test.ts
@@ -3503,10 +3503,18 @@ function createDonationTestCases() {
   });
 
   it('should create donation with correct QF round when roundId is provided and project is in QF round', async () => {
-    const project = await saveProjectDirectlyToDb(createProjectData());
-    const user = await User.findOne({
+    const firstUser = await User.findOne({
       where: { id: SEED_DATA.FIRST_USER.id },
     });
+    const project = await saveProjectDirectlyToDb(
+      createProjectData(),
+      firstUser!,
+    );
+    const user = await User.create({
+      walletAddress: generateRandomEtheriumAddress(),
+      loginType: 'wallet',
+      firstName: 'first name',
+    }).save();
 
     // Create a QF round for testing
     const qfRound = await QfRound.create({

--- a/src/resolvers/donationResolver.test.ts
+++ b/src/resolvers/donationResolver.test.ts
@@ -3504,11 +3504,9 @@ function createDonationTestCases() {
 
   it('should create donation with correct QF round when roundId is provided and project is in QF round', async () => {
     const project = await saveProjectDirectlyToDb(createProjectData());
-    const user = await User.create({
-      walletAddress: generateRandomEtheriumAddress(),
-      loginType: 'wallet',
-      firstName: 'first name',
-    }).save();
+    const user = await User.findOne({
+      where: { id: SEED_DATA.FIRST_USER.id },
+    });
 
     // Create a QF round for testing
     const qfRound = await QfRound.create({
@@ -3525,7 +3523,7 @@ function createDonationTestCases() {
     project.qfRounds = [qfRound];
     await project.save();
 
-    const accessToken = await generateTestAccessToken(user.id);
+    const accessToken = await generateTestAccessToken(user!.id);
 
     // Test the normal donation creation with roundId parameter
     // This verifies that when roundId is passed, it gets assigned correctly

--- a/src/resolvers/donationResolver.test.ts
+++ b/src/resolvers/donationResolver.test.ts
@@ -3560,12 +3560,13 @@ function createDonationTestCases() {
     assert.isOk(saveDonationResponse.data.data.createDonation);
 
     // Verify the created donation has the correct QF round
+    const donationId = saveDonationResponse.data.data.createDonation;
+
     const createdDonation = await Donation.findOne({
-      where: {
-        id: saveDonationResponse.data.data.createDonation,
-      },
-      relations: ['qfRound'],
+      where: { id: donationId },
+      relations: ['qfRoundId'],
     });
+
     assert.equal(createdDonation?.qfRoundId, qfRound.id);
 
     // Clean up

--- a/src/resolvers/donationResolver.test.ts
+++ b/src/resolvers/donationResolver.test.ts
@@ -3564,7 +3564,7 @@ function createDonationTestCases() {
 
     const createdDonation = await Donation.findOne({
       where: { id: donationId },
-      relations: ['qfRoundId'],
+      relations: ['qfRound'],
     });
 
     assert.equal(createdDonation?.qfRoundId, qfRound.id);

--- a/src/resolvers/donationResolver.test.ts
+++ b/src/resolvers/donationResolver.test.ts
@@ -3513,7 +3513,7 @@ function createDonationTestCases() {
     // Create a QF round for testing
     const qfRound = await QfRound.create({
       name: 'Test QF Round for Draft Matching',
-      slug: 'test-qf-round-draft-matching',
+      slug: `test-qf-round-draft-matching-${Date.now()}`,
       allocatedFund: 1000,
       minimumPassportScore: 8,
       beginDate: new Date('2021-09-01'),

--- a/src/resolvers/donationResolver.test.ts
+++ b/src/resolvers/donationResolver.test.ts
@@ -3564,7 +3564,6 @@ function createDonationTestCases() {
 
     const createdDonation = await Donation.findOne({
       where: { id: donationId },
-      relations: ['qfRound'],
     });
 
     assert.equal(createdDonation?.qfRoundId, qfRound.id);

--- a/src/resolvers/draftDonationResolver.test.ts
+++ b/src/resolvers/draftDonationResolver.test.ts
@@ -165,7 +165,7 @@ function createDraftDonationTestCases() {
     // Create a QF round for testing
     const qfRound = await QfRound.create({
       name: 'Test QF Round',
-      slug: 'test-qf-round',
+      slug: `test-qf-round-${Date.now()}`,
       allocatedFund: 1000,
       minimumPassportScore: 8,
       beginDate: new Date('2021-09-01'),

--- a/src/resolvers/draftDonationResolver.test.ts
+++ b/src/resolvers/draftDonationResolver.test.ts
@@ -173,6 +173,10 @@ function createDraftDonationTestCases() {
       isActive: true,
     }).save();
 
+    // Add project to QF round
+    project.qfRounds = [qfRound];
+    await project.save();
+
     const donationDataWithRoundId = {
       ...donationData,
       roundId: qfRound.id,

--- a/src/resolvers/draftDonationResolver.ts
+++ b/src/resolvers/draftDonationResolver.ts
@@ -64,6 +64,7 @@ export class DraftDonationResolver {
     @Arg('isQRDonation', { nullable: true, defaultValue: false })
     isQRDonation?: boolean,
     @Arg('fromTokenAmount', { nullable: true }) fromTokenAmount?: number,
+    @Arg('roundId', { nullable: true }) roundId?: number,
   ): Promise<number> {
     const logData = {
       amount,
@@ -74,6 +75,7 @@ export class DraftDonationResolver {
       projectId,
       referrerId,
       toWalletMemo,
+      roundId,
       userId: ctx?.req?.user?.userId,
     };
     logger.debug(
@@ -140,6 +142,7 @@ export class DraftDonationResolver {
         qrCodeDataUrl,
         isQRDonation,
         fromTokenAmount,
+        roundId,
       };
       try {
         validateWithJoiSchema(
@@ -203,6 +206,7 @@ export class DraftDonationResolver {
           qrCodeDataUrl,
           isQRDonation,
           expiresAt,
+          qfRoundId: roundId,
           createdAt: new Date(),
         })
         .orIgnore()

--- a/src/services/chains/evm/draftDonationService.ts
+++ b/src/services/chains/evm/draftDonationService.ts
@@ -265,6 +265,7 @@ async function submitMatchedDraftDonation(
     currency,
     projectId,
     referrerId,
+    qfRoundId,
   } = draftDonation;
 
   try {
@@ -291,6 +292,7 @@ async function submitMatchedDraftDonation(
       undefined, // relevantDonationTxHash
       undefined, // swapData
       draftDonation.fromTokenAmount, // fromTokenAmount
+      qfRoundId, // roundId
     );
 
     await Donation.update(Number(donationId), {

--- a/src/utils/validators/graphqlQueryValidators.ts
+++ b/src/utils/validators/graphqlQueryValidators.ts
@@ -250,6 +250,7 @@ export const createDraftDonationQueryValidator = Joi.object({
   qrCodeDataUrl: Joi.string().allow(null, '').pattern(dateURLRegex),
   isQRDonation: Joi.boolean(),
   fromTokenAmount: Joi.number().greater(0).allow(null),
+  roundId: Joi.number().integer().min(1).allow(null),
 });
 
 export const createDraftRecurringDonationQueryValidator = Joi.object({

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -83,6 +83,7 @@ export const createDraftDonationMutation = `
     $toWalletMemo: String
     $qrCodeDataUrl: String
     $isQRDonation: Boolean
+    $roundId: Float
   ) {
     createDraftDonation(
       networkId: $networkId
@@ -99,6 +100,7 @@ export const createDraftDonationMutation = `
       toWalletMemo: $toWalletMemo
       qrCodeDataUrl: $qrCodeDataUrl
       isQRDonation: $isQRDonation
+      roundId: $roundId
     )
   }
 `;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Draft donations can include an optional QF round ID; it’s validated, stored, exposed via GraphQL, and honored during final donation creation (draft-specified round takes precedence over auto-selection).

* **Tests**
  * Added tests verifying roundId is saved on draft creation and propagated to the resulting donation (includes an extra duplicated test block).

* **Chores**
  * Database migration adds a nullable qfRoundId column for draft donations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->