### PR TITLE
add delete handler for projectQfRound middle table

### DIFF
--- a/src/server/adminJs/tabs/projectQfRoundsTab.ts
+++ b/src/server/adminJs/tabs/projectQfRoundsTab.ts
@@ -1,3 +1,4 @@
+import { RecordJSON } from 'adminjs/src/frontend/interfaces/record-json.interface';
 import { ProjectQfRound } from '../../../entities/projectQfRound';
 import {
   canAccessProjectQfRoundAction,
@@ -8,8 +9,6 @@ import {
   AdminJsContextInterface,
 } from '../adminJs-types';
 import { logger } from '../../../utils/logger';
-import { RecordJSON } from 'adminjs/src/frontend/interfaces/record-json.interface';
-import { getRedirectUrl } from '../adminJsUtils';
 
 const deleteProjectQfRound = async (
   request: AdminJsRequestInterface,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a delete action to the Project QF Rounds Admin tab, enabling admins to remove project-round associations with confirmation flow and automatic redirect after deletion.
- Bug Fixes
  - Improved deletion error handling to surface informative error notices on failure, avoiding silent failures and aiding troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->