### PR TITLE
QF Multi: fix returning round for project by slug and id

### DIFF
--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -1078,13 +1078,17 @@ export class ProjectResolver {
       );
     }
     if (fields.qfRounds) {
-      query = query.leftJoinAndSelect('project.qfRounds', 'qfRounds');
-
-      // Apply activeOnly filtering if requested
       if (activeOnly) {
-        query = query.andWhere('qfRounds.isActive = :isActive', {
-          isActive: true,
-        });
+        // Only join active QF rounds - project will still be returned with qfRounds: []
+        query = query.leftJoinAndSelect(
+          'project.qfRounds',
+          'qfRounds',
+          'qfRounds.isActive = :isActive',
+          { isActive: true },
+        );
+      } else {
+        // Join all QF rounds
+        query = query.leftJoinAndSelect('project.qfRounds', 'qfRounds');
       }
 
       // Apply Priority sorting if requested
@@ -1196,13 +1200,17 @@ export class ProjectResolver {
       );
     }
     if (fields.qfRounds) {
-      query = query.leftJoinAndSelect('project.qfRounds', 'qfRounds');
-
-      // Apply activeOnly filtering if requested
       if (activeOnly) {
-        query = query.andWhere('qfRounds.isActive = :isActive', {
-          isActive: true,
-        });
+        // Only join active QF rounds - project will still be returned with qfRounds: []
+        query = query.leftJoinAndSelect(
+          'project.qfRounds',
+          'qfRounds',
+          'qfRounds.isActive = :isActive',
+          { isActive: true },
+        );
+      } else {
+        // Join all QF rounds
+        query = query.leftJoinAndSelect('project.qfRounds', 'qfRounds');
       }
 
       // Apply Priority sorting if requested


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/5349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now request only active QF rounds for a project (by ID or slug); if none are active, the list may be empty.
  * QF rounds are included in responses only when explicitly requested, reducing unnecessary payloads.
  * Existing prioritization/sorting of QF rounds remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->