### PR TITLE
Fix Stellar BE draft donation checks

### DIFF
--- a/src/services/cronJobs/checkQRTransactionJob.ts
+++ b/src/services/cronJobs/checkQRTransactionJob.ts
@@ -120,7 +120,7 @@ export async function checkTransactions(
             }
           } else if (memo !== id.toString()) {
             logger.debug(
-              `Transaction memo does not match donation ID for donation ID ${donation.id}`,
+              `Transaction memo does not match draft id for donation ID ${donation.id}`,
             );
             continue;
           }

--- a/src/services/cronJobs/checkQRTransactionJob.ts
+++ b/src/services/cronJobs/checkQRTransactionJob.ts
@@ -78,11 +78,16 @@ export async function checkTransactions(
     const transactions = response.data._embedded.records;
     if (!transactions.length) return;
 
+    // Only consider payments made at/after this draft was created (with a small
+    // clock-skew allowance). The memo + amount already uniquely identify the
+    // donation, so we match across the whole draft lifetime instead of a narrow
+    // 2-minute window — otherwise a valid payment is lost whenever the cron
+    // doesn't inspect it within 120s (e.g. when the jobs worker lags).
+    const CLOCK_SKEW = 60 * 1000;
+    const draftCreatedAt = new Date(donation.createdAt).getTime();
+
     for (const transaction of transactions) {
       const transactionCreatedAt = new Date(transaction.created_at).getTime();
-      const transactionAge = Date.now() - transactionCreatedAt;
-
-      const TWO_MINUTES = 2 * 60 * 1000;
 
       const isNativePayment =
         transaction.asset_type === 'native' &&
@@ -96,7 +101,8 @@ export async function checkTransactions(
         Number(transaction.starting_balance) === amount;
 
       const isMatchingTransaction =
-        (isNativePayment || isCreateAccount) && transactionAge < TWO_MINUTES;
+        (isNativePayment || isCreateAccount) &&
+        transactionCreatedAt >= draftCreatedAt - CLOCK_SKEW;
 
       if (isMatchingTransaction) {
         const memo = transaction.transaction.memo;
@@ -107,13 +113,16 @@ export async function checkTransactions(
               logger.debug(
                 `Transaction memo does not match donation memo for donation ID ${donation.id}`,
               );
-              return;
+              // Skip this payment and keep scanning: another donation to the
+              // same address may carry a different memo. Bailing here (return)
+              // would abandon the search before reaching this donation's payment.
+              continue;
             }
           } else if (memo !== id.toString()) {
             logger.debug(
-              `Transaction memo matches donation memo for donation ID ${donation.id}`,
+              `Transaction memo does not match donation ID for donation ID ${donation.id}`,
             );
-            return;
+            continue;
           }
         }
 


### PR DESCRIPTION
## Summary

Fixes the Stellar QR draft-donation matcher (`checkQRTransactionJob`) so on-chain payments are reliably matched to their draft donations. Previously, valid donations were frequently marked `failed` even though the payment was on-chain, correct, and within the draft's validity window.

Three independent bugs in `src/services/cronJobs/checkQRTransactionJob.ts` combined to cause this:

## Bug 1 — `return` → `continue` on memo mismatch (Critical)

**Old behavior:** When a transaction matched the address + amount but had the wrong memo, the code called `return`, exiting the entire `checkTransactions` function. With a wallet that receives multiple payments, the job would silently give up as soon as it hit *any* unrelated payment to the same address — never reaching the correct one.

**New behavior:** `continue` skips the non-matching payment and keeps scanning.

This is the most impactful fix: donations to a shared address with the same amount would consistently block each other.

## Bug 2 — Time window: `transactionAge < 2min` → `transactionCreatedAt >= draftCreatedAt - CLOCK_SKEW` (Important)

**Old behavior:** Only matched transactions created within the last 2 minutes. Any worker lag, backpressure, or re-queuing beyond 120s caused a valid payment to be permanently missed — even though it was on-chain and the draft hadn't expired.

**New behavior:** Matches any payment made on or after the draft was created (minus a 60s clock-skew allowance). The memo + amount already uniquely identify the payment, so the broader window is safe, and the existing `expiresAt` check still caps the overall processing window — so matching is not indefinite.

## Bug 3 — Incorrect log message (Minor)

The `else if (memo !== id.toString())` branch logged `"Transaction memo matches donation memo"` — the exact opposite of what was happening. Corrected to `"... does not match ..."`.

## Root-cause evidence

Reproduced on staging with a perfect payment that still failed:

- Draft `2229`: `pending`, amount `0.0002`, address `GBOWT4…I44G6`, expected memo `2229`, created `12:18:43`, expires `12:33:43`.
- On-chain payment at `12:19:00` (17s after creation): `amount=0.0002000`, `memo=2229`, `to=GBOWT4…`, `ok=true` — all four match conditions satisfied.
- Result: no match attempt logged; draft expired and emitted `draft-donation-failed` at `12:33:46`.

The payment was only eligible for matching between `12:19:00` and `12:21:00` (the 2-minute window). The jobs worker (event loop congested / `unhealthy`) didn't inspect it in that slot, so it could never match afterward. Bug 2 fixes this; Bug 1 fixes the separate multi-payment collision case.

## Known limitation (pre-existing, not addressed here)

Horizon payments are fetched with `?limit=200&order=desc`, and the endpoint cannot filter by memo. For a wallet that receives **more than 200 payments** between draft creation and expiry, the matching payment could fall outside the first page. Acceptable for normal volume; a follow-up could paginate until `transactionCreatedAt < draftCreatedAt`.

## Notes

- Change is confined to the **Stellar QR matcher** (the `jobs` role / `ENABLE_CRONJOBS=true`). It does not touch the EVM `draftDonationService` amount logic.
- Separately worth addressing in ops: the `impact-graph-jobs` container has been `unhealthy` — Bug 2 makes matching tolerant of cron lag, but the worker's health should still be investigated.

## Testing

- Built the image from this branch and ran it locally against the existing Postgres/Redis; confirmed `checkQRTransactionJob` registers and the SSE `/events` pipeline (`notifyClients` → Redis → graphql containers → browser) delivers `new-donation`.
- Verified a draft whose payment lands inside its lifetime now matches (instead of expiring), and that a sibling payment with a different memo no longer aborts the scan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stellar QR payments now match transactions against the full draft lifetime (with clock-skew tolerance) instead of a fixed short window.
  * Memo mismatches no longer stop scanning; mismatched transactions are skipped so additional qualifying donations to the same address can be discovered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->