### PR TITLE
fix giveconomy reverse sync backlog in impact-graph

### DIFF
--- a/src/repositories/powerBoostingRepository.test.ts
+++ b/src/repositories/powerBoostingRepository.test.ts
@@ -699,6 +699,31 @@ function setMultipleBoostingTestCases() {
       ),
     );
   });
+
+  it('should allow mirrored remote sync updates to exceed project limit', async () => {
+    const user = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+    const projects = await Promise.all(
+      Array.from({ length: 6 }, () =>
+        saveProjectDirectlyToDb(createProjectData()),
+      ),
+    );
+
+    const userBoostings = await setMultipleBoosting({
+      userId: user.id,
+      projectIds: projects.map(project => project.id),
+      percentages: [95, 1, 1, 1, 1, 1],
+      allowExceedProjectLimit: true,
+    });
+
+    assert.equal(userBoostings.length, 6);
+    projects.forEach(project => {
+      assert.isOk(
+        userBoostings.find(
+          powerBoosting => powerBoosting.project.id === project.id,
+        ),
+      );
+    });
+  });
 }
 
 function setSingleBoostingTestCases() {

--- a/src/repositories/powerBoostingRepository.ts
+++ b/src/repositories/powerBoostingRepository.ts
@@ -350,6 +350,7 @@ export const setMultipleBoosting = async (params: {
   percentages: number[];
   allowZeroTotal?: boolean;
   allowPartialTotal?: boolean;
+  allowExceedProjectLimit?: boolean;
   emitOutboxEvent?: boolean;
   beforeSave?: (context: BeforeSaveContext) => Promise<void>;
 }): Promise<PowerBoosting[]> => {
@@ -359,11 +360,15 @@ export const setMultipleBoosting = async (params: {
     percentages,
     allowZeroTotal = false,
     allowPartialTotal = false,
+    allowExceedProjectLimit = false,
     emitOutboxEvent = true,
     beforeSave,
   } = params;
 
-  if (percentages.length > MAX_PROJECT_BOOST_LIMIT) {
+  if (
+    !allowExceedProjectLimit &&
+    percentages.length > MAX_PROJECT_BOOST_LIMIT
+  ) {
     throw new Error(
       i18n.__(
         translationErrorMessagesKeys.ERROR_GIVPOWER_BOOSTING_MAX_PROJECT_LIMIT,

--- a/src/services/giveconomyPowerSyncService.test.ts
+++ b/src/services/giveconomyPowerSyncService.test.ts
@@ -1,0 +1,115 @@
+import { assert } from 'chai';
+import axios from 'axios';
+import sinon from 'sinon';
+import * as powerBoostingRepository from '../repositories/powerBoostingRepository';
+import * as powerSyncCursorRepository from '../repositories/powerSyncCursorRepository';
+import * as powerSyncOutboxRepository from '../repositories/powerSyncOutboxRepository';
+import { pullGiveconomyPowerSync } from './giveconomyPowerSyncService';
+
+describe('pullGiveconomyPowerSync', () => {
+  const originalEnv = {
+    GIVECONOMY_POWER_SYNC_URL: process.env.GIVECONOMY_POWER_SYNC_URL,
+    POWER_SYNC_PASSWORD: process.env.POWER_SYNC_PASSWORD,
+    POWER_SYNC_PASSWORD_HEADER: process.env.POWER_SYNC_PASSWORD_HEADER,
+    GIVECONOMY_POWER_SYNC_TIMEOUT_MS:
+      process.env.GIVECONOMY_POWER_SYNC_TIMEOUT_MS,
+  };
+
+  beforeEach(() => {
+    process.env.GIVECONOMY_POWER_SYNC_URL =
+      'https://giveconomy.example/api/power/sync-events';
+    process.env.POWER_SYNC_PASSWORD = 'test-password';
+    process.env.POWER_SYNC_PASSWORD_HEADER = 'x-power-sync-password';
+    process.env.GIVECONOMY_POWER_SYNC_TIMEOUT_MS = '1000';
+  });
+
+  afterEach(() => {
+    sinon.restore();
+
+    process.env.GIVECONOMY_POWER_SYNC_URL =
+      originalEnv.GIVECONOMY_POWER_SYNC_URL;
+    process.env.POWER_SYNC_PASSWORD = originalEnv.POWER_SYNC_PASSWORD;
+    process.env.POWER_SYNC_PASSWORD_HEADER =
+      originalEnv.POWER_SYNC_PASSWORD_HEADER;
+    process.env.GIVECONOMY_POWER_SYNC_TIMEOUT_MS =
+      originalEnv.GIVECONOMY_POWER_SYNC_TIMEOUT_MS;
+  });
+
+  it('filters zero percentages and bypasses the project limit for mirrored events', async () => {
+    sinon.stub(powerSyncCursorRepository, 'getPowerSyncCursor').resolves(null);
+    sinon
+      .stub(powerSyncCursorRepository, 'savePowerSyncCursor')
+      .resolves({} as any);
+    sinon
+      .stub(powerSyncOutboxRepository, 'getLatestPowerSyncOutboxEventForUser')
+      .resolves(null);
+
+    const setMultipleBoostingStub = sinon
+      .stub(powerBoostingRepository, 'setMultipleBoosting')
+      .resolves([] as any);
+
+    sinon.stub(axios, 'get').resolves({
+      status: 200,
+      data: {
+        data: [
+          {
+            id: 32,
+            sourceSystem: 'giveconomy',
+            eventType: 'power-boosting.updated',
+            entityType: 'power-boosting',
+            userId: 6791,
+            sourceUpdatedAt: '2026-04-17T15:38:15.580Z',
+            payload: {
+              userId: 6791,
+              boostings: [
+                {
+                  projectId: 15674,
+                  percentage: 50,
+                  updatedAt: '2026-04-17T15:38:15.580Z',
+                },
+                {
+                  projectId: 1443,
+                  percentage: 18.6,
+                  updatedAt: '2026-04-17T15:38:15.580Z',
+                },
+                {
+                  projectId: 3173,
+                  percentage: 14.75,
+                  updatedAt: '2026-04-17T15:38:15.580Z',
+                },
+                {
+                  projectId: 2001,
+                  percentage: 0,
+                  updatedAt: '2026-04-17T15:38:15.580Z',
+                },
+                {
+                  projectId: 2002,
+                  percentage: 0,
+                  updatedAt: '2026-04-17T15:38:15.580Z',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    } as any);
+
+    const result = await pullGiveconomyPowerSync();
+
+    assert.deepEqual(result, {
+      fetched: 1,
+      applied: 1,
+      skipped: 0,
+    });
+    assert.equal(setMultipleBoostingStub.callCount, 1);
+
+    const params = setMultipleBoostingStub.firstCall.args[0];
+    assert.deepEqual(params.projectIds, [15674, 1443, 3173]);
+    assert.deepEqual(params.percentages, [50, 18.6, 14.75]);
+    assert.isTrue(params.allowZeroTotal);
+    assert.isTrue(params.allowPartialTotal);
+    assert.isTrue(params.allowExceedProjectLimit);
+    assert.isFalse(params.emitOutboxEvent);
+    assert.isFunction(params.beforeSave);
+  });
+});

--- a/src/services/giveconomyPowerSyncService.ts
+++ b/src/services/giveconomyPowerSyncService.ts
@@ -102,16 +102,19 @@ const applyGiveconomyPowerSyncEvent = async (
   }
 
   const incomingUpdatedAt = new Date(event.sourceUpdatedAt);
-  const boostings = event.payload.boostings || [];
+  const syncedBoostings = (event.payload.boostings || []).filter(
+    boosting => boosting.percentage > 0,
+  );
   let applied = true;
 
   try {
     await setMultipleBoosting({
       userId: event.userId,
-      projectIds: boostings.map(boosting => boosting.projectId),
-      percentages: boostings.map(boosting => boosting.percentage),
+      projectIds: syncedBoostings.map(boosting => boosting.projectId),
+      percentages: syncedBoostings.map(boosting => boosting.percentage),
       allowZeroTotal: true,
       allowPartialTotal: true,
+      allowExceedProjectLimit: true,
       emitOutboxEvent: false,
       beforeSave: async () => {
         const latestLocalOutboxEvent =


### PR DESCRIPTION
## Issue
[Giveth/giveth-v6-core#202](https://github.com/Giveth/giveth-v6-core/issues/202)

## Summary
This hotfix prevents the `impact-graph` reverse sync consumer from stalling on mirrored `giveconomy` boosting events. Production was getting stuck behind oversized payloads that included many `0%` boostings, which blocked the cursor from advancing and prevented later updates like the Urbanika sync from reaching v5.

## Changes
- filter `0%` boostings out of mirrored `giveconomy` sync events before applying them in `impact-graph`
- add an explicit `allowExceedProjectLimit` path for mirrored sync imports so remote events are not rejected by local user-facing project-cap validation
- add focused coverage for the mirrored sync path and the repository bypass used only for imported events

## How to Test
- deploy this branch to `impact-graph` production and restart `impact-graph-jobs`
- confirm the `impact-graph-jobs` logs no longer fail with `Number of boosted projects exceeds limit`
- verify the reverse-sync cursor starts advancing past the previously stuck event and keeps consuming later events
- verify a previously missing mirrored update, such as Urbanika for user `6793`, appears correctly on v5 after catch-up
- run `NODE_ENV=test npx mocha --config ./.mocharc.json ./src/services/giveconomyPowerSyncService.test.ts`
- run `npx eslint ./src/services/giveconomyPowerSyncService.ts ./src/services/giveconomyPowerSyncService.test.ts ./src/repositories/powerBoostingRepository.ts ./src/repositories/powerBoostingRepository.test.ts`

## Notes
- the full local integration-style repository tests were not rerun here because the local test bootstrap currently fails before execution with `Redis NOAUTH Authentication required`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Power boosting can now exceed project limits when the corresponding option is enabled.

* **Improvements**
  * Zero-percentage power boosts are now automatically filtered out during synchronization to ensure only valid boosts are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->