### PR TITLE
Fix the bug on create donation mutation

### DIFF
--- a/src/entities/draftDonation.ts
+++ b/src/entities/draftDonation.ts
@@ -7,7 +7,6 @@ import {
   Index,
   CreateDateColumn,
   ManyToOne,
-  RelationId,
   JoinColumn,
 } from 'typeorm';
 import { ChainType } from '../types/network';
@@ -151,6 +150,6 @@ export class DraftDonation extends BaseEntity {
   qfRound?: QfRound;
 
   @Field({ nullable: true })
-  @RelationId((draftDonation: DraftDonation) => draftDonation.qfRound)
+  @Column({ nullable: true })
   qfRoundId?: number;
 }

--- a/src/resolvers/draftDonationResolver.test.ts
+++ b/src/resolvers/draftDonationResolver.test.ts
@@ -388,9 +388,23 @@ function createDraftDonationTestCases() {
     assert.equal(createdDonation?.amount, donationData.amount);
     assert.equal(createdDonation?.currency, donationData.token);
 
-    // Clean up
-    qfRound.isActive = false;
-    await qfRound.save();
+    // Clean up - delete all created data
+    if (createdDonation) {
+      await Donation.remove(createdDonation);
+    }
+
+    if (draftDonation) {
+      await DraftDonation.remove(draftDonation);
+    }
+
+    // Remove project from QF round
+    await ProjectQfRound.delete({
+      projectId: project.id,
+      qfRoundId: qfRound.id,
+    });
+
+    // Delete the QF round
+    await QfRound.remove(qfRound);
   });
 }
 

--- a/src/resolvers/draftDonationResolver.ts
+++ b/src/resolvers/draftDonationResolver.ts
@@ -245,7 +245,7 @@ export class DraftDonationResolver {
           isQRDonation,
           expiresAt,
           createdAt: new Date(),
-          qfRound: qfRound ?? undefined,
+          qfRoundId: qfRound?.id,
         })
         .orIgnore()
         .returning('id')

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -83,6 +83,7 @@ export const createDraftDonationMutation = `
     $toWalletMemo: String
     $qrCodeDataUrl: String
     $isQRDonation: Boolean
+    $fromTokenAmount: Float
     $roundId: Float
   ) {
     createDraftDonation(
@@ -100,6 +101,7 @@ export const createDraftDonationMutation = `
       toWalletMemo: $toWalletMemo
       qrCodeDataUrl: $qrCodeDataUrl
       isQRDonation: $isQRDonation
+      fromTokenAmount: $fromTokenAmount
       roundId: $roundId
     )
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Draft donation mutation accepts an optional fromTokenAmount input.

- Bug Fixes
  - Creating a donation from a draft now reliably preserves the associated QF round, amount, and currency.

- Refactor
  - Draft donations now persist the QF round as a nullable foreign-key value to improve consistency.

- Tests
  - Added test coverage for creating a donation from a draft with a QF round ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->