### PR TITLE
Add hub image to history round query

### DIFF
--- a/src/repositories/qfRoundRepository.ts
+++ b/src/repositories/qfRoundRepository.ts
@@ -117,6 +117,9 @@ export class QFArchivedRounds {
 
   @Field(_type => String, { nullable: true })
   bannerMobile: string;
+
+  @Field(_type => String, { nullable: true })
+  hubCardImage: string;
 }
 
 export const findArchivedQfRounds = async (


### PR DESCRIPTION
- https://github.com/Giveth/giveth-dapps-v2/issues/5443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hub card images in archived rounds, enabling richer visual content for historical funding rounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->