### PR TITLE
fix: make API resilient to DB/pooler connection loss

### DIFF
--- a/config/example.env
+++ b/config/example.env
@@ -13,8 +13,9 @@ TYPEORM_LOGGING=
 # connection limit. Behind DigitalOcean managed Postgres / PgBouncer,
 # oversizing this (e.g. 97 per process across 5 processes) exhausts the pooler
 # and triggers "server login has been failing ... (server_login_retry)" errors.
-# (The jobs process also opens a small separate CronDataSource pool of up to
-# ~10 connections on top of this value.)
+# (The jobs process also opens a separate CronDataSource pool that does NOT
+# honor this setting — it uses node-postgres' default of ~10 connections — so
+# count ~10 extra for that process on top of this value.)
 TYPEORM_DATABASE_POOL_SIZE=
 DROP_DATABASE=
 APOLLO_KEY=

--- a/config/example.env
+++ b/config/example.env
@@ -7,6 +7,14 @@ TYPEORM_DATABASE_PASSWORD=
 TYPEORM_DATABASE_HOST=
 TYPEORM_DATABASE_PORT=
 TYPEORM_LOGGING=
+# Per-process node-postgres pool size (default 10 if empty). The effective DB
+# connection count is this value x number of app processes (each graphql
+# instance + the jobs process). Keep the total well under the database/pooler
+# connection limit. Behind DigitalOcean managed Postgres / PgBouncer,
+# oversizing this (e.g. 97 per process across 5 processes) exhausts the pooler
+# and triggers "server login has been failing ... (server_login_retry)" errors.
+# (The jobs process also opens a small separate CronDataSource pool of up to
+# ~10 connections on top of this value.)
 TYPEORM_DATABASE_POOL_SIZE=
 DROP_DATABASE=
 APOLLO_KEY=

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
 import 'reflect-metadata';
+import { registerGlobalErrorHandlers } from './utils/globalErrorHandlers';
 import { bootstrap } from './server/bootstrap';
+
+// Register process-level error handlers before anything async runs so a
+// transient DB/pooler error rejecting a promise cannot crash the whole API.
+registerGlobalErrorHandlers();
 
 bootstrap();

--- a/src/orm.ts
+++ b/src/orm.ts
@@ -5,6 +5,20 @@ import { CronJob } from './entities/CronJob';
 import { getEntities } from './entities/entities';
 import { redisConfig } from './redis';
 
+// Shared connection-pool tuning for DataSources that run behind a Postgres
+// connection pooler (DigitalOcean managed Postgres / PgBouncer).
+const poolerExtraConfig = {
+  // Recycling idle connections every 500ms (the previous idleTimeoutMillis)
+  // caused constant reconnect + login churn against the pooler, surfacing in
+  // production as "server login has been failing ... (server_login_retry)" errors.
+  idleTimeoutMillis: 30000,
+  // Fail fast instead of hanging forever when a connection cannot be acquired
+  // during a pooler stall, so requests error out quickly and the pool can recover.
+  connectionTimeoutMillis: 10000,
+  // (maxWaitingClients / evictionRunIntervalMillis were generic-pool options
+  // that node-postgres ignores, so they were removed.)
+};
+
 export class AppDataSource {
   private static datasource: DataSource;
 
@@ -52,20 +66,7 @@ export class AppDataSource {
           },
         },
         poolSize,
-        extra: {
-          // The service runs behind a Postgres connection pooler (DigitalOcean
-          // managed Postgres / PgBouncer). Recycling idle connections every
-          // 500ms (the previous idleTimeoutMillis) caused constant reconnect +
-          // login churn against the pooler, surfacing in production as
-          // "server login has been failing ... (server_login_retry)" errors.
-          idleTimeoutMillis: 30000,
-          // Fail fast instead of hanging forever when a connection cannot be
-          // acquired during a pooler stall, so requests error out quickly and
-          // the pool can recover.
-          connectionTimeoutMillis: 10000,
-          // (maxWaitingClients / evictionRunIntervalMillis were generic-pool
-          // options that node-postgres ignores, so they were removed.)
-        },
+        extra: poolerExtraConfig,
       });
       await AppDataSource.datasource.initialize();
     }
@@ -90,20 +91,7 @@ export class CronDataSource {
         entities: [CronJob],
         synchronize: false,
         dropSchema: false,
-        extra: {
-          // The service runs behind a Postgres connection pooler (DigitalOcean
-          // managed Postgres / PgBouncer). Recycling idle connections every
-          // 500ms (the previous idleTimeoutMillis) caused constant reconnect +
-          // login churn against the pooler, surfacing in production as
-          // "server login has been failing ... (server_login_retry)" errors.
-          idleTimeoutMillis: 30000,
-          // Fail fast instead of hanging forever when a connection cannot be
-          // acquired during a pooler stall, so requests error out quickly and
-          // the pool can recover.
-          connectionTimeoutMillis: 10000,
-          // (maxWaitingClients / evictionRunIntervalMillis were generic-pool
-          // options that node-postgres ignores, so they were removed.)
-        },
+        extra: poolerExtraConfig,
       });
       await CronDataSource.datasource.initialize();
     }

--- a/src/orm.ts
+++ b/src/orm.ts
@@ -53,9 +53,18 @@ export class AppDataSource {
         },
         poolSize,
         extra: {
-          maxWaitingClients: 10,
-          evictionRunIntervalMillis: 500,
-          idleTimeoutMillis: 500,
+          // The service runs behind a Postgres connection pooler (DigitalOcean
+          // managed Postgres / PgBouncer). Recycling idle connections every
+          // 500ms (the previous idleTimeoutMillis) caused constant reconnect +
+          // login churn against the pooler, surfacing in production as
+          // "server login has been failing ... (server_login_retry)" errors.
+          idleTimeoutMillis: 30000,
+          // Fail fast instead of hanging forever when a connection cannot be
+          // acquired during a pooler stall, so requests error out quickly and
+          // the pool can recover.
+          connectionTimeoutMillis: 10000,
+          // (maxWaitingClients / evictionRunIntervalMillis were generic-pool
+          // options that node-postgres ignores, so they were removed.)
         },
       });
       await AppDataSource.datasource.initialize();
@@ -82,9 +91,18 @@ export class CronDataSource {
         synchronize: false,
         dropSchema: false,
         extra: {
-          maxWaitingClients: 10,
-          evictionRunIntervalMillis: 500,
-          idleTimeoutMillis: 500,
+          // The service runs behind a Postgres connection pooler (DigitalOcean
+          // managed Postgres / PgBouncer). Recycling idle connections every
+          // 500ms (the previous idleTimeoutMillis) caused constant reconnect +
+          // login churn against the pooler, surfacing in production as
+          // "server login has been failing ... (server_login_retry)" errors.
+          idleTimeoutMillis: 30000,
+          // Fail fast instead of hanging forever when a connection cannot be
+          // acquired during a pooler stall, so requests error out quickly and
+          // the pool can recover.
+          connectionTimeoutMillis: 10000,
+          // (maxWaitingClients / evictionRunIntervalMillis were generic-pool
+          // options that node-postgres ignores, so they were removed.)
         },
       });
       await CronDataSource.datasource.initialize();

--- a/src/sentryLogger.ts
+++ b/src/sentryLogger.ts
@@ -10,6 +10,17 @@ Sentry.init({
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control
   tracesSampleRate: 1.0,
+
+  // Crash/rejection handling lives in src/utils/globalErrorHandlers.ts, which
+  // registers our own process-level handlers (keep-alive on unhandledRejection,
+  // clean exit on uncaughtException). Disable Sentry's built-in global handlers
+  // so errors aren't captured twice and the handlers don't race to exit.
+  integrations: defaults =>
+    defaults.filter(
+      integration =>
+        integration.name !== 'OnUncaughtException' &&
+        integration.name !== 'OnUnhandledRejection',
+    ),
 });
 
 export default Sentry;

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -35,6 +35,7 @@ import {
   translationErrorMessagesKeys,
 } from '../utils/errorMessages';
 import { logger } from '../utils/logger';
+import { flushSentryAndExit } from '../utils/globalErrorHandlers';
 import { isTrustedVercelRequest } from '../utils/ipWhitelist';
 import { adminJsRootPath, getAdminJsRouter } from './adminJs/adminJs';
 // import { apiGivRouter } from '../routers/apiGivRoutes';
@@ -426,6 +427,17 @@ export async function bootstrap() {
     });
   } catch (err) {
     logger.fatal('bootstrap() error', err);
+    SentryLogger.captureException(err as Error);
+    // A failure during startup (e.g. the database/pooler being unreachable when
+    // AppDataSource.initialize() runs) leaves the process with no HTTP listener
+    // on port 4000 — a zombie that `restart: always` never recovers, because the
+    // restart policy only fires on process exit. Exit so the container is
+    // recreated cleanly and self-heals once the dependency is reachable again.
+    // Skipped under tests so a failed bootstrap is reported by the test runner
+    // instead of abruptly terminating it.
+    if (!isTestEnv) {
+      flushSentryAndExit();
+    }
   }
 
   async function continueDbSetup() {

--- a/src/utils/globalErrorHandlers.ts
+++ b/src/utils/globalErrorHandlers.ts
@@ -1,0 +1,67 @@
+import { logger } from './logger';
+import SentryLogger from '../sentryLogger';
+
+/**
+ * Registers process-level handlers for errors that escape application code.
+ *
+ * Why this exists: the API runs behind a Postgres connection pooler
+ * (DigitalOcean managed Postgres / PgBouncer). When the pooler or database has
+ * a transient problem, in-flight DB queries reject. Without an
+ * `unhandledRejection` listener, Node (>= 15) terminates the whole process on
+ * the first such rejection, taking the entire API down for a momentary DB blip.
+ *
+ * Behaviour:
+ *  - unhandledRejection: log + report to Sentry, then KEEP the process alive.
+ *    A single rejected promise (often a transient DB error) must not tear down
+ *    the server; it should keep serving and recover once the DB is reachable.
+ *  - uncaughtException: log + report to Sentry, then EXIT. The process state is
+ *    undefined after an uncaught exception, so we let the container restart
+ *    policy (`restart: always`) recreate a clean process.
+ */
+let handlersRegistered = false;
+
+export function registerGlobalErrorHandlers(): void {
+  // Idempotent: never attach the listeners more than once.
+  if (handlersRegistered) {
+    return;
+  }
+  handlersRegistered = true;
+
+  process.on('unhandledRejection', (reason: unknown) => {
+    logger.error('unhandledRejection - process kept alive', reason);
+    captureToSentry(reason);
+  });
+
+  process.on('uncaughtException', (error: Error) => {
+    logger.fatal('uncaughtException - exiting for a clean restart', error);
+    captureToSentry(error);
+    flushSentryAndExit();
+  });
+}
+
+function captureToSentry(error: unknown): void {
+  try {
+    SentryLogger.captureException(
+      error instanceof Error ? error : new Error(String(error)),
+    );
+  } catch {
+    // Never let error reporting throw from inside an error handler.
+  }
+}
+
+/**
+ * Flushes pending Sentry events (best-effort, max 2s) and then exits with a
+ * non-zero code so the container restart policy (`restart: always`) recreates a
+ * clean process. Used by the uncaughtException handler above and by the
+ * bootstrap() startup-failure path.
+ */
+export function flushSentryAndExit(): void {
+  // A hard fallback guarantees the process exits even if flushing stalls.
+  const forceExit = setTimeout(() => process.exit(1), 3000);
+  void SentryLogger.close(2000)
+    .catch(() => undefined)
+    .then(() => {
+      clearTimeout(forceExit);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Problem

Production (`mainnet`) and staging both went down and required a **manual full redeploy** to recover. Logs showed:

- `error: server login has been failing, cached error: connect failed (server_login_retry)` — a **PgBouncer** message; the app talks to **DigitalOcean managed Postgres via the PgBouncer pool** (`...ondigitalocean.com:25061`), and the pooler couldn't log in to the backend.
- `query failed: SELECT 1` — the failing health-check query (TypeORM `advanced-console` logger).
- `SyntaxError: ... is not valid JSON` / `BadRequestError: request aborted` — **noise** (handled 400s from garbage/aborted requests; printed by Express's default error handler because `NODE_ENV=production !== 'test'`). Not crashes.

## Root cause

A transient DB/pooler problem was amplified into a hard outage by several app-side issues:

1. **No process-level error handlers** → a rejected DB query during the blip crashed the whole Node process (`unhandledRejection`; Node ≥15 exits when there is no listener). *(Note: Sentry's default integrations partially masked this, but with `OnUncaughtException` also force-exiting.)*
2. **`idleTimeoutMillis: 500`** in `orm.ts` recycled idle connections **twice a second**, hammering the pooler with reconnect/login churn.
3. **No `connectionTimeoutMillis`** → during a pooler stall, `pool.connect()` waits **forever**, so requests hang instead of failing fast (matches the staging `jobs` health-check 10s timeouts).
4. **`bootstrap()` swallowed startup failures** — its `catch` only logged. If the DB was unreachable at startup, the process stayed up with **no HTTP listener on :4000** — a zombie that `restart: always` never restarts (the policy only fires on process *exit*). This is the most likely reason a **manual redeploy** was needed.
5. **Sentry's built-in `OnUncaughtException`/`OnUnhandledRejection`** integrations double-handled with any new handlers (double capture + racing `process.exit`).

## Changes

| File | Change |
|------|--------|
| `src/utils/globalErrorHandlers.ts` *(new)* | `unhandledRejection` → log + Sentry, **keep process alive** (a transient DB error must not kill the API). `uncaughtException` → log + Sentry, **flush + exit(1)** so Docker (`restart: always`) recreates a clean process. Idempotent. |
| `src/index.ts` | Register the handlers first thing, before `bootstrap()`. |
| `src/orm.ts` | `idleTimeoutMillis: 500 → 30000` and add `connectionTimeoutMillis: 10000` on **both** `AppDataSource` and `CronDataSource`. Removed `maxWaitingClients`/`evictionRunIntervalMillis` (generic-pool options that node-postgres ignores). |
| `src/server/bootstrap.ts` | On startup failure, capture to Sentry and **exit** (skipped under tests) so `restart: always` self-heals once the DB is reachable. |
| `src/sentryLogger.ts` | Disable Sentry's built-in global handlers so ours are the single source of truth (no double capture / exit race). |
| `config/example.env` | Document `TYPEORM_DATABASE_POOL_SIZE` sizing to prevent recurrence. |

## ⚠️ Required ops change (NOT in this PR)

The over-sized pool lives in the **gitignored** `config/production.env` on the server, so it can't be changed here:

- Prod `production.env` has **`TYPEORM_DATABASE_POOL_SIZE=97`** → with 4 `ql` + 1 `jobs` = **~485 connections** to the DO PgBouncer pool. **Reduce it** so `pool_size × num_processes` stays well under the DO pool/cluster connection limit (≈ **15–20** per process is a sane starting point; verify against the DO pool size & confirm pool mode = `transaction`).

## Testing (local)

- `tsc --noEmit`, `eslint`, `prettier --check`, full `npm run build` — all pass.
- Runtime smoke tests:
  - `unhandledRejection` → process stays alive (exit 0), error logged. ✅
  - `uncaughtException` → exits 1 after Sentry flush. ✅
  - Verified Sentry registers **0** global handlers after init (filter works); our handlers are the only app listeners; registration is idempotent. ✅
  - `flushSentryAndExit` (bootstrap startup-failure path) exits 1. ✅

## Reviewed

Ran an adversarial multi-dimension review (correctness / resilience / conventions / side-effects). All confirmed findings are addressed in this PR.

## Suggested follow-ups (out of scope here)

- **Add a Docker healthcheck** to the production/staging compose services hitting `/healthz`, so a non-serving-but-alive process is detectable.
- **Graceful shutdown** on `SIGTERM`/`SIGINT` (drain in-flight requests, `httpServer.close()`, `DataSource.destroy()`) to avoid abrupt connection teardown on deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup and process-level error handling to avoid zombie processes and ensure orderly shutdown.
  * Prevented duplicate error captures to monitoring by coordinating global handlers and SDK integrations.

* **Chores**
  * Tuned database connection pooling behavior for pooler environments.
  * Added documentation for connection-pool sizing and notes about extra cron connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->