### PR TITLE
Add activeOnly filter to project queries

### DIFF
--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -1015,6 +1015,8 @@ export class ProjectResolver {
     userRemoved?: boolean,
     @Arg('qfRoundsSortBy', _type => String, { nullable: true })
     qfRoundsSortBy?: string,
+    @Arg('activeOnly', _type => Boolean, { nullable: true })
+    activeOnly?: boolean,
   ) {
     const fields = graphqlFields(info);
 
@@ -1078,6 +1080,13 @@ export class ProjectResolver {
     if (fields.qfRounds) {
       query = query.leftJoinAndSelect('project.qfRounds', 'qfRounds');
 
+      // Apply activeOnly filtering if requested
+      if (activeOnly) {
+        query = query.andWhere('qfRounds.isActive = :isActive', {
+          isActive: true,
+        });
+      }
+
       // Apply Priority sorting if requested
       if (qfRoundsSortBy === 'priority') {
         query = query
@@ -1120,6 +1129,8 @@ export class ProjectResolver {
     userRemoved?: boolean,
     @Arg('qfRoundsSortBy', _type => String, { nullable: true })
     qfRoundsSortBy?: string,
+    @Arg('activeOnly', _type => Boolean, { nullable: true })
+    activeOnly?: boolean,
   ) {
     const minimalProject = await findProjectIdBySlug(slug);
     if (!minimalProject) {
@@ -1186,6 +1197,13 @@ export class ProjectResolver {
     }
     if (fields.qfRounds) {
       query = query.leftJoinAndSelect('project.qfRounds', 'qfRounds');
+
+      // Apply activeOnly filtering if requested
+      if (activeOnly) {
+        query = query.andWhere('qfRounds.isActive = :isActive', {
+          isActive: true,
+        });
+      }
 
       // Apply Priority sorting if requested
       if (qfRoundsSortBy === 'priority') {

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -1189,10 +1189,12 @@ export const fetchProjectBySlugQuery = `
   query (
     $slug: String!
     $qfRoundsSortBy: String
+    $activeOnly: Boolean
   ) {
     projectBySlug(
       slug: $slug
       qfRoundsSortBy: $qfRoundsSortBy
+      activeOnly: $activeOnly
     ) {
       id
       title
@@ -1777,13 +1779,15 @@ export const projectByIdQuery = `
       $id: Float!,
       $connectedWalletUserId: Int,
       $userRemoved: Boolean,
-      $qfRoundsSortBy: String
+      $qfRoundsSortBy: String,
+      $activeOnly: Boolean
   ){
     projectById(
      id:$id,
      connectedWalletUserId: $connectedWalletUserId,
      userRemoved: $userRemoved,
-     qfRoundsSortBy: $qfRoundsSortBy){
+     qfRoundsSortBy: $qfRoundsSortBy,
+     activeOnly: $activeOnly){
       id
       slug,
       verified


### PR DESCRIPTION
related to: #2147 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Project GraphQL queries now support an optional activeOnly filter to return only active QF rounds when requested. Default behavior remains unchanged if not provided.

- Tests
  - Added test coverage validating activeOnly filtering for both project-by-ID and project-by-slug queries, ensuring correct results for active and mixed-round scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->