### PR TITLE
Change projectId to id in the qfProjects query

### DIFF
--- a/src/resolvers/projectResolver.test.ts
+++ b/src/resolvers/projectResolver.test.ts
@@ -6232,10 +6232,7 @@ function qfProjectsTestCases() {
     assert.isOk(result.data.data.qfProjects);
     assert.equal(result.data.data.qfProjects.totalCount, 1);
     assert.equal(result.data.data.qfProjects.projects.length, 1);
-    assert.equal(
-      result.data.data.qfProjects.projects[0].projectId,
-      activeProject.id,
-    );
+    assert.equal(result.data.data.qfProjects.projects[0].id, activeProject.id);
 
     // Cleanup
     await removeProjectAndRelatedEntities(activeProject.id);

--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -180,7 +180,7 @@ class QfRoundStats {
 @ObjectType()
 class QfProject {
   @Field(_type => ID)
-  projectId: number;
+  id: number;
 
   @Field()
   title: string;
@@ -2624,7 +2624,7 @@ export class ProjectResolver {
           : undefined;
 
         return {
-          projectId: project.id,
+          id: project.id,
           title: project.title,
           descriptionSummary: project.descriptionSummary,
           description: project.description,

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -1865,7 +1865,7 @@ export const qfProjectsQuery = `
   query($qfRoundId: Int!, $skip: Int, $limit: Int, $searchTerm: String, $filters: [FilterField!], $sortingBy: SortingField) {
     qfProjects(qfRoundId: $qfRoundId, skip: $skip, limit: $limit, searchTerm: $searchTerm, filters: $filters, sortingBy: $sortingBy) {
       projects {
-        projectId
+        id
         title
         descriptionSummary
         description


### PR DESCRIPTION
related to: #2152 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - The project identifier field in the qfProjects GraphQL response has been renamed from projectId to id. Update any client queries or integrations that consume this field.
- Tests
  - Test queries and assertions have been updated to reference id instead of projectId.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->