### PR TITLE
Disable the legacy GIVeconomy power sync cron

### DIFF
--- a/src/services/cronJobs/syncGiveconomyPowerEvents.ts
+++ b/src/services/cronJobs/syncGiveconomyPowerEvents.ts
@@ -7,6 +7,10 @@ let isGiveconomyPowerSyncRunning = false;
 export const runGiveconomyPowerSyncCronJob = () => {
   const cronExpression =
     process.env.GIVECONOMY_POWER_SYNC_CRON_EXPRESSION || '*/1 * * * *';
+  if (process.env.DISABLE_GIVECONOMY_POWER_SYNC_JOB !== 'false') {
+    logger.info('GIVeconomy power sync cron job is disabled by configuration');
+    return;
+  }
   if (!process.env.GIVECONOMY_POWER_SYNC_URL) {
     logger.info('GIVeconomy power sync cron job is disabled');
     return;


### PR DESCRIPTION
## Issue


## Summary

Stop the legacy impact-graph service from continuing to poll GIVeconomy for power updates once the new service becomes the source of truth. This makes the power cutover one-directional and keeps the old backend from reintroducing mirrored state after deployment.

## Changes

- add a configuration guard that disables the GIVeconomy power sync cron unless `DISABLE_GIVECONOMY_POWER_SYNC_JOB=false` is set explicitly
- leave the existing URL/password validation in place for any intentional manual re-enable during rollback testing

## How to Test

1. Run `npx eslint "src/services/cronJobs/syncGiveconomyPowerEvents.ts"`.
2. Start the old backend with its usual env and verify the GIVeconomy sync cron no longer schedules by default.
3. If rollback testing is needed, set `DISABLE_GIVECONOMY_POWER_SYNC_JOB=false` and confirm the cron can still be re-enabled intentionally.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-based configuration option to disable the Giveconomy Power synchronization job through simple configuration. When disabled, the job logs its status and exits gracefully without processing, providing operational flexibility and control over synchronization behavior without requiring code modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->