### PR TITLE
stabilize giveconomy reverse sync and related tests

### DIFF
--- a/src/services/giveconomyPowerSyncService.test.ts
+++ b/src/services/giveconomyPowerSyncService.test.ts
@@ -117,4 +117,137 @@ describe('pullGiveconomyPowerSync', () => {
     assert.isFalse(params.emitOutboxEvent);
     assert.isFunction(params.beforeSave);
   });
+
+  it('normalizes rounded mirrored percentages when they overflow 100 by rounding drift', async () => {
+    sinon.stub(powerSyncCursorRepository, 'getPowerSyncCursor').resolves({
+      sourceSystem: 'giveconomy',
+      lastEventId: 41,
+    } as any);
+    sinon
+      .stub(powerSyncCursorRepository, 'savePowerSyncCursor')
+      .resolves({} as any);
+    sinon
+      .stub(powerSyncOutboxRepository, 'getLatestPowerSyncOutboxEventForUser')
+      .resolves(null);
+
+    const setMultipleBoostingStub = sinon
+      .stub(powerBoostingRepository, 'setMultipleBoosting')
+      .resolves([] as any);
+
+    sinon.stub(axios, 'get').resolves({
+      status: 200,
+      data: {
+        data: [
+          {
+            id: 42,
+            sourceSystem: 'giveconomy',
+            eventType: 'power-boosting.updated',
+            entityType: 'power-boosting',
+            userId: 80,
+            sourceUpdatedAt: '2026-04-17T16:41:41.486Z',
+            payload: {
+              userId: 80,
+              boostings: [
+                {
+                  projectId: 16152,
+                  percentage: 12.78654464506554,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+                {
+                  projectId: 15754,
+                  percentage: 10.25772940885481,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+                {
+                  projectId: 1,
+                  percentage: 9.830324016819194,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+                {
+                  projectId: 15919,
+                  percentage: 8.500618352708385,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+                {
+                  projectId: 2955,
+                  percentage: 8.310660400692552,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+                {
+                  projectId: 2795,
+                  percentage: 7.07593371258966,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+                {
+                  projectId: 2808,
+                  percentage: 6.88597576057383,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+                {
+                  projectId: 2297,
+                  percentage: 5.401929260450157,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+                {
+                  projectId: 2636,
+                  percentage: 4.927034380410584,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+                {
+                  projectId: 1443,
+                  percentage: 4.915162008409596,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+                {
+                  projectId: 3452,
+                  percentage: 4.84392777640366,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+                {
+                  projectId: 3760,
+                  percentage: 4.558990848379917,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+                {
+                  projectId: 16199,
+                  percentage: 4,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+                {
+                  projectId: 1711,
+                  percentage: 3.953499876329457,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+                {
+                  projectId: 14863,
+                  percentage: 3.751669552312638,
+                  updatedAt: '2026-04-17T16:41:41.486Z',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    } as any);
+
+    const result = await pullGiveconomyPowerSync();
+
+    assert.deepEqual(result, {
+      fetched: 1,
+      applied: 1,
+      skipped: 0,
+    });
+    assert.equal(setMultipleBoostingStub.callCount, 1);
+
+    const params = setMultipleBoostingStub.firstCall.args[0];
+    assert.equal(params.projectIds.length, 15);
+    assert.closeTo(
+      params.percentages.reduce((sum, value) => sum + value, 0),
+      100,
+      0.00001,
+    );
+    assert.equal(params.percentages[0], 12.78);
+    assert.equal(params.percentages[1], 10.26);
+    assert.equal(params.percentages[14], 3.75);
+  });
 });

--- a/src/services/giveconomyPowerSyncService.ts
+++ b/src/services/giveconomyPowerSyncService.ts
@@ -28,14 +28,70 @@ const GIVECONOMY_SOURCE_SYSTEM = 'giveconomy';
 const STALE_GIVECONOMY_POWER_SYNC_EVENT = 'STALE_GIVECONOMY_POWER_SYNC_EVENT';
 const DEFAULT_GIVPOWER_PERCENTAGE_PRECISION = 2;
 
-const roundSyncedPercentage = (percentage: number): number => {
+const getSyncedPercentagePrecision = (): number => {
   const precision = Number(process.env.GIVPOWER_BOOSTING_PERCENTAGE_PRECISION);
-  const resolvedPrecision =
-    Number.isInteger(precision) && precision >= 0
-      ? precision
-      : DEFAULT_GIVPOWER_PERCENTAGE_PRECISION;
+  return Number.isInteger(precision) && precision >= 0
+    ? precision
+    : DEFAULT_GIVPOWER_PERCENTAGE_PRECISION;
+};
 
-  return Number(percentage.toFixed(resolvedPrecision));
+const roundSyncedPercentage = (percentage: number): number => {
+  return Number(percentage.toFixed(getSyncedPercentagePrecision()));
+};
+
+const normalizeRoundedBoostings = (
+  boostings: Array<{
+    projectId: number;
+    percentage: number;
+    updatedAt: string;
+  }>,
+): Array<{
+  projectId: number;
+  percentage: number;
+  updatedAt: string;
+}> => {
+  if (boostings.length === 0) {
+    return boostings;
+  }
+
+  const precision = getSyncedPercentagePrecision();
+  const roundingStep = 1 / 10 ** precision;
+  const total = boostings.reduce(
+    (sum, boosting) => sum + boosting.percentage,
+    0,
+  );
+  const delta = Number((100 - total).toFixed(precision));
+  const maxRoundingDrift = roundingStep * boostings.length;
+
+  if (
+    total <= 0 ||
+    delta === 0 ||
+    Math.abs(delta) > maxRoundingDrift + Number.EPSILON
+  ) {
+    return boostings;
+  }
+
+  const indexToAdjust = boostings.reduce(
+    (bestIndex, boosting, index, items) =>
+      boosting.percentage > items[bestIndex].percentage ? index : bestIndex,
+    0,
+  );
+  const adjustedPercentage = Number(
+    (boostings[indexToAdjust].percentage + delta).toFixed(precision),
+  );
+
+  if (adjustedPercentage < 0 || adjustedPercentage > 100) {
+    return boostings;
+  }
+
+  return boostings.map((boosting, index) =>
+    index === indexToAdjust
+      ? {
+          ...boosting,
+          percentage: adjustedPercentage,
+        }
+      : boosting,
+  );
 };
 
 export const pullGiveconomyPowerSync = async (): Promise<{
@@ -113,12 +169,14 @@ const applyGiveconomyPowerSyncEvent = async (
   }
 
   const incomingUpdatedAt = new Date(event.sourceUpdatedAt);
-  const syncedBoostings = (event.payload.boostings || [])
-    .map(boosting => ({
-      ...boosting,
-      percentage: roundSyncedPercentage(boosting.percentage),
-    }))
-    .filter(boosting => boosting.percentage > 0);
+  const syncedBoostings = normalizeRoundedBoostings(
+    (event.payload.boostings || [])
+      .map(boosting => ({
+        ...boosting,
+        percentage: roundSyncedPercentage(boosting.percentage),
+      }))
+      .filter(boosting => boosting.percentage > 0),
+  ).filter(boosting => boosting.percentage > 0);
   let applied = true;
 
   try {


### PR DESCRIPTION
### Issue

### Summary
This PR stabilizes the mirrored GIVeconomy -> impact-graph sync flow and folds in the follow-up CI fixes that were needed to keep the branch mergeable. It preserves the earlier precision handling while also normalizing mirrored totals that only overflow 100 because of 2-decimal rounding drift in production data.

### Changes
- Round mirrored giveconomy sync percentages using the configured precision and filter values that collapse to zero before saving on impact-graph.
- Normalize rounded mirrored boosting totals back to an exact 100 when the overflow is only rounding drift, which fixes the production stall on later sync events like event `42`.
- Add regression coverage for both the precision-rounding case and the production-shaped `100.01 after rounding` case in `giveconomyPowerSyncService` tests.
- Include the branch’s CI follow-ups: fix cause recipient network id handling in tests and make resolver assertions independent from seeded staging snapshot data.

### How to Test
1. Run `NODE_ENV=test npx mocha ./src/services/giveconomyPowerSyncService.test.ts` and confirm the mirrored sync service tests pass, including the new normalization case.
2. Run `npx eslint src/services/giveconomyPowerSyncService.ts src/services/giveconomyPowerSyncService.test.ts` and confirm the updated sync files are lint-clean.
3. In a production-like environment, configure `ENABLE_GIVECONOMY_POWER_SYNC=true` with `GIVPOWER_BOOSTING_PERCENTAGE_PRECISION=2`, replay a mirrored event whose rounded percentages sum to `100.01`, and confirm `pullGiveconomyPowerSync()` applies it instead of failing.
4. After deploy, verify the `power_sync_cursor` row for `sourceSystem='giveconomy'` advances beyond event `41` and newer mirrored events begin applying on `impact-graph`.
5. Spot-check one of the stalled users, such as `6791` or the production-shaped overflow case, and confirm the v5 `power_boosting` rows match the latest v6 mirrored payload after the cron runs.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boosting percentage normalization to correctly handle rounding adjustments and ensure total allocation remains within acceptable bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->