### PR TITLE
Add id to projectQfRoundRelation table for deletion

### DIFF
--- a/migration/1779182511001-AddIdToProjectQfRound.ts
+++ b/migration/1779182511001-AddIdToProjectQfRound.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddIdToProjectQfRound1779182511001 implements MigrationInterface {
+  name = 'AddIdToProjectQfRound1779182511001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add the new id column as auto-incrementing column (not primary key)
+    await queryRunner.query(`
+      ALTER TABLE "project_qf_rounds_qf_round" 
+      ADD COLUMN "id" SERIAL
+    `);
+
+    // Add index on the id column for performance
+    await queryRunner.query(`
+      CREATE INDEX "IDX_project_qf_rounds_id" 
+      ON "project_qf_rounds_qf_round" ("id")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop the index first
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS "IDX_project_qf_rounds_id"
+    `);
+
+    // Drop the id column
+    await queryRunner.query(`
+      ALTER TABLE "project_qf_rounds_qf_round" 
+      DROP COLUMN IF EXISTS "id"
+    `);
+  }
+}

--- a/src/entities/projectQfRound.ts
+++ b/src/entities/projectQfRound.ts
@@ -1,12 +1,13 @@
 import { Field, ID, ObjectType, Float, Int } from 'type-graphql';
 import {
   PrimaryColumn,
+  Column,
   Entity,
   ManyToOne,
   BaseEntity,
   CreateDateColumn,
   UpdateDateColumn,
-  Column,
+  Index,
 } from 'typeorm';
 import { Project } from './project';
 import { QfRound } from './qfRound';
@@ -14,6 +15,11 @@ import { QfRound } from './qfRound';
 @Entity('project_qf_rounds_qf_round')
 @ObjectType()
 export class ProjectQfRound extends BaseEntity {
+  @Field(_type => ID)
+  @Column({ generated: 'increment' })
+  @Index()
+  id: number;
+
   @Field(_type => ID)
   @PrimaryColumn()
   projectId: number;

--- a/src/server/adminJs/tabs/projectQfRoundsTab.ts
+++ b/src/server/adminJs/tabs/projectQfRoundsTab.ts
@@ -29,30 +29,26 @@ const deleteProjectQfRound = async (
       adminUserId: currentAdmin.id,
     });
 
-    // Extract projectId and qfRoundId from record params
-    const projectId = record.params?.projectId;
-    const qfRoundId = record.params?.qfRoundId;
+    // Extract the id from record params
+    const id = record.params?.id;
 
     logger.info('Record data:', {
       recordId,
-      projectId,
-      qfRoundId,
+      id,
       allParams: record.params,
     });
 
-    if (!projectId || !qfRoundId) {
-      throw new Error('Missing projectId or qfRoundId in record params');
+    if (!id) {
+      throw new Error('Missing id in record params');
     }
 
-    // Delete using the composite primary key (projectId and qfRoundId)
+    // Delete using the new auto-incrementing primary key
     const deleteResult = await ProjectQfRound.delete({
-      projectId: projectId,
-      qfRoundId: qfRoundId,
+      id: id,
     });
 
     logger.info('ProjectQfRound deleted successfully:', {
-      projectId,
-      qfRoundId,
+      id,
       deleteResult,
       adminUserId: currentAdmin.id,
     });
@@ -140,6 +136,15 @@ export const projectQfRoundsTab = {
       },
     },
     properties: {
+      id: {
+        isVisible: {
+          list: true,
+          filter: true,
+          show: true,
+          edit: false,
+          new: false,
+        },
+      },
       projectId: {
         isVisible: {
           list: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Admin panel shows a read-only auto-generated ID for Project QF Rounds (visible in list, filter, show).

- Refactor
  - Admin operations and validations now use the single ID instead of the composite project/qf key, simplifying record handling and deletion.

- Chores
  - Database schema updated to add an auto-increment ID for Project QF Rounds; migration included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->