### PR TITLE
QF Multi: fix getting active rounds, history rounds

### DIFF
--- a/src/repositories/qfRoundRepository.ts
+++ b/src/repositories/qfRoundRepository.ts
@@ -70,6 +70,9 @@ export class QFArchivedRounds {
   @Field(_type => String, { nullable: true })
   name: string;
 
+  @Field(_type => String, { nullable: true })
+  description: string;
+
   @Field(_type => String)
   slug: string;
 
@@ -102,6 +105,15 @@ export class QFArchivedRounds {
 
   @Field(_type => Boolean)
   isDataAnalysisDone: boolean;
+
+  @Field(_type => String, { nullable: true })
+  bannerBgImage: string;
+
+  @Field(_type => String, { nullable: true })
+  bannerFull: string;
+
+  @Field(_type => String, { nullable: true })
+  bannerMobile: string;
 }
 
 export const findArchivedQfRounds = async (
@@ -123,6 +135,7 @@ export const findArchivedQfRounds = async (
     .select('qfRound.id', 'id')
     .addSelect('qfRound.name', 'name')
     .addSelect('qfRound.slug', 'slug')
+    .addSelect('qfRound.description', 'description')
     .addSelect('qfRound.isActive', 'isActive')
     .addSelect('qfRound.endDate', 'endDate')
     .addSelect('qfRound.eligibleNetworks', 'eligibleNetworks')
@@ -131,6 +144,9 @@ export const findArchivedQfRounds = async (
     .addSelect('qfRound.allocatedFundUSD', 'allocatedFundUSD')
     .addSelect('qfRound.allocatedTokenSymbol', 'allocatedTokenSymbol')
     .addSelect('qfRound.beginDate', 'beginDate')
+    .addSelect('qfRound.bannerBgImage', 'bannerBgImage')
+    .addSelect('qfRound.bannerFull', 'bannerFull')
+    .addSelect('qfRound.bannerMobile', 'bannerMobile')
     .addSelect(
       qb =>
         qb
@@ -184,6 +200,17 @@ export const findActiveQfRound = async (
     return query.getOne();
   }
   return query.cache('findActiveQfRound', qfRoundsCacheDuration).getOne();
+};
+
+export const findActiveQfRounds = async (
+  noCache?: boolean,
+): Promise<QfRound[] | null> => {
+  const query =
+    QfRound.createQueryBuilder('qfRound').where('"isActive" = true');
+  if (noCache) {
+    return query.getMany();
+  }
+  return query.cache('findActiveQfRound', qfRoundsCacheDuration).getMany();
 };
 
 export const findUsersWithoutMBDScoreInActiveAround = async (): Promise<

--- a/src/resolvers/qfRoundResolver.ts
+++ b/src/resolvers/qfRoundResolver.ts
@@ -23,6 +23,7 @@ import {
   QfArchivedRoundsSortType,
   getQfRoundStats,
   getQfRoundTotalSqrtRootSumSquared,
+  findActiveQfRounds,
 } from '../repositories/qfRoundRepository';
 import { QfRound } from '../entities/qfRound';
 import { OrderDirection } from './projectResolver';
@@ -156,8 +157,8 @@ export class QfRoundResolver {
     { slug, activeOnly, sortBy }: QfRoundsArgs,
   ) {
     if (activeOnly) {
-      const activeQfRound = await findActiveQfRound();
-      return activeQfRound ? [activeQfRound] : [];
+      const activeQfRounds = await findActiveQfRounds();
+      return activeQfRounds ? activeQfRounds : [];
     }
     return findQfRounds({ slug, sortBy });
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Archived rounds now display a description and banner images (background, full, and mobile).
  * The “Active” filter now returns all active rounds instead of a single round.

* Improvements
  * Faster loading and more reliable results when viewing active rounds due to enhanced caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->