### PR TITLE
Add v5 GivBacks donation CSV export

### DIFF
--- a/src/server/adminJs/adminJs-types.ts
+++ b/src/server/adminJs/adminJs-types.ts
@@ -11,6 +11,7 @@ export interface AdminJsContextInterface {
 }
 
 export interface AdminJsRequestInterface {
+  method?: string;
   payload?: any;
   record?: any;
   rawHeaders?: any;

--- a/src/server/adminJs/tabs/components/GivbacksEligibleDonationsExport.tsx
+++ b/src/server/adminJs/tabs/components/GivbacksEligibleDonationsExport.tsx
@@ -1,0 +1,225 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Input,
+  Label,
+  Select,
+  Text,
+} from '@adminjs/design-system';
+import { ApiClient } from 'adminjs';
+
+const api = new ApiClient();
+
+const downloadCsv = (csvContent: string, fileName: string) => {
+  const blob = new Blob([csvContent], { type: 'text/csv' });
+  const url = window.URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = fileName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  window.URL.revokeObjectURL(url);
+  document.body.removeChild(anchor);
+};
+
+const FilterField = ({
+  label,
+  name,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  name: string;
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder: string;
+}) => (
+  <Box mb="lg" width={['100%', '48%']}>
+    <Label>{label}</Label>
+    <Input
+      name={name}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+    />
+  </Box>
+);
+
+const GivbacksEligibleDonationsExport = props => {
+  const { resource } = props;
+  const [filters, setFilters] = useState({
+    fromDate: '',
+    toDate: '',
+    networkId: '',
+    projectId: '',
+    userId: '',
+    isEligibleForGivbacks: '',
+  });
+  const [isExporting, setIsExporting] = useState(false);
+  const [isLoadingThresholds, setIsLoadingThresholds] = useState(true);
+  const [thresholds, setThresholds] = useState<{
+    defaultMinimumUsdAmount: number;
+    communityOfMakersMinimumUsdAmount: number;
+  } | null>(null);
+
+  useEffect(() => {
+    const loadThresholds = async () => {
+      setIsLoadingThresholds(true);
+
+      try {
+        const { data } = await api.resourceAction({
+          resourceId: resource.id,
+          actionName: 'exportGivbacksEligibleDonations',
+        });
+
+        if (data && data.thresholds) {
+          setThresholds(data.thresholds);
+        }
+      } catch {
+        setThresholds(null);
+      } finally {
+        setIsLoadingThresholds(false);
+      }
+    };
+
+    loadThresholds();
+  }, [resource.id]);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setFilters(current => ({ ...current, [name]: value }));
+  };
+
+  const handleExport = async () => {
+    setIsExporting(true);
+
+    try {
+      const { data } = await api.resourceAction({
+        resourceId: resource.id,
+        actionName: 'exportGivbacksEligibleDonations',
+        method: 'post',
+        data: filters,
+      });
+
+      if (data && data.csvContent) {
+        downloadCsv(
+          data.csvContent,
+          data.fileName || 'givbacks-eligible-donations.csv',
+        );
+      }
+
+      if (data && data.notice && data.notice.message) {
+        alert(data.notice.message);
+      }
+    } catch (error) {
+      alert(
+        `Export failed: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
+      );
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <Box variant="grey">
+      <Box variant="white" p="xl">
+        <Text fontSize="xl" fontWeight="bold" mb="default">
+          Export GivBack Eligible Donations
+        </Text>
+        <Text mb="xl" color="grey60">
+          Download a CSV of verified donations evaluated against the current
+          GivBack eligibility rules. All filters are optional.
+        </Text>
+        <Box display="flex" flexWrap="wrap" justifyContent="space-between">
+          <FilterField
+            label="From date"
+            name="fromDate"
+            value={filters.fromDate}
+            onChange={handleChange}
+            placeholder="2026-01-01"
+          />
+          <FilterField
+            label="To date"
+            name="toDate"
+            value={filters.toDate}
+            onChange={handleChange}
+            placeholder="2026-12-31"
+          />
+          <FilterField
+            label="Network ID"
+            name="networkId"
+            value={filters.networkId}
+            onChange={handleChange}
+            placeholder="10"
+          />
+          <FilterField
+            label="Project ID"
+            name="projectId"
+            value={filters.projectId}
+            onChange={handleChange}
+            placeholder="123"
+          />
+          <FilterField
+            label="User ID"
+            name="userId"
+            value={filters.userId}
+            onChange={handleChange}
+            placeholder="456"
+          />
+          <Box mb="lg" width={['100%', '48%']}>
+            <Label>Eligibility</Label>
+            <Select
+              value={
+                [
+                  { value: '', label: 'All donations' },
+                  { value: 'true', label: 'Eligible only' },
+                  { value: 'false', label: 'Ineligible only' },
+                ].find(
+                  option => option.value === filters.isEligibleForGivbacks,
+                ) || null
+              }
+              onChange={selected =>
+                setFilters(current => ({
+                  ...current,
+                  isEligibleForGivbacks: selected?.value || '',
+                }))
+              }
+              options={[
+                { value: '', label: 'All donations' },
+                { value: 'true', label: 'Eligible only' },
+                { value: 'false', label: 'Ineligible only' },
+              ]}
+              isClearable
+            />
+          </Box>
+        </Box>
+        <Text mb="xl" color="grey60" fontSize="sm">
+          {isLoadingThresholds
+            ? 'Loading current thresholds...'
+            : thresholds
+              ? `Current thresholds: ${thresholds.defaultMinimumUsdAmount} USD by default, and ${thresholds.communityOfMakersMinimumUsdAmount} USD for giveth-community-of-makers.`
+              : 'Thresholds use the default GivBack export values.'}
+        </Text>
+        <Button
+          onClick={handleExport}
+          disabled={isExporting || isLoadingThresholds}
+          variant="primary"
+          size="lg"
+          isLoading={isExporting}
+        >
+          {isLoadingThresholds
+            ? 'Loading thresholds...'
+            : isExporting
+              ? 'Exporting...'
+              : 'Download CSV'}
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default GivbacksEligibleDonationsExport;

--- a/src/server/adminJs/tabs/donationTab.ts
+++ b/src/server/adminJs/tabs/donationTab.ts
@@ -799,15 +799,27 @@ export const exportDonationsWithFiltersToCsv = async (
   }
 };
 
-const parseOptionalPositiveInteger = (value: unknown): number | undefined => {
-  if (typeof value !== 'string' || value.trim().length === 0) {
+const parseOptionalPositiveInteger = (
+  value: unknown,
+  fieldName: string,
+): number | undefined => {
+  if (value === null || value === undefined) {
     return undefined;
   }
 
-  const parsedValue = Number(value);
-  return Number.isInteger(parsedValue) && parsedValue > 0
-    ? parsedValue
-    : undefined;
+  const normalizedValue = String(value).trim();
+  if (normalizedValue.length === 0) {
+    return undefined;
+  }
+
+  const parsedValue = Number(normalizedValue);
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    throw new Error(
+      `Invalid ${fieldName} value "${normalizedValue}". Expected a positive integer.`,
+    );
+  }
+
+  return parsedValue;
 };
 
 const parseOptionalBoolean = (value: unknown): boolean | undefined => {
@@ -824,6 +836,9 @@ const parseOptionalBoolean = (value: unknown): boolean | undefined => {
 const readOptionalString = (value: unknown): string | undefined =>
   typeof value === 'string' && value.trim().length > 0 ? value : undefined;
 
+const getErrorMessage = (error: unknown): string =>
+  (error instanceof Error ? error.message : String(error)) || 'Unknown error';
+
 export const exportGivbacksEligibleDonations = async (
   request: AdminJsRequestInterface,
 ) => {
@@ -839,9 +854,9 @@ export const exportGivbacksEligibleDonations = async (
       await exportEligibleDonations({
         fromDate: readOptionalString(payload.fromDate),
         toDate: readOptionalString(payload.toDate),
-        networkId: parseOptionalPositiveInteger(payload.networkId),
-        projectId: parseOptionalPositiveInteger(payload.projectId),
-        userId: parseOptionalPositiveInteger(payload.userId),
+        networkId: parseOptionalPositiveInteger(payload.networkId, 'networkId'),
+        projectId: parseOptionalPositiveInteger(payload.projectId, 'projectId'),
+        userId: parseOptionalPositiveInteger(payload.userId, 'userId'),
         isEligibleForGivbacks: parseOptionalBoolean(
           payload.isEligibleForGivbacks,
         ),
@@ -857,10 +872,11 @@ export const exportGivbacksEligibleDonations = async (
       },
     };
   } catch (e) {
+    const message = getErrorMessage(e);
     logger.error('exportGivbacksEligibleDonations() error', e);
     return {
       notice: {
-        message: e.message,
+        message,
         type: 'danger',
       },
     };

--- a/src/server/adminJs/tabs/donationTab.ts
+++ b/src/server/adminJs/tabs/donationTab.ts
@@ -1,4 +1,5 @@
 import { ActionContext } from 'adminjs';
+import adminJs from 'adminjs';
 import moment from 'moment';
 import { ILike, SelectQueryBuilder } from 'typeorm';
 import { CoingeckoPriceAdapter } from '../../../adapters/price/CoingeckoPriceAdapter';
@@ -29,6 +30,10 @@ import {
   addDonationsSheetToSpreadsheet,
   initExportSpreadsheet,
 } from '../../../services/googleSheets';
+import {
+  exportEligibleDonations,
+  getCurrentEligibilityThresholds,
+} from '../../../services/givbacksEligibleDonationsCsvService';
 import { updateProjectStatistics } from '../../../services/projectService';
 import {
   updateUserTotalDonated,
@@ -794,6 +799,74 @@ export const exportDonationsWithFiltersToCsv = async (
   }
 };
 
+const parseOptionalPositiveInteger = (value: unknown): number | undefined => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return undefined;
+  }
+
+  const parsedValue = Number(value);
+  return Number.isInteger(parsedValue) && parsedValue > 0
+    ? parsedValue
+    : undefined;
+};
+
+const parseOptionalBoolean = (value: unknown): boolean | undefined => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return undefined;
+  }
+
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+
+  throw new Error('Invalid isEligibleForGivbacks value');
+};
+
+const readOptionalString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+
+export const exportGivbacksEligibleDonations = async (
+  request: AdminJsRequestInterface,
+) => {
+  try {
+    if (request.method !== 'post') {
+      return {
+        thresholds: await getCurrentEligibilityThresholds(),
+      };
+    }
+
+    const payload = request.payload || {};
+    const { csvContent, fileName, totalDonations } =
+      await exportEligibleDonations({
+        fromDate: readOptionalString(payload.fromDate),
+        toDate: readOptionalString(payload.toDate),
+        networkId: parseOptionalPositiveInteger(payload.networkId),
+        projectId: parseOptionalPositiveInteger(payload.projectId),
+        userId: parseOptionalPositiveInteger(payload.userId),
+        isEligibleForGivbacks: parseOptionalBoolean(
+          payload.isEligibleForGivbacks,
+        ),
+      });
+
+    return {
+      csvContent,
+      fileName,
+      totalDonations,
+      notice: {
+        message: `Exported ${totalDonations} GivBack-eligible donations`,
+        type: 'success',
+      },
+    };
+  } catch (e) {
+    logger.error('exportGivbacksEligibleDonations() error', e);
+    return {
+      notice: {
+        message: e.message,
+        type: 'danger',
+      },
+    };
+  }
+};
+
 // Spreadsheet filters included
 const sendDonationsToGoogleSheet = async (
   donations: Donation[],
@@ -1385,6 +1458,19 @@ export const donationTab = {
           ),
         handler: exportDonationsWithFiltersToCsv,
         component: false,
+      },
+      exportGivbacksEligibleDonations: {
+        actionType: 'resource',
+        isVisible: true,
+        isAccessible: ({ currentAdmin }) =>
+          canAccessDonationAction(
+            { currentAdmin },
+            ResourceActions.EXPORT_FILTER_TO_CSV,
+          ),
+        handler: exportGivbacksEligibleDonations,
+        component: adminJs.bundle(
+          './components/GivbacksEligibleDonationsExport',
+        ),
       },
       importIdrissDonations: {
         actionType: 'resource',

--- a/src/services/givbacksEligibleDonationsCsvService.test.ts
+++ b/src/services/givbacksEligibleDonationsCsvService.test.ts
@@ -1,0 +1,181 @@
+import { assert } from 'chai';
+import moment from 'moment';
+import { Donation, DONATION_STATUS } from '../entities/donation';
+import { Token } from '../entities/token';
+import { NETWORK_IDS } from '../provider';
+import { ChainType } from '../types/network';
+import {
+  createDonationData,
+  createProjectData,
+  generateRandomEtheriumAddress,
+  generateRandomEvmTxHash,
+  saveProjectDirectlyToDb,
+  saveRecurringDonationDirectlyToDb,
+  saveUserDirectlyToDb,
+} from '../../test/testUtils';
+import { exportEligibleDonations } from './givbacksEligibleDonationsCsvService';
+
+const parseCsv = (csvContent: string): Record<string, string>[] => {
+  const [headerLine, ...rowLines] = csvContent.split('\n');
+  const headers = headerLine.split(',');
+
+  return rowLines
+    .filter(row => row.trim().length > 0)
+    .map(row => {
+      const values = row.split(',');
+      return headers.reduce<Record<string, string>>((record, header, index) => {
+        record[header] = values[index] || '';
+        return record;
+      }, {});
+    });
+};
+
+describe(
+  'givbacksEligibleDonationsCsvService',
+  givbacksEligibleDonationsCsvServiceTestCases,
+);
+
+function givbacksEligibleDonationsCsvServiceTestCases() {
+  it('exports regular and recurring donations with recurring parent hash', async () => {
+    const donor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+    const project = await saveProjectDirectlyToDb({
+      ...createProjectData(`export-test-${Date.now()}`),
+      networkId: NETWORK_IDS.OPTIMISTIC,
+      chainType: ChainType.EVM,
+    });
+    const tokenAddress = generateRandomEtheriumAddress();
+
+    await Token.create({
+      name: 'Export Test DAI',
+      symbol: 'DAI',
+      address: tokenAddress,
+      networkId: NETWORK_IDS.OPTIMISTIC,
+      chainType: ChainType.EVM,
+      decimals: 18,
+      isGivbackEligible: true,
+    }).save();
+
+    await Donation.create({
+      ...createDonationData({
+        status: DONATION_STATUS.VERIFIED,
+        valueUsd: 5,
+        createdAt: moment.utc('2026-04-01').toDate(),
+      }),
+      transactionId: generateRandomEvmTxHash(),
+      transactionNetworkId: NETWORK_IDS.OPTIMISTIC,
+      toWalletAddress: project.walletAddress,
+      fromWalletAddress: donor.walletAddress,
+      currency: 'DAI',
+      amount: 5,
+      valueUsd: 5,
+      priceUsd: 1,
+      project,
+      projectId: project.id,
+      user: donor,
+      userId: donor.id,
+      tokenAddress,
+      chainType: ChainType.EVM,
+      isProjectGivbackEligible: true,
+      givbackFactor: 2,
+    }).save();
+
+    const parentHash = generateRandomEvmTxHash();
+    const recurringDonation = await saveRecurringDonationDirectlyToDb({
+      donationData: {
+        projectId: project.id,
+        donorId: donor.id,
+        txHash: parentHash,
+        networkId: NETWORK_IDS.OPTIMISTIC,
+        currency: 'DAI',
+      },
+    });
+    const firstPeriodStart = moment.utc('2026-04-01').unix();
+    const firstPeriodEnd = moment.utc('2026-04-02').unix();
+    const secondPeriodStart = moment.utc('2026-04-02').unix();
+    const secondPeriodEnd = moment.utc('2026-04-03').unix();
+
+    await Donation.create({
+      ...createDonationData({
+        status: DONATION_STATUS.VERIFIED,
+        valueUsd: 2,
+        createdAt: moment.utc('2026-04-02').toDate(),
+      }),
+      transactionId: generateRandomEvmTxHash(),
+      transactionNetworkId: NETWORK_IDS.OPTIMISTIC,
+      toWalletAddress: project.walletAddress,
+      fromWalletAddress: donor.walletAddress,
+      currency: 'DAI',
+      amount: 2,
+      valueUsd: 2,
+      priceUsd: 1,
+      project,
+      projectId: project.id,
+      user: donor,
+      userId: donor.id,
+      tokenAddress,
+      chainType: ChainType.EVM,
+      isProjectGivbackEligible: true,
+      givbackFactor: 2,
+      recurringDonation,
+      recurringDonationId: recurringDonation.id,
+      virtualPeriodStart: firstPeriodStart,
+      virtualPeriodEnd: firstPeriodEnd,
+    }).save();
+
+    await Donation.create({
+      ...createDonationData({
+        status: DONATION_STATUS.VERIFIED,
+        valueUsd: 2.25,
+        createdAt: moment.utc('2026-04-03').toDate(),
+      }),
+      transactionId: generateRandomEvmTxHash(),
+      transactionNetworkId: NETWORK_IDS.OPTIMISTIC,
+      toWalletAddress: project.walletAddress,
+      fromWalletAddress: donor.walletAddress,
+      currency: 'DAI',
+      amount: 2.25,
+      valueUsd: 2.25,
+      priceUsd: 1,
+      project,
+      projectId: project.id,
+      user: donor,
+      userId: donor.id,
+      tokenAddress,
+      chainType: ChainType.EVM,
+      isProjectGivbackEligible: true,
+      givbackFactor: 2,
+      recurringDonation,
+      recurringDonationId: recurringDonation.id,
+      virtualPeriodStart: secondPeriodStart,
+      virtualPeriodEnd: secondPeriodEnd,
+    }).save();
+
+    const result = await exportEligibleDonations({
+      projectId: project.id,
+      isEligibleForGivbacks: true,
+    });
+    const rows = parseCsv(result.csvContent);
+    const recurringRow = rows.find(
+      row => row.transactionId === `recurring-${recurringDonation.id}`,
+    );
+
+    assert.equal(result.totalDonations, 2);
+    assert.equal(recurringRow?.amount, '4.25');
+    assert.equal(recurringRow?.valueUsd, '4.25');
+    assert.equal(recurringRow?.valueUsdAfterGivbackFactor, '8.5');
+    assert.equal(
+      recurringRow?.legacyRecurringDonationId,
+      String(recurringDonation.id),
+    );
+    assert.equal(recurringRow?.parentRecurringDonationTxHash, parentHash);
+    assert.equal(
+      recurringRow?.legacyVirtualPeriodStart,
+      '2026-04-01T00:00:00.000Z',
+    );
+    assert.equal(
+      recurringRow?.legacyVirtualPeriodEnd,
+      '2026-04-03T00:00:00.000Z',
+    );
+    assert.equal(recurringRow?.isEligibleForGivbacks, 'true');
+  });
+}

--- a/src/services/givbacksEligibleDonationsCsvService.test.ts
+++ b/src/services/givbacksEligibleDonationsCsvService.test.ts
@@ -16,15 +16,67 @@ import {
 import { exportEligibleDonations } from './givbacksEligibleDonationsCsvService';
 
 const parseCsv = (csvContent: string): Record<string, string>[] => {
-  const [headerLine, ...rowLines] = csvContent.split('\n');
-  const headers = headerLine.split(',');
+  const parsedRows: string[][] = [];
+  let currentRow: string[] = [];
+  let currentValue = '';
+  let isInsideQuotes = false;
 
-  return rowLines
-    .filter(row => row.trim().length > 0)
+  for (let index = 0; index < csvContent.length; index += 1) {
+    const character = csvContent[index];
+
+    if (isInsideQuotes) {
+      if (character === '"') {
+        if (csvContent[index + 1] === '"') {
+          currentValue += '"';
+          index += 1;
+        } else {
+          isInsideQuotes = false;
+        }
+      } else {
+        currentValue += character;
+      }
+
+      continue;
+    }
+
+    if (character === '"') {
+      isInsideQuotes = true;
+      continue;
+    }
+
+    if (character === ',') {
+      currentRow.push(currentValue);
+      currentValue = '';
+      continue;
+    }
+
+    if (character === '\n' || character === '\r') {
+      if (character === '\r' && csvContent[index + 1] === '\n') {
+        index += 1;
+      }
+
+      currentRow.push(currentValue);
+      parsedRows.push(currentRow);
+      currentRow = [];
+      currentValue = '';
+      continue;
+    }
+
+    currentValue += character;
+  }
+
+  if (currentRow.length > 0 || currentValue.length > 0) {
+    currentRow.push(currentValue);
+    parsedRows.push(currentRow);
+  }
+
+  const [headers, ...rows] = parsedRows;
+
+  return rows
+    .filter(row => row.some(value => value.trim().length > 0))
     .map(row => {
-      const values = row.split(',');
       return headers.reduce<Record<string, string>>((record, header, index) => {
-        record[header] = values[index] || '';
+        record[header] = row[index] || '';
         return record;
       }, {});
     });
@@ -55,7 +107,7 @@ function givbacksEligibleDonationsCsvServiceTestCases() {
       isGivbackEligible: true,
     }).save();
 
-    await Donation.create({
+    const regularDonation = await Donation.create({
       ...createDonationData({
         status: DONATION_STATUS.VERIFIED,
         valueUsd: 5,
@@ -158,24 +210,34 @@ function givbacksEligibleDonationsCsvServiceTestCases() {
     const recurringRow = rows.find(
       row => row.transactionId === `recurring-${recurringDonation.id}`,
     );
+    const regularRow = rows.find(
+      row => row.transactionId === regularDonation.transactionId,
+    );
 
     assert.equal(result.totalDonations, 2);
-    assert.equal(recurringRow?.amount, '4.25');
-    assert.equal(recurringRow?.valueUsd, '4.25');
-    assert.equal(recurringRow?.valueUsdAfterGivbackFactor, '8.5');
+    if (!recurringRow) assert.fail('recurring row not found');
+    assert.equal(recurringRow.amount, '4.25');
+    assert.equal(recurringRow.valueUsd, '4.25');
+    assert.equal(recurringRow.valueUsdAfterGivbackFactor, '8.5');
     assert.equal(
-      recurringRow?.legacyRecurringDonationId,
+      recurringRow.legacyRecurringDonationId,
       String(recurringDonation.id),
     );
-    assert.equal(recurringRow?.parentRecurringDonationTxHash, parentHash);
+    assert.equal(recurringRow.parentRecurringDonationTxHash, parentHash);
     assert.equal(
-      recurringRow?.legacyVirtualPeriodStart,
+      recurringRow.legacyVirtualPeriodStart,
       '2026-04-01T00:00:00.000Z',
     );
     assert.equal(
-      recurringRow?.legacyVirtualPeriodEnd,
+      recurringRow.legacyVirtualPeriodEnd,
       '2026-04-03T00:00:00.000Z',
     );
-    assert.equal(recurringRow?.isEligibleForGivbacks, 'true');
+    assert.equal(recurringRow.isEligibleForGivbacks, 'true');
+
+    if (!regularRow) assert.fail('regular row not found');
+    assert.equal(regularRow.amount, '5');
+    assert.equal(regularRow.valueUsd, '5');
+    assert.equal(regularRow.valueUsdAfterGivbackFactor, '10');
+    assert.equal(regularRow.isEligibleForGivbacks, 'true');
   });
 }

--- a/src/services/givbacksEligibleDonationsCsvService.ts
+++ b/src/services/givbacksEligibleDonationsCsvService.ts
@@ -1,0 +1,649 @@
+import { Donation, DONATION_STATUS } from '../entities/donation';
+import {
+  PROJECT_VERIFICATION_STATUSES,
+  ProjectVerificationForm,
+} from '../entities/projectVerificationForm';
+import { Project, ProjStatus, ReviewStatus } from '../entities/project';
+import { ProjectAddress } from '../entities/projectAddress';
+import { Token } from '../entities/token';
+import { NETWORKS_IDS_TO_NAME } from '../provider';
+import { getGlobalConfigurationValues } from '../repositories/globalConfigurationRepository';
+import { ChainType } from '../types/network';
+
+const GIVETH_COMMUNITY_OF_MAKERS_SLUGS = new Set([
+  'giveth',
+  'giveth-community-of-makers',
+  'the-giveth-community-of-makers',
+]);
+const DEFAULT_MINIMUM_USD_AMOUNT = 4;
+const COMMUNITY_OF_MAKERS_MINIMUM_USD_AMOUNT = 0.05;
+const DEFAULT_MINIMUM_USD_AMOUNT_CONFIG_KEY = 'eligible-donation-minimum-usd';
+const COMMUNITY_OF_MAKERS_MINIMUM_USD_AMOUNT_CONFIG_KEY =
+  'community-makers-eligible-donation-minimum-usd';
+
+type CsvValue = string | number | boolean | null;
+
+export interface ExportEligibleDonationsFilters {
+  fromDate?: string;
+  toDate?: string;
+  networkId?: number;
+  projectId?: number;
+  userId?: number;
+  isEligibleForGivbacks?: boolean;
+}
+
+interface DonationExportRow {
+  donationId: number;
+  createdAt: string;
+  status: string;
+  chainType: string;
+  transactionId: string;
+  transactionNetworkId: number;
+  network: string;
+  nonce: number | null;
+  fromWalletAddress: string;
+  toWalletAddress: string;
+  anonymous: boolean;
+  currency: string;
+  tokenAddress: string | null;
+  tokenName: string | null;
+  tokenSymbol: string | null;
+  tokenNetworkId: number | null;
+  tokenChainType: string | null;
+  tokenIsActive: boolean | null;
+  tokenIsGivbacksEligible: boolean;
+  amount: number;
+  valueUsd: number | null;
+  projectGivbackFactor: number;
+  valueUsdAfterGivbackFactor: number | null;
+  priceUsd: number | null;
+  legacyRecurringDonationId: number | null;
+  parentRecurringDonationTxHash: string | null;
+  legacyVirtualPeriodStart: string | null;
+  legacyVirtualPeriodEnd: string | null;
+  eligibilityAmountThresholdUsd: number;
+  meetsEligibilityAmountThreshold: boolean;
+  donorIsPurpleListed: boolean;
+  isEligibleForGivbacks: boolean;
+  eligibilityFailureReasons: string;
+  isProjectGivbackEligibleSnapshot: boolean;
+  projectId: number;
+  projectTitle: string;
+  projectSlug: string;
+  projectIsGivbacksEligible: boolean;
+  projectAdminUserId: number | null;
+  projectAdminName: string | null;
+  projectAdminEmail: string | null;
+  userId: number | null;
+  userName: string | null;
+  userEmail: string | null;
+  qfRoundId: number | null;
+  qfRoundName: string | null;
+  isCustomToken: boolean;
+  isExternal: boolean;
+  useDonationBox: boolean;
+  donationPercentage: number | null;
+  qfRoundUserScore: number | null;
+  verifyErrorMessage: string | null;
+  qfRoundErrorMessage: string | null;
+}
+
+const DONATION_EXPORT_HEADERS: Array<keyof DonationExportRow> = [
+  'donationId',
+  'createdAt',
+  'status',
+  'chainType',
+  'transactionId',
+  'transactionNetworkId',
+  'network',
+  'nonce',
+  'fromWalletAddress',
+  'toWalletAddress',
+  'anonymous',
+  'currency',
+  'tokenAddress',
+  'tokenName',
+  'tokenSymbol',
+  'tokenNetworkId',
+  'tokenChainType',
+  'tokenIsActive',
+  'tokenIsGivbacksEligible',
+  'amount',
+  'valueUsd',
+  'projectGivbackFactor',
+  'valueUsdAfterGivbackFactor',
+  'priceUsd',
+  'legacyRecurringDonationId',
+  'parentRecurringDonationTxHash',
+  'legacyVirtualPeriodStart',
+  'legacyVirtualPeriodEnd',
+  'eligibilityAmountThresholdUsd',
+  'meetsEligibilityAmountThreshold',
+  'donorIsPurpleListed',
+  'isEligibleForGivbacks',
+  'eligibilityFailureReasons',
+  'isProjectGivbackEligibleSnapshot',
+  'projectId',
+  'projectTitle',
+  'projectSlug',
+  'projectIsGivbacksEligible',
+  'projectAdminUserId',
+  'projectAdminName',
+  'projectAdminEmail',
+  'userId',
+  'userName',
+  'userEmail',
+  'qfRoundId',
+  'qfRoundName',
+  'isCustomToken',
+  'isExternal',
+  'useDonationBox',
+  'donationPercentage',
+  'qfRoundUserScore',
+  'verifyErrorMessage',
+  'qfRoundErrorMessage',
+];
+
+type ConsolidatedDonation = Donation & {
+  legacyRecurringDonationId?: number | null;
+  parentRecurringDonationTxHash?: string | null;
+  legacyVirtualPeriodStart?: Date | null;
+  legacyVirtualPeriodEnd?: Date | null;
+};
+
+export const getCurrentEligibilityThresholds = async (): Promise<{
+  defaultMinimumUsdAmount: number;
+  communityOfMakersMinimumUsdAmount: number;
+}> => {
+  const configs = await getGlobalConfigurationValues([
+    DEFAULT_MINIMUM_USD_AMOUNT_CONFIG_KEY,
+    COMMUNITY_OF_MAKERS_MINIMUM_USD_AMOUNT_CONFIG_KEY,
+  ]);
+
+  return {
+    defaultMinimumUsdAmount: normalizeThreshold(
+      configs[DEFAULT_MINIMUM_USD_AMOUNT_CONFIG_KEY],
+      DEFAULT_MINIMUM_USD_AMOUNT,
+    ),
+    communityOfMakersMinimumUsdAmount: normalizeThreshold(
+      configs[COMMUNITY_OF_MAKERS_MINIMUM_USD_AMOUNT_CONFIG_KEY],
+      COMMUNITY_OF_MAKERS_MINIMUM_USD_AMOUNT,
+    ),
+  };
+};
+
+export const exportEligibleDonations = async (
+  filters: ExportEligibleDonationsFilters = {},
+): Promise<{
+  csvContent: string;
+  fileName: string;
+  totalDonations: number;
+}> => {
+  const thresholds = await getCurrentEligibilityThresholds();
+  const [donations, eligibleTokens, purpleListAddresses] = await Promise.all([
+    findExportableDonations(filters),
+    Token.find({ where: { isGivbackEligible: true } }),
+    getPurpleListAddressKeys(),
+  ]);
+
+  const eligibleTokensByAddress = new Map(
+    eligibleTokens
+      .filter(token => token.address)
+      .map(token => [
+        buildTokenAddressKey(token.chainType, token.networkId, token.address),
+        token,
+      ]),
+  );
+  const eligibleTokensBySymbol = new Map(
+    eligibleTokens.map(token => [
+      buildTokenSymbolKey(token.chainType, token.networkId, token.symbol),
+      token,
+    ]),
+  );
+  const rows: DonationExportRow[] = [];
+
+  for (const donation of consolidateRecurringDonations(donations)) {
+    const isDonorPurpleListed = purpleListAddresses.has(
+      buildPurpleListKey(donation.fromWalletAddress, donation.chainType),
+    );
+    const matchedToken =
+      (donation.tokenAddress
+        ? eligibleTokensByAddress.get(
+            buildTokenAddressKey(
+              donation.chainType,
+              donation.transactionNetworkId,
+              donation.tokenAddress,
+            ),
+          )
+        : undefined) ??
+      eligibleTokensBySymbol.get(
+        buildTokenSymbolKey(
+          donation.chainType,
+          donation.transactionNetworkId,
+          donation.currency,
+        ),
+      );
+    const minimumUsdAmount = isGivethCommunityOfMakersProject(
+      donation.project.slug || '',
+    )
+      ? thresholds.communityOfMakersMinimumUsdAmount
+      : thresholds.defaultMinimumUsdAmount;
+    const meetsEligibilityAmountThreshold =
+      (donation.valueUsd || 0) >= minimumUsdAmount;
+    const eligibilityFailureReasons = buildEligibilityFailureReasons({
+      isDonorPurpleListed,
+      isProjectGivbacksEligibleSnapshot: donation.isProjectGivbackEligible,
+      tokenIsGivbacksEligible: Boolean(matchedToken),
+      meetsEligibilityAmountThreshold,
+    });
+    const isEligibleForGivbacks = eligibilityFailureReasons.length === 0;
+
+    if (
+      filters.isEligibleForGivbacks !== undefined &&
+      isEligibleForGivbacks !== filters.isEligibleForGivbacks
+    ) {
+      continue;
+    }
+
+    const projectGivbackFactor = normalizeGivbackFactor(donation.givbackFactor);
+    const valueUsdAfterGivbackFactor =
+      donation.valueUsd === null || donation.valueUsd === undefined
+        ? null
+        : Number((donation.valueUsd * projectGivbackFactor).toFixed(6));
+
+    rows.push({
+      donationId: donation.id,
+      createdAt: donation.createdAt.toISOString(),
+      status: donation.status,
+      chainType: donation.chainType,
+      transactionId: donation.transactionId,
+      transactionNetworkId: donation.transactionNetworkId,
+      network: getNetworkNameById(donation.transactionNetworkId),
+      nonce: donation.nonce || null,
+      fromWalletAddress: donation.fromWalletAddress,
+      toWalletAddress: donation.toWalletAddress,
+      anonymous: Boolean(donation.anonymous),
+      currency: donation.currency,
+      tokenAddress: donation.tokenAddress || null,
+      tokenName: matchedToken?.name || null,
+      tokenSymbol: matchedToken?.symbol || donation.currency,
+      tokenNetworkId: matchedToken?.networkId || donation.transactionNetworkId,
+      tokenChainType: matchedToken?.chainType || donation.chainType,
+      tokenIsActive: null,
+      tokenIsGivbacksEligible: Boolean(matchedToken),
+      amount: donation.amount,
+      valueUsd: donation.valueUsd ?? null,
+      projectGivbackFactor,
+      valueUsdAfterGivbackFactor,
+      priceUsd: donation.priceUsd ?? null,
+      legacyRecurringDonationId: donation.legacyRecurringDonationId || null,
+      parentRecurringDonationTxHash:
+        donation.parentRecurringDonationTxHash || null,
+      legacyVirtualPeriodStart:
+        donation.legacyVirtualPeriodStart?.toISOString() || null,
+      legacyVirtualPeriodEnd:
+        donation.legacyVirtualPeriodEnd?.toISOString() || null,
+      eligibilityAmountThresholdUsd: minimumUsdAmount,
+      meetsEligibilityAmountThreshold,
+      donorIsPurpleListed: isDonorPurpleListed,
+      isEligibleForGivbacks,
+      eligibilityFailureReasons: eligibilityFailureReasons.join('|'),
+      isProjectGivbackEligibleSnapshot: donation.isProjectGivbackEligible,
+      projectId: donation.project.id,
+      projectTitle: donation.project.title,
+      projectSlug: donation.project.slug || '',
+      projectIsGivbacksEligible: donation.project.isGivbackEligible,
+      projectAdminUserId: donation.project.adminUserId || null,
+      projectAdminName: donation.project.adminUser?.name || null,
+      projectAdminEmail: donation.project.adminUser?.email || null,
+      userId: donation.user?.id || donation.userId || null,
+      userName: donation.user?.name || null,
+      userEmail: donation.user?.email || null,
+      qfRoundId: donation.qfRound?.id || donation.qfRoundId || null,
+      qfRoundName: donation.qfRound?.name || donation.qfRound?.title || null,
+      isCustomToken: Boolean(donation.isCustomToken),
+      isExternal: Boolean(donation.isExternal),
+      useDonationBox: Boolean(donation.useDonationBox),
+      donationPercentage:
+        donation.donationPercentage === null ||
+        donation.donationPercentage === undefined
+          ? null
+          : Number(donation.donationPercentage),
+      qfRoundUserScore: donation.qfRoundUserScore ?? null,
+      verifyErrorMessage: donation.verifyErrorMessage || null,
+      qfRoundErrorMessage: donation.qfRoundErrorMessage || null,
+    });
+  }
+
+  return {
+    csvContent: generateCsv(rows),
+    fileName: buildFileName(),
+    totalDonations: rows.length,
+  };
+};
+
+const findExportableDonations = async (
+  filters: ExportEligibleDonationsFilters,
+): Promise<Donation[]> => {
+  const query = Donation.createQueryBuilder('donation')
+    .leftJoinAndSelect('donation.user', 'user')
+    .leftJoinAndSelect('donation.project', 'project')
+    .leftJoinAndSelect('project.adminUser', 'projectAdmin')
+    .leftJoinAndSelect('donation.qfRound', 'qfRound')
+    .leftJoinAndSelect('donation.recurringDonation', 'recurringDonation')
+    .where('donation.status = :status', {
+      status: DONATION_STATUS.VERIFIED,
+    })
+    .andWhere('donation."valueUsd" IS NOT NULL')
+    .andWhere('donation."distributedFundQfRoundId" IS NULL')
+    .orderBy('donation.createdAt', 'DESC');
+
+  const fromDate = filters.fromDate
+    ? parseDateFilter(filters.fromDate, 'fromDate')
+    : undefined;
+  const toDate = filters.toDate
+    ? parseDateFilter(filters.toDate, 'toDate')
+    : undefined;
+
+  if (fromDate || toDate) {
+    const regularCreatedAtConditions: string[] = [
+      'donation."recurringDonationId" IS NULL',
+    ];
+    const recurringPeriodEndConditions: string[] = [
+      'donation."recurringDonationId" IS NOT NULL',
+    ];
+
+    if (fromDate) {
+      regularCreatedAtConditions.push('donation."createdAt" >= :fromDate');
+      recurringPeriodEndConditions.push(
+        'donation."virtualPeriodEnd" >= :fromDateTimestamp',
+      );
+      query.setParameter('fromDate', fromDate);
+      query.setParameter('fromDateTimestamp', dateToUnixSeconds(fromDate));
+    }
+
+    if (toDate) {
+      regularCreatedAtConditions.push('donation."createdAt" <= :toDate');
+      recurringPeriodEndConditions.push(
+        'donation."virtualPeriodEnd" <= :toDateTimestamp',
+      );
+      query.setParameter('toDate', toDate);
+      query.setParameter('toDateTimestamp', dateToUnixSeconds(toDate));
+    }
+
+    query.andWhere(
+      `((${regularCreatedAtConditions.join(
+        ' AND ',
+      )}) OR (${recurringPeriodEndConditions.join(' AND ')}))`,
+    );
+  }
+
+  if (filters.networkId) {
+    query.andWhere('donation."transactionNetworkId" = :networkId', {
+      networkId: filters.networkId,
+    });
+  }
+
+  if (filters.projectId) {
+    query.andWhere('donation."projectId" = :projectId', {
+      projectId: filters.projectId,
+    });
+  }
+
+  if (filters.userId) {
+    query.andWhere('donation."userId" = :userId', {
+      userId: filters.userId,
+    });
+  }
+
+  return query.getMany();
+};
+
+const consolidateRecurringDonations = (
+  donations: Donation[],
+): ConsolidatedDonation[] => {
+  const consolidated = new Map<number, ConsolidatedDonation>();
+  const regularDonations: ConsolidatedDonation[] = [];
+
+  for (const donation of donations) {
+    if (!donation.recurringDonationId) {
+      const regularDonation = donation as ConsolidatedDonation;
+      regularDonation.legacyRecurringDonationId = null;
+      regularDonation.parentRecurringDonationTxHash = null;
+      regularDonation.legacyVirtualPeriodStart = null;
+      regularDonation.legacyVirtualPeriodEnd = null;
+      regularDonations.push(regularDonation);
+      continue;
+    }
+
+    const recurringDonationId = donation.recurringDonationId;
+    const existing = consolidated.get(recurringDonationId);
+    const periodStart = unixSecondsToDate(donation.virtualPeriodStart);
+    const periodEnd = unixSecondsToDate(donation.virtualPeriodEnd);
+
+    if (!existing) {
+      const recurringDonation = donation as ConsolidatedDonation;
+      recurringDonation.transactionId = `recurring-${recurringDonationId}`;
+      recurringDonation.legacyRecurringDonationId = recurringDonationId;
+      recurringDonation.parentRecurringDonationTxHash =
+        donation.recurringDonation?.txHash || null;
+      recurringDonation.legacyVirtualPeriodStart = periodStart;
+      recurringDonation.legacyVirtualPeriodEnd = periodEnd;
+      consolidated.set(recurringDonationId, recurringDonation);
+      continue;
+    }
+
+    existing.amount += donation.amount;
+    existing.valueUsd =
+      Number(existing.valueUsd || 0) + Number(donation.valueUsd || 0);
+    existing.parentRecurringDonationTxHash ||=
+      donation.recurringDonation?.txHash || null;
+
+    if (
+      periodStart &&
+      (!existing.legacyVirtualPeriodStart ||
+        periodStart < existing.legacyVirtualPeriodStart)
+    ) {
+      existing.legacyVirtualPeriodStart = periodStart;
+    }
+
+    if (
+      periodEnd &&
+      (!existing.legacyVirtualPeriodEnd ||
+        periodEnd > existing.legacyVirtualPeriodEnd)
+    ) {
+      existing.legacyVirtualPeriodEnd = periodEnd;
+    }
+  }
+
+  return [...regularDonations, ...consolidated.values()];
+};
+
+const getPurpleListAddressKeys = async (): Promise<Set<string>> => {
+  const [projectAddresses, verifiedForms] = await Promise.all([
+    ProjectAddress.createQueryBuilder('projectAddress')
+      .innerJoin('projectAddress.project', 'project')
+      .where('projectAddress.isRecipient = true')
+      .andWhere('project.verified = true')
+      .andWhere('project.statusId = :statusId', {
+        statusId: ProjStatus.active,
+      })
+      .select(['projectAddress.address', 'projectAddress.chainType'])
+      .getMany(),
+    ProjectVerificationForm.find({
+      where: {
+        status: PROJECT_VERIFICATION_STATUSES.VERIFIED,
+        project: {
+          reviewStatus: ReviewStatus.Listed,
+          statusId: ProjStatus.active,
+        } as Project,
+      },
+      relations: ['project'],
+    }),
+  ]);
+  const keys = new Set<string>();
+
+  projectAddresses.forEach(address => {
+    keys.add(buildPurpleListKey(address.address, address.chainType));
+  });
+  verifiedForms
+    .flatMap(form => form.managingFunds?.relatedAddresses || [])
+    .forEach(address => {
+      if (!address.address) return;
+
+      keys.add(
+        buildPurpleListKey(
+          address.address,
+          resolveChainType(address.chainType),
+        ),
+      );
+    });
+
+  return keys;
+};
+
+const buildEligibilityFailureReasons = (input: {
+  isDonorPurpleListed: boolean;
+  isProjectGivbacksEligibleSnapshot: boolean;
+  tokenIsGivbacksEligible: boolean;
+  meetsEligibilityAmountThreshold: boolean;
+}): string[] => {
+  const reasons: string[] = [];
+
+  if (input.isDonorPurpleListed) {
+    reasons.push('PURPLE_LISTED');
+  }
+
+  if (!input.isProjectGivbacksEligibleSnapshot) {
+    reasons.push('PROJECT_NOT_GIVBACKS_ELIGIBLE_SNAPSHOT');
+  }
+
+  if (!input.tokenIsGivbacksEligible) {
+    reasons.push('TOKEN_NOT_GIVBACKS_ELIGIBLE');
+  }
+
+  if (!input.meetsEligibilityAmountThreshold) {
+    reasons.push('BELOW_MINIMUM_USD_AMOUNT');
+  }
+
+  return reasons;
+};
+
+const buildPurpleListKey = (address: string, chainType: ChainType): string =>
+  `${chainType}:${normalizeAddress(address, chainType)}`;
+
+const buildTokenAddressKey = (
+  chainType: ChainType,
+  networkId: number,
+  address: string,
+): string =>
+  `${chainType}:${networkId}:${normalizeAddress(address, chainType)}`;
+
+const buildTokenSymbolKey = (
+  chainType: ChainType,
+  networkId: number,
+  symbol: string,
+): string => `${chainType}:${networkId}:${symbol.toUpperCase()}`;
+
+const normalizeAddress = (address: string, chainType: ChainType): string => {
+  const normalizedAddress = address.trim();
+  return chainType === ChainType.EVM
+    ? normalizedAddress.toLowerCase()
+    : normalizedAddress;
+};
+
+const resolveChainType = (chainType: unknown): ChainType => {
+  if (
+    typeof chainType === 'string' &&
+    Object.values(ChainType).includes(chainType.toUpperCase() as ChainType)
+  ) {
+    return chainType.toUpperCase() as ChainType;
+  }
+
+  return ChainType.EVM;
+};
+
+const isGivethCommunityOfMakersProject = (projectSlug: string): boolean =>
+  GIVETH_COMMUNITY_OF_MAKERS_SLUGS.has(projectSlug);
+
+const normalizeGivbackFactor = (value: unknown): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+};
+
+const normalizeThreshold = (
+  value: string | number | null,
+  fallbackValue: number,
+): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallbackValue;
+};
+
+const getNetworkNameById = (networkId: number): string =>
+  NETWORKS_IDS_TO_NAME[networkId] || String(networkId);
+
+const parseDateFilter = (
+  value: string,
+  fieldName: 'fromDate' | 'toDate',
+): Date => {
+  const parsedDate = new Date(value);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    throw new Error(`Invalid ${fieldName} value`);
+  }
+
+  if (fieldName === 'toDate' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    parsedDate.setUTCHours(23, 59, 59, 999);
+  }
+
+  return parsedDate;
+};
+
+const dateToUnixSeconds = (date: Date): number =>
+  Math.floor(date.getTime() / 1000);
+
+const unixSecondsToDate = (value?: number | null): Date | null => {
+  if (!value) return null;
+  return new Date(value * 1000);
+};
+
+const buildFileName = (): string => {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  return `givbacks-eligible-donations-${timestamp}.csv`;
+};
+
+const generateCsv = (rows: DonationExportRow[]): string => {
+  const csvRows = [DONATION_EXPORT_HEADERS.join(',')];
+
+  for (const row of rows) {
+    const values = DONATION_EXPORT_HEADERS.map(header =>
+      escapeCsvValue(row[header]),
+    );
+    csvRows.push(values.join(','));
+  }
+
+  return csvRows.join('\n');
+};
+
+const escapeCsvValue = (value: CsvValue): string => {
+  if (value === null) {
+    return '';
+  }
+
+  let stringValue = String(value);
+  if (['=', '+', '-', '@', '\t', '\r'].includes(stringValue.charAt(0))) {
+    stringValue = `'${stringValue}`;
+  }
+
+  if (
+    stringValue.includes(',') ||
+    stringValue.includes('"') ||
+    stringValue.includes('\n') ||
+    stringValue.includes('\r') ||
+    stringValue.includes('\t')
+  ) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+
+  return stringValue;
+};

--- a/src/services/givbacksEligibleDonationsCsvService.ts
+++ b/src/services/givbacksEligibleDonationsCsvService.ts
@@ -622,7 +622,7 @@ const generateCsv = (rows: DonationExportRow[]): string => {
     csvRows.push(values.join(','));
   }
 
-  return csvRows.join('\n');
+  return csvRows.join('\r\n');
 };
 
 const escapeCsvValue = (value: CsvValue): string => {


### PR DESCRIPTION
## Issue


## Summary

Adds a v5 admin CSV export for GivBacks donation review, matching the v6 export shape closely enough for support to compare old v5 donations against v6 migration results. The export evaluates verified donations against eligibility rules, consolidates recurring donation stream periods, and includes the recurring parent transaction hash.

## Changes

- Added a GivBacks eligible donations CSV export service for v5 donations.
- Consolidated recurring donation rows by `recurringDonationId`, preserving parent `txHash`, total amount, total USD value, and virtual period boundaries.
- Added token, project snapshot, purple-list, threshold, GivBack factor, QF round, donor, and admin metadata to the CSV output.
- Added an AdminJS download screen with optional filters for date range, network, project, user, and eligibility status.
- Wired the new export action into the Donation admin resource.
- Added regression coverage for exporting regular donations alongside consolidated recurring donations with parent hash.

## How to Test

Draft for review and adjustment:

1. Run typecheck:
   `npx tsc --noEmit --pretty false`

2. Run lint:
   `npx eslint src/services/givbacksEligibleDonationsCsvService.ts src/services/givbacksEligibleDonationsCsvService.test.ts src/server/adminJs/tabs/donationTab.ts src/server/adminJs/adminJs-types.ts`

3. Run the focused test:
   `NODE_ENV=test npx mocha --require ts-node/register --timeout 90000 --exit ./test/pre-test-scripts.ts ./src/services/givbacksEligibleDonationsCsvService.test.ts`

4. Start the app and open AdminJS.

5. Go to Donation admin actions and open `exportGivbacksEligibleDonations`.

6. Export with no filters and confirm a CSV downloads.

7. Export with filters such as:
   - `projectId`
   - `networkId`
   - `fromDate` / `toDate`
   - `Eligibility = Eligible only`

8. Confirm recurring donations are represented as one row per `recurringDonationId`, with:
   - `transactionId = recurring-<id>`
   - `legacyRecurringDonationId`
   - `parentRecurringDonationTxHash`
   - `legacyVirtualPeriodStart`
   - `legacyVirtualPeriodEnd`
   - summed `amount` and `valueUsd`

9. Compare a sample of v5 exported recurring donations against v6 export rows to verify parent hash and eligibility data are available for support review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV export functionality for GivBack eligible donations in the admin panel.
  * Users can filter donations by date range, network, project ID, and user ID before exporting.
  * View current eligibility thresholds before exporting.
  * Download filtered donation data with comprehensive fields and eligibility information.

* **Tests**
  * Added comprehensive test coverage for the CSV export feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Giveth/impact-graph/pull/2322)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->