### PR TITLE
Add projectQfRounds query

### DIFF
--- a/src/resolvers/qfRoundResolver.ts
+++ b/src/resolvers/qfRoundResolver.ts
@@ -24,6 +24,7 @@ import {
   getQfRoundStats,
   getQfRoundTotalSqrtRootSumSquared,
   findActiveQfRound,
+  findProjectQfRounds,
 } from '../repositories/qfRoundRepository';
 import { QfRound } from '../entities/qfRound';
 import { OrderDirection } from './projectResolver';
@@ -281,6 +282,24 @@ export class QfRoundResolver {
         throw new Error(error.message);
       }
       logger.error('Error in qfRoundSmartSelect:', error);
+      throw error;
+    }
+  }
+
+  @Query(_returns => [QfRound], { nullable: true })
+  async projectQfRounds(
+    @Arg('projectId', _type => Int) projectId: number,
+    @Arg('activeOnly', _type => Boolean, { nullable: true })
+    activeOnly?: boolean,
+    @Arg('sortBy', _type => String, { nullable: true }) sortBy?: string,
+  ): Promise<QfRound[] | null> {
+    try {
+      return await findProjectQfRounds(projectId, {
+        activeOnly,
+        sortBy,
+      });
+    } catch (error) {
+      logger.error('Error in projectQfRounds query:', error);
       throw error;
     }
   }


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/5419
- https://github.com/Giveth/giveth-dapps-v2/issues/5382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a GraphQL API query to fetch a project’s QF rounds, with optional filtering for active rounds and sorting by priority or end date (default: end date). Results are returned in the specified order.

* Tests
  * Introduced test coverage to verify retrieval of a project’s QF rounds and correct ordering by priority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->