### PR TITLE
Release hotfix: fix stale giveconomy sync event handling

### DIFF
--- a/src/repositories/powerBoostingRepository.test.ts
+++ b/src/repositories/powerBoostingRepository.test.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from 'vm';
 import { assert } from 'chai';
 import {
   assertThrowsAsync,
@@ -723,6 +724,44 @@ function setMultipleBoostingTestCases() {
         ),
       );
     });
+  });
+
+  it('should preserve stale mirrored sync errors thrown by beforeSave', async () => {
+    const user = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+    const project = await saveProjectDirectlyToDb(createProjectData());
+
+    await assertThrowsAsync(
+      async () =>
+        setMultipleBoosting({
+          userId: user.id,
+          projectIds: [project.id],
+          percentages: [100],
+          beforeSave: async () => {
+            throw new Error('STALE_GIVECONOMY_POWER_SYNC_EVENT');
+          },
+        }),
+      'STALE_GIVECONOMY_POWER_SYNC_EVENT',
+    );
+  });
+
+  it('should preserve cross-realm stale mirrored sync errors thrown by beforeSave', async () => {
+    const user = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+    const project = await saveProjectDirectlyToDb(createProjectData());
+
+    await assertThrowsAsync(
+      async () =>
+        setMultipleBoosting({
+          userId: user.id,
+          projectIds: [project.id],
+          percentages: [100],
+          beforeSave: async () => {
+            throw runInNewContext(
+              'new Error("STALE_GIVECONOMY_POWER_SYNC_EVENT")',
+            );
+          },
+        }),
+      'STALE_GIVECONOMY_POWER_SYNC_EVENT',
+    );
   });
 }
 

--- a/src/repositories/powerBoostingRepository.ts
+++ b/src/repositories/powerBoostingRepository.ts
@@ -22,6 +22,20 @@ const PERCENTAGE_PRECISION = Number(
   process.env.GIVPOWER_BOOSTING_PERCENTAGE_PRECISION || '2',
 );
 const POWER_BOOSTING_USER_LOCK_KEY = 48_103;
+const STALE_GIVECONOMY_POWER_SYNC_EVENT = 'STALE_GIVECONOMY_POWER_SYNC_EVENT';
+
+const hasErrorMessage = (
+  error: unknown,
+): error is {
+  message: string;
+} =>
+  typeof error === 'object' &&
+  error !== null &&
+  'message' in error &&
+  typeof error.message === 'string';
+
+const isStaleGiveconomyPowerSyncError = (error: unknown): boolean =>
+  hasErrorMessage(error) && error.message === STALE_GIVECONOMY_POWER_SYNC_EVENT;
 
 type BeforeSaveContext = {
   queryRunnerManager: EntityManager;
@@ -333,6 +347,9 @@ const _setSingleBoosting = async (params: {
 
     // since we have errors let's rollback changes we made
     await queryRunner.rollbackTransaction();
+    if (isStaleGiveconomyPowerSyncError(e)) {
+      throw e;
+    }
     const errorKey = getKeyByValue(errorMessages, e.message);
     if (errorKey)
       throw new Error(i18n.__(translationErrorMessagesKeys[errorKey]));
@@ -489,6 +506,9 @@ export const setMultipleBoosting = async (params: {
 
     // since we have errors let's rollback changes we made
     await queryRunner.rollbackTransaction();
+    if (isStaleGiveconomyPowerSyncError(e)) {
+      throw e;
+    }
     const errorKey = getKeyByValue(errorMessages, e.message);
     if (errorKey)
       throw new Error(i18n.__(translationErrorMessagesKeys[errorKey]));

--- a/src/services/giveconomyPowerSyncService.test.ts
+++ b/src/services/giveconomyPowerSyncService.test.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from 'vm';
 import { assert } from 'chai';
 import axios from 'axios';
 import sinon from 'sinon';
@@ -249,5 +250,107 @@ describe('pullGiveconomyPowerSync', () => {
     assert.equal(params.percentages[0], 12.78);
     assert.equal(params.percentages[1], 10.26);
     assert.equal(params.percentages[14], 3.75);
+  });
+
+  it('skips stale mirrored sync events without failing the pull', async () => {
+    sinon.stub(powerSyncCursorRepository, 'getPowerSyncCursor').resolves({
+      sourceSystem: 'giveconomy',
+      lastEventId: 43,
+    } as any);
+    const savePowerSyncCursorStub = sinon
+      .stub(powerSyncCursorRepository, 'savePowerSyncCursor')
+      .resolves({} as any);
+
+    sinon
+      .stub(powerBoostingRepository, 'setMultipleBoosting')
+      .rejects(new Error('STALE_GIVECONOMY_POWER_SYNC_EVENT'));
+
+    sinon.stub(axios, 'get').resolves({
+      status: 200,
+      data: {
+        data: [
+          {
+            id: 44,
+            sourceSystem: 'giveconomy',
+            eventType: 'power-boosting.updated',
+            entityType: 'power-boosting',
+            userId: 6793,
+            sourceUpdatedAt: '2026-04-17T16:42:55.129Z',
+            payload: {
+              userId: 6793,
+              boostings: [
+                {
+                  projectId: 15674,
+                  percentage: 100,
+                  updatedAt: '2026-04-17T16:42:55.129Z',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    } as any);
+
+    const result = await pullGiveconomyPowerSync();
+
+    assert.deepEqual(result, {
+      fetched: 1,
+      applied: 0,
+      skipped: 1,
+    });
+    assert.equal(savePowerSyncCursorStub.callCount, 1);
+    assert.equal(savePowerSyncCursorStub.firstCall.args[0].lastEventId, 44);
+  });
+
+  it('skips cross-realm stale mirrored sync events without failing the pull', async () => {
+    sinon.stub(powerSyncCursorRepository, 'getPowerSyncCursor').resolves({
+      sourceSystem: 'giveconomy',
+      lastEventId: 43,
+    } as any);
+    const savePowerSyncCursorStub = sinon
+      .stub(powerSyncCursorRepository, 'savePowerSyncCursor')
+      .resolves({} as any);
+
+    sinon
+      .stub(powerBoostingRepository, 'setMultipleBoosting')
+      .rejects(
+        runInNewContext('new Error("STALE_GIVECONOMY_POWER_SYNC_EVENT")'),
+      );
+
+    sinon.stub(axios, 'get').resolves({
+      status: 200,
+      data: {
+        data: [
+          {
+            id: 44,
+            sourceSystem: 'giveconomy',
+            eventType: 'power-boosting.updated',
+            entityType: 'power-boosting',
+            userId: 6793,
+            sourceUpdatedAt: '2026-04-17T16:42:55.129Z',
+            payload: {
+              userId: 6793,
+              boostings: [
+                {
+                  projectId: 15674,
+                  percentage: 100,
+                  updatedAt: '2026-04-17T16:42:55.129Z',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    } as any);
+
+    const result = await pullGiveconomyPowerSync();
+
+    assert.deepEqual(result, {
+      fetched: 1,
+      applied: 0,
+      skipped: 1,
+    });
+    assert.equal(savePowerSyncCursorStub.callCount, 1);
+    assert.equal(savePowerSyncCursorStub.firstCall.args[0].lastEventId, 44);
   });
 });

--- a/src/services/giveconomyPowerSyncService.ts
+++ b/src/services/giveconomyPowerSyncService.ts
@@ -28,6 +28,19 @@ const GIVECONOMY_SOURCE_SYSTEM = 'giveconomy';
 const STALE_GIVECONOMY_POWER_SYNC_EVENT = 'STALE_GIVECONOMY_POWER_SYNC_EVENT';
 const DEFAULT_GIVPOWER_PERCENTAGE_PRECISION = 2;
 
+const hasErrorMessage = (
+  error: unknown,
+): error is {
+  message: string;
+} =>
+  typeof error === 'object' &&
+  error !== null &&
+  'message' in error &&
+  typeof error.message === 'string';
+
+const isStaleGiveconomyPowerSyncError = (error: unknown): boolean =>
+  hasErrorMessage(error) && error.message === STALE_GIVECONOMY_POWER_SYNC_EVENT;
+
 const getSyncedPercentagePrecision = (): number => {
   const precision = Number(process.env.GIVPOWER_BOOSTING_PERCENTAGE_PRECISION);
   return Number.isInteger(precision) && precision >= 0
@@ -210,10 +223,7 @@ const applyGiveconomyPowerSyncEvent = async (
       },
     });
   } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message === STALE_GIVECONOMY_POWER_SYNC_EVENT
-    ) {
+    if (isStaleGiveconomyPowerSyncError(error)) {
       return false;
     }
 


### PR DESCRIPTION
## Summary
- preserve the mirrored stale-event sentinel in the reverse sync path so outdated GIVeconomy events are skipped instead of aborting the pull with a generic error
- recognize cross-realm `Error` objects when classifying stale mirrored sync events
- add regression coverage for both repository and service stale-event handling

## Test plan
- [x] `NODE_ENV=test REDIS_PORT=6380 SHARED_REDIS_PORT=6380 ./node_modules/.bin/mocha --config ./.mocharc.json ./test/pre-test-scripts.ts ./src/repositories/powerBoostingRepository.test.ts ./src/services/giveconomyPowerSyncService.test.ts --grep "stale mirrored sync|cross-realm stale mirrored sync|skips stale mirrored sync|skips cross-realm stale"`
- [ ] Verify the reverse sync cursor advances past stale mirrored events after deployment

Made with [Cursor](https://cursor.com)