### PR TITLE
docs: fix typos and grammar in QF documentation

### DIFF
--- a/docs/qfRoundInstruction.md
+++ b/docs/qfRoundInstruction.md
@@ -3,11 +3,11 @@
 <img width="1907" alt="Screen Shot 1402-04-20 at 11 58 44" src="https://github.com/Giveth/impact-graph/assets/9850545/7ac55e3d-7a17-4f44-9823-bcca3a9b4316">
 
 * **Name** name of round that we show in the UI
-* **Is Active** If we want qfRound be active we should check this option. **Be careful we can just have one active qfRound, otherwise system would not work well in this state**
+* **Is Active** If we want qfRound to be active we should check this option. **Be careful we can only have one active qfRound, otherwise system would not work well in this state**
 * **Allocated Fund** The amount of fund that we want to distribute in this round ( USD value)
 * **Minimum Passport Score** At the end of the round we just consider donations whose donor passport score is greater than or equal to this field
 * **Begin Date** Exact time of when we want to begin round
-* **End Date** Exact time of when round supposed to end **be careful of this field, because when end date passes admins can not edit round anymore**
+* **End Date** Exact time of when the round is supposed to end **be careful of this field, because when the end date passes, admins cannot edit the round anymore**
 
 
 # List
@@ -18,13 +18,13 @@ Admins can see list of QF Rounds here
 # Show Single QF Round
 <img width="1733" alt="Screen Shot 1402-04-20 at 12 10 16" src="https://github.com/Giveth/impact-graph/assets/9850545/239f9fe9-4684-4789-b2c6-11ad62f0a6a2">
 
-You can see qf round detail and related projects of a qf round in this page
+You can see QF round details and related projects of a qf round in this page
 
 # Add projects to an active QF round
 ## Project list
 <img width="1565" alt="Screen Shot 1402-04-20 at 12 38 11" src="https://github.com/Giveth/impact-graph/assets/9850545/e9e6f54a-21a5-471a-a662-e94ad4067cbf">
 
-You can select multiple project and add/remove them to existing active QF Round with these two buttons
+You can select multiple projects and add/remove them to existing active QF Round with these two buttons
 **Add To Qf Round** and **Remove From Qf Round**
 
 ## Project page

--- a/docs/qfRoundMatchingFundCalculation.md
+++ b/docs/qfRoundMatchingFundCalculation.md
@@ -1,7 +1,7 @@
 # how our Actual matching fund is calculated
 
 ## Formula
-We use Gitcoin formula you can see the detail https://qf.gitcoin.co/?grant=1,2,3&grant=4,5,6&grant=12,1&grant=8&match=1000
+We use Gitcoin formula you can see the details https://qf.gitcoin.co/?grant=1,2,3&grant=4,5,6&grant=12,1&grant=8&match=1000
 and play it with different amounts to see what happens
 
 ## Edge Cases
@@ -31,7 +31,7 @@ whether they have donations or not. If they have no donations, the amount will b
 * Ensures pending and failed donation statuses are **excluded** from both pre-analysis and post-analysis totals
 
 ## Estimated Matching
-Estimated Matching is like actual matching except we **dont ignore** donations in these cases :
+Estimated Matching is like actual matching except we **don't ignore** donations in these cases :
 * donations from recipients of verified projects
 * donations from users with low passport scores
 * donations from sybil users


### PR DESCRIPTION
## Summary
This PR fixes several typos and grammar issues in the Quadratic Funding (QF) documentation to improve clarity and consistency.

## Changes Made

### docs/qfRoundMatchingFundCalculation.md
- Fixed "detail" to "details" (line 4)
- Added missing apostrophe in "don't" (line 34)

### docs/qfRoundInstruction.md
- Fixed "be active" to "to be active" (line 6)
- Changed "just" to "only" for better clarity (line 6)
- Added missing articles "the" and "is" (line 10)
- Fixed "can not" to "cannot" (line 10)
- Capitalized "QF" and made "detail" plural (line 21)
- Fixed "project" to "projects" (line 28)

## Impact
- Improves documentation readability
- Ensures grammatical consistency
- Makes instructions clearer for users

## Type of Change
- [x] Documentation update
- [x] Grammar/typo fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined QF Round admin UI documentation with clearer wording and improved guidance for round creation, status management, and project operations
  * Enhanced explanations for QF Round details viewing and project selection workflows
  * Corrected grammar and punctuation in matching fund calculation documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->