### PR TITLE
Add qf round stats to qf projects

### DIFF
--- a/src/resolvers/projectResolver.ts
+++ b/src/resolvers/projectResolver.ts
@@ -237,8 +237,8 @@ class QfProject {
   @Field(_type => [QfRound], { nullable: true })
   qfRounds?: QfRound[];
 
-  @Field(_type => [projectQfRoundRelations], { nullable: true })
-  projectQfRoundRelations?: projectQfRoundRelations[];
+  @Field(_type => projectQfRoundRelations, { nullable: true })
+  projectQfRoundRelations?: projectQfRoundRelations;
 }
 
 @ObjectType()
@@ -2784,12 +2784,18 @@ export class ProjectResolver {
 
       // Transform projects to QfProject format
       const qfProjects: QfProject[] = projects.map(project => {
-        const projectQfRoundRelations = project.projectQfRoundRelations?.map(
-          relation => ({
-            sumDonationValueUsd: relation.sumDonationValueUsd,
-            countUniqueDonors: relation.countUniqueDonors,
-          }),
+        // Find the matching QF round relation
+        const matchingRelation = project.projectQfRoundRelations?.find(
+          relation => relation.qfRoundId === qfRoundId,
         );
+
+        // Extract donation data if relation exists
+        const projectQfRoundRelations = matchingRelation
+          ? {
+              sumDonationValueUsd: matchingRelation.sumDonationValueUsd,
+              countUniqueDonors: matchingRelation.countUniqueDonors,
+            }
+          : undefined;
 
         return {
           id: project.id,

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -2019,10 +2019,9 @@ export const qfProjectsQuery = `
           slug
           isActive
         }
-        qfRoundStats {
-          roundId
-          totalRaisedInRound
-          totalDonorsInRound
+        projectQfRoundRelations {
+          sumDonationValueUsd
+          countUniqueDonors
         }
       }
       totalCount


### PR DESCRIPTION
related to: #2199 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced qfRoundStats with projectQfRoundRelations in GraphQL responses.
  * Exposes per-round metrics: sumDonationValueUsd and countUniqueDonors.
  * Removed totalRaisedInRound and totalDonorsInRound from queries.

* **Tests**
  * Expanded coverage for per-round metrics across multiple rounds, multiple/no donors, and activeOnly filtering.
  * Added test utilities and cleanup for per-project round relations.
  * Verified correct data shape and values across qfProjectsQuery and project detail queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->