### PR TITLE
Hotfix: clean request error handling + /admin/download traversal fix (production)

### DIFF
--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -211,8 +211,17 @@ export async function bootstrap() {
 
     // To download email addresses of projects in AdminJS projects tab
     app.get('/admin/download/:filename', (req, res) => {
-      const filename = req.params.filename;
-      const filePath = path.join(__dirname, '/adminJs/tabs/exports', filename);
+      const exportsDir = path.join(__dirname, '/adminJs/tabs/exports');
+      // Prevent path traversal: reduce to a bare filename (strips any `../`),
+      // then confirm the resolved path is directly inside the exports dir.
+      const filePath = path.join(
+        exportsDir,
+        path.basename(req.params.filename),
+      );
+      if (path.dirname(filePath) !== exportsDir) {
+        res.status(400).send('Invalid filename');
+        return;
+      }
       res.download(filePath);
     });
 

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -75,6 +75,7 @@ import { ApolloContext } from '../types/ApolloContext';
 import { isTestEnv } from '../utils/utils';
 import { ProjectResolverWorker } from '../workers/projectsResolverWorker';
 import { corsOptions, whitelistHostnames } from './cors';
+import { expressErrorHandler } from './expressErrorHandler';
 
 Resource.validate = validate;
 
@@ -402,6 +403,12 @@ export async function bootstrap() {
     app.get('/events', (_req: Request, res: Response) => {
       addClient(res);
     });
+
+    // Centralized error handler — must be registered after all routes so that
+    // malformed/aborted requests (and any unhandled route error) are turned
+    // into clean responses + concise logs instead of raw stack-trace noise,
+    // and genuine 5xx failures are reported to Sentry.
+    app.use(expressErrorHandler);
 
     const httpServer = http.createServer(app);
 

--- a/src/server/expressErrorHandler.ts
+++ b/src/server/expressErrorHandler.ts
@@ -23,25 +23,37 @@ interface HttpError extends Error {
  *
  * Policy:
  *  - Client errors (4xx): expected noise. Respond cleanly, log a single concise
- *    line (no stack trace), and DO NOT crash — otherwise any scanner could take
- *    the API down with one malformed request.
+ *    line (no stack, no message — 4xx messages can echo back user input/PII),
+ *    and DO NOT crash — otherwise any scanner could take the API down with one
+ *    malformed request.
  *  - Server errors (5xx): genuine server-side failures. Make them loud (bunyan
  *    error + Sentry) so they can't fail silently, while still serving other
- *    requests. Process-level fatal errors are handled separately by the
- *    global handlers in utils/globalErrorHandlers.ts (which exit for a clean
- *    container restart).
+ *    requests. Process-level fatal errors are handled separately by the global
+ *    handlers in utils/globalErrorHandlers.ts (which exit for a clean restart).
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function expressErrorHandler(
-  err: HttpError,
+  err: unknown,
   req: Request,
   res: Response,
   _next: NextFunction,
 ): void {
-  const status = err.status || err.statusCode || 500;
+  // Anything can be passed to next() (a string, null, a plain object). Coerce
+  // to an Error so the property access below can never crash the handler.
+  const error: HttpError =
+    err instanceof Error
+      ? err
+      : new Error(typeof err === 'string' ? err : 'Unknown error');
+
+  // Derive a valid HTTP status; fall back to 500 for anything out of range.
+  const candidate = error.status ?? error.statusCode ?? 500;
+  const status =
+    Number.isInteger(candidate) && candidate >= 100 && candidate <= 599
+      ? candidate
+      : 500;
 
   // Client disconnected mid-request: there is nothing to respond to.
-  if (err.type === 'request.aborted') {
+  if (error.type === 'request.aborted') {
     logger.debug('Request aborted by client', {
       method: req.method,
       path: req.path,
@@ -52,10 +64,9 @@ export function expressErrorHandler(
   if (status < 500) {
     logger.debug('Rejected bad request', {
       status,
-      type: err.type,
+      type: error.type,
       method: req.method,
       path: req.path,
-      message: err.message,
     });
     if (!res.headersSent) {
       res.sendStatus(status);
@@ -64,8 +75,8 @@ export function expressErrorHandler(
   }
 
   // Genuine server error — surface it loudly so it is never silent.
-  logger.error('Unhandled server error', err);
-  SentryLogger.captureException(err);
+  logger.error('Unhandled server error', error);
+  SentryLogger.captureException(error);
   if (!res.headersSent) {
     res.sendStatus(500);
   }

--- a/src/server/expressErrorHandler.ts
+++ b/src/server/expressErrorHandler.ts
@@ -31,7 +31,6 @@ interface HttpError extends Error {
  *    requests. Process-level fatal errors are handled separately by the global
  *    handlers in utils/globalErrorHandlers.ts (which exit for a clean restart).
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function expressErrorHandler(
   err: unknown,
   req: Request,

--- a/src/server/expressErrorHandler.ts
+++ b/src/server/expressErrorHandler.ts
@@ -1,0 +1,72 @@
+import { NextFunction, Request, Response } from 'express';
+import { logger } from '../utils/logger';
+import SentryLogger from '../sentryLogger';
+
+interface HttpError extends Error {
+  status?: number;
+  statusCode?: number;
+  // body-parser / http-errors set a machine-readable `type`
+  // (e.g. 'entity.parse.failed', 'entity.too.large', 'request.aborted').
+  type?: string;
+}
+
+/**
+ * Centralized Express error-handling middleware. Must be registered LAST (after
+ * all routes) and must keep all four arguments — that 4-arity signature is how
+ * Express recognizes it as an error handler.
+ *
+ * Why this exists: without it, Express's default handler prints a full stack
+ * trace to stderr for every error — including malformed/aborted requests from
+ * internet scanners (bad JSON bodies, oversized payloads, path-traversal
+ * probes). That noise buries genuine failures and looks like the app is
+ * breaking when it is just rejecting junk.
+ *
+ * Policy:
+ *  - Client errors (4xx): expected noise. Respond cleanly, log a single concise
+ *    line (no stack trace), and DO NOT crash — otherwise any scanner could take
+ *    the API down with one malformed request.
+ *  - Server errors (5xx): genuine server-side failures. Make them loud (bunyan
+ *    error + Sentry) so they can't fail silently, while still serving other
+ *    requests. Process-level fatal errors are handled separately by the
+ *    global handlers in utils/globalErrorHandlers.ts (which exit for a clean
+ *    container restart).
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function expressErrorHandler(
+  err: HttpError,
+  req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
+  const status = err.status || err.statusCode || 500;
+
+  // Client disconnected mid-request: there is nothing to respond to.
+  if (err.type === 'request.aborted') {
+    logger.debug('Request aborted by client', {
+      method: req.method,
+      path: req.path,
+    });
+    return;
+  }
+
+  if (status < 500) {
+    logger.debug('Rejected bad request', {
+      status,
+      type: err.type,
+      method: req.method,
+      path: req.path,
+      message: err.message,
+    });
+    if (!res.headersSent) {
+      res.sendStatus(status);
+    }
+    return;
+  }
+
+  // Genuine server error — surface it loudly so it is never silent.
+  logger.error('Unhandled server error', err);
+  SentryLogger.captureException(err);
+  if (!res.headersSent) {
+    res.sendStatus(500);
+  }
+}


### PR DESCRIPTION
## Production release → `master`

Promotes the request error-handling + `/admin/download` hardening to production. These commits are cherry-picked from **#2333** (already merged to `staging`); other in-flight staging work is intentionally **excluded** so this stays a focused, low-risk hotfix.

### What's included
| File | Change |
|------|--------|
| `src/server/expressErrorHandler.ts` *(new)* + `bootstrap.ts` | Centralized Express error handler (registered after all routes): client 4xx (malformed/aborted requests from scanners) → clean response + one concise log line, **never crash**; genuine 5xx → log + **Sentry**. Coerces non-`Error` `next()` values and clamps status to 100–599; no PII in 4xx logs. |
| `src/server/bootstrap.ts` | `/admin/download/:filename` hardened against **path traversal** (`path.basename` + containment check). |

This is the correct, scoped version of the "errors must fail loud, not silently" availability item — fatal/process-level failures already crash-and-restart via the earlier `globalErrorHandlers` work (already on `master`).

### Testing
`tsc`, ESLint, Prettier, and full build pass on the `master` base. Runtime tests confirm: malformed JSON → 400 (no crash, no Sentry), `next(null)`/`next('string')` → coerced (no crash), out-of-range status → clamped to 500, 4xx logs carry no message/PII, genuine 5xx → 500 + Sentry, and traversal inputs (URL-encoded, absolute, null-byte) stay contained in the exports dir. Independently reviewed (verdict: sound and safe to merge).

### Known, out of scope (tracked separately)
`/admin/download` is also **unauthenticated** (pre-existing — serves PII email CSVs). Path traversal is fixed here; the auth gating is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
