### PR TITLE
Fixing Eligible Network After QF Round Creation

### DIFF
--- a/src/server/adminJs/tabs/qfRoundTab.ts
+++ b/src/server/adminJs/tabs/qfRoundTab.ts
@@ -537,8 +537,24 @@ export const qfRoundTab = {
             await handleBannerMobile(request.payload);
             await handleHubCardImage(request.payload);
 
+            // Process array fields properly (AdminJS sometimes sends them as indexed properties even in NEW)
+            const processedPayload: any = {};
+
+            Object.keys(request.payload).forEach(key => {
+              // Handle eligibleNetworks array
+              if (key.startsWith('eligibleNetworks.')) {
+                if (!processedPayload.eligibleNetworks) {
+                  processedPayload.eligibleNetworks = [];
+                }
+                const index = parseInt(key.split('.')[1]);
+                processedPayload.eligibleNetworks[index] = request.payload[key];
+              } else {
+                processedPayload[key] = request.payload[key];
+              }
+            });
+
             // Create the record
-            const qfRound = QfRound.create(request.payload);
+            const qfRound = QfRound.create(processedPayload);
             record = await qfRound.save();
           } catch (error) {
             logger.error('Error creating QF Round:', error);


### PR DESCRIPTION
- https://github.com/Giveth/impact-graph/issues/2193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed QF Round admin form to properly save eligible networks and sponsor images when creating or updating rounds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->