### PR TITLE
Bump updatedAt on every project status change

### DIFF
--- a/src/repositories/projectRepository.ts
+++ b/src/repositories/projectRepository.ts
@@ -700,10 +700,14 @@ export const totalProjectsPerDateByMonthAndYear = async (
 };
 
 export const makeProjectListed = async (id: number): Promise<void> => {
+  // updatedAt bump is required so giveth-v6-core's legacy sync recognizes this
+  // change as newer than its mirror row. Without it, the v6 row's updated_at
+  // stays ahead and the next v5→v6 pull skips the update.
   await Project.createQueryBuilder('broadcast_notification')
     .update<Project>(Project, {
       listed: true,
       reviewStatus: ReviewStatus.Listed,
+      updatedAt: new Date(),
     })
     .where(`id =${id}`)
     .updateEntity(true)

--- a/src/server/adminJs/tabs/projectsTab.ts
+++ b/src/server/adminJs/tabs/projectsTab.ts
@@ -262,7 +262,10 @@ export const verifyProjects = async (
       }
     }
 
-    const updateParams = { verified: vouchedStatus };
+    // updatedAt bump keeps giveth-v6-core's legacy sync timestamp guard
+    // aligned; .createQueryBuilder().update() bypasses TypeORM entity hooks
+    // so we set it explicitly here.
+    const updateParams = { verified: vouchedStatus, updatedAt: new Date() };
 
     // Perform the update
     await Project.createQueryBuilder('project')
@@ -352,7 +355,10 @@ export const updateStatusOfProjects = async (
     where: { id: status },
   });
   if (projectStatus) {
-    const updateData: any = { status: projectStatus };
+    // updatedAt bump keeps giveth-v6-core's legacy sync timestamp guard
+    // aligned; .createQueryBuilder().update() bypasses TypeORM entity hooks
+    // so we set it explicitly here.
+    const updateData: any = { status: projectStatus, updatedAt: new Date() };
     if (status === ProjStatus.cancelled || status === ProjStatus.deactive) {
       updateData.listed = false;
       updateData.reviewStatus = ReviewStatus.NotListed;
@@ -600,8 +606,11 @@ export const listDelist = async (
       ?.split(',')
       ?.map(strId => Number(strId)) as number[];
     const projectsBeforeUpdating = await findProjectsByIdArray(projectIds);
+    // updatedAt bump keeps giveth-v6-core's legacy sync timestamp guard
+    // aligned; .createQueryBuilder().update() bypasses TypeORM entity hooks
+    // so we set it explicitly here.
     const projects = await Project.createQueryBuilder('project')
-      .update<Project>(Project, { reviewStatus, listed })
+      .update<Project>(Project, { reviewStatus, listed, updatedAt: new Date() })
       .where('project.id IN (:...ids)')
       .setParameter('ids', projectIds)
       .returning('*')
@@ -1121,6 +1130,7 @@ export const projectsTab = {
                 where: { id: request?.record?.params?.newAdminId },
               });
               project.adminUser = adminUser!;
+              project.updatedAt = new Date();
               await project.save();
 
               // Update project verification form owner if it has been changed
@@ -1234,6 +1244,7 @@ export const projectsTab = {
               statusChanges?.includes(NOTIFICATIONS_EVENT_NAMES.PROJECT_LISTED)
             ) {
               project.listed = true;
+              project.updatedAt = new Date();
               await project.save();
             }
 
@@ -1243,6 +1254,7 @@ export const projectsTab = {
               )
             ) {
               project.listed = false;
+              project.updatedAt = new Date();
               await project.save();
             }
 
@@ -1252,6 +1264,7 @@ export const projectsTab = {
               )
             ) {
               project.listed = null;
+              project.updatedAt = new Date();
               await project.save();
             }
 
@@ -1424,5 +1437,6 @@ async function saveCategories(project: Project, categoryIds?: string[]) {
     .getMany();
 
   project.categories = categories;
+  project.updatedAt = new Date();
   await project.save();
 }


### PR DESCRIPTION
## Summary
Required companion to [giveth-v6-core#325](https://github.com/Giveth/giveth-v6-core/pull/325).

`Project.updatedAt` is declared with `@Column({ nullable: true })`, not `@UpdateDateColumn`, so TypeORM never auto-bumps it. The admin and cron paths also use `.createQueryBuilder().update()`, which bypasses entity hooks entirely. The result: a project's `updatedAt` stays at its previous value even when its status, listing, or vouched flag changes.

The new v5↔v6 sync in v6-core uses `updatedAt` as a last-write-wins tie-breaker. With this gap, a status change made in v5 admin can be silently reverted on the next v5→v6 pull because v6's mirror row appears newer.

## Changes
Explicitly set `updatedAt = new Date()` in the five paths that mutate status fields:

- [`makeProjectListed`](src/repositories/projectRepository.ts#L702) — daily auto-listing cron
- [`verifyProjects`](src/server/adminJs/tabs/projectsTab.ts#L241) — bulk vouch/unvouch admin action
- [`updateStatusOfProjects`](src/server/adminJs/tabs/projectsTab.ts#L340) — bulk active / deactive / cancel
- [`listDelist`](src/server/adminJs/tabs/projectsTab.ts#L576) — bulk list / unlist
- The AdminJS edit `after` hook's `project.save()` calls — admin transfer + per-status side-effects
- `saveCategories` — admin category edit

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on touched files
- [x] Pre-commit hook ran on push
- [ ] Manual: change a project's status as v5 admin; verify the DB row's `updatedAt` is now `NOW()` instead of the previous value
- [ ] Manual: change a project's status as v5 admin, then wait for v6's legacy sync tick (default 30 min); confirm v6 picks up the change and does NOT revert it on the next cycle

## Related
- v6-core PR: [Giveth/giveth-v6-core#325](https://github.com/Giveth/giveth-v6-core/pull/325)
- Issue: [Giveth/giveth-v6-core#78](https://github.com/Giveth/giveth-v6-core/issues/78)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing timestamp updates when modifying projects through admin actions, including when listing projects, changing status, verifying projects, updating admin users, and managing categories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Giveth/impact-graph/pull/2325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->