### PR TITLE
fix: require admin session to download AdminJS PII exports

### DIFF
--- a/src/server/adminJsExportDownload.test.ts
+++ b/src/server/adminJsExportDownload.test.ts
@@ -1,0 +1,70 @@
+import { assert } from 'chai';
+import sinon from 'sinon';
+import { Request, Response } from 'express';
+import { createDownloadAdminJsExportHandler } from './adminJsExportDownload';
+
+describe(
+  'createDownloadAdminJsExportHandler() test cases',
+  downloadAdminJsExportTestCases,
+);
+
+function downloadAdminJsExportTestCases() {
+  const buildReq = (filename: string): Request =>
+    ({ params: { filename }, headers: {} }) as unknown as Request;
+
+  const buildRes = () => {
+    const res: any = {};
+    res.statusCode = undefined;
+    res.status = sinon.stub().callsFake((code: number) => {
+      res.statusCode = code;
+      return res;
+    });
+    res.send = sinon.stub().returnsThis();
+    res.download = sinon.stub();
+    return res as Response & {
+      status: sinon.SinonStub;
+      send: sinon.SinonStub;
+      download: sinon.SinonStub;
+    };
+  };
+
+  it('responds 401 and serves no file when there is no admin session', async () => {
+    const handler = createDownloadAdminJsExportHandler(
+      sinon.stub().resolves(false),
+    );
+    const res = buildRes();
+
+    await handler(buildReq('emails.csv'), res);
+
+    assert.isTrue(res.status.calledOnceWith(401));
+    assert.isTrue(res.send.calledOnceWith('Unauthorized'));
+    assert.isFalse(res.download.called);
+  });
+
+  it('responds 401 when resolving the session throws (e.g. no cookie header)', async () => {
+    // getCurrentAdminJsSession throws TypeError when there is no cookie header.
+    const handler = createDownloadAdminJsExportHandler(
+      sinon.stub().rejects(new TypeError('argument str must be a string')),
+    );
+    const res = buildRes();
+
+    await handler(buildReq('emails.csv'), res);
+
+    assert.isTrue(res.status.calledOnceWith(401));
+    assert.isFalse(res.download.called);
+  });
+
+  it('serves the requested export from the exports dir for a valid admin session', async () => {
+    const handler = createDownloadAdminJsExportHandler(
+      sinon.stub().resolves({ id: 1 }),
+    );
+    const res = buildRes();
+
+    await handler(buildReq('emails.csv'), res);
+
+    assert.isFalse(res.status.calledWith(401));
+    assert.isTrue(res.download.calledOnce);
+    const servedPath = res.download.firstCall.args[0] as string;
+    assert.match(servedPath, /adminJs\/tabs\/exports\/emails\.csv$/);
+  });
+}

--- a/src/server/adminJsExportDownload.ts
+++ b/src/server/adminJsExportDownload.ts
@@ -1,0 +1,58 @@
+import path from 'path';
+import { Request, Response } from 'express';
+import { logger } from '../utils/logger';
+import type { IncomingMessage } from 'connect';
+
+/**
+ * Resolves the current AdminJS admin session for a request (from its signed
+ * session cookie). Mirrors the signature of `getCurrentAdminJsSession` in
+ * `./adminJs/adminJs`; a truthy value means "authenticated admin", `false`
+ * means "no valid session". It is injected (rather than imported directly) so
+ * this module — and its unit test — stay decoupled from the AdminJS/Redis
+ * machinery.
+ */
+export type AdminJsSessionResolver = (req: IncomingMessage) => Promise<unknown>;
+
+// AdminJS-generated CSV exports live here (e.g. project/donor email-address
+// lists). Resolved relative to this file so it matches where projectsTab
+// writes them (src/server/adminJs/tabs/exports).
+const exportsDir = path.join(__dirname, '/adminJs/tabs/exports');
+
+/**
+ * Builds the handler for `GET /admin/download/:filename`, which serves the
+ * AdminJS CSV exports created from the projects tab.
+ *
+ * Those exports contain PII (project/donor email addresses). The route is
+ * registered as a plain Express route, OUTSIDE the AdminJS authenticated
+ * router, so it does NOT inherit AdminJS auth. Without the explicit session
+ * check below, anyone could download the files. We therefore require a valid
+ * admin session and reject everything else with 401.
+ */
+export const createDownloadAdminJsExportHandler = (
+  getCurrentAdminJsSession: AdminJsSessionResolver,
+) => {
+  return async (req: Request, res: Response): Promise<void> => {
+    // Require a valid admin session. `getCurrentAdminJsSession` throws when the
+    // request carries no cookie header, so treat any failure (thrown or falsy)
+    // as "not authenticated".
+    let isAuthenticatedAdmin = false;
+    try {
+      isAuthenticatedAdmin = Boolean(await getCurrentAdminJsSession(req));
+    } catch (e) {
+      logger.error('admin export download auth check failed', e);
+    }
+    if (!isAuthenticatedAdmin) {
+      res.status(401).send('Unauthorized');
+      return;
+    }
+
+    // Prevent path traversal: reduce to a bare filename (strips any `../`),
+    // then confirm the resolved path is directly inside the exports dir.
+    const filePath = path.join(exportsDir, path.basename(req.params.filename));
+    if (path.dirname(filePath) !== exportsDir) {
+      res.status(400).send('Invalid filename');
+      return;
+    }
+    res.download(filePath);
+  };
+};

--- a/src/server/bootstrap.ts
+++ b/src/server/bootstrap.ts
@@ -1,6 +1,5 @@
 // @ts-check
 import http from 'http';
-import path from 'path';
 import { Resource } from '@adminjs/typeorm';
 import { ApolloServer } from '@apollo/server';
 import { ApolloServerPluginLandingPageGraphQLPlayground } from '@apollo/server-plugin-landing-page-graphql-playground';
@@ -37,7 +36,12 @@ import {
 import { logger } from '../utils/logger';
 import { flushSentryAndExit } from '../utils/globalErrorHandlers';
 import { isTrustedVercelRequest } from '../utils/ipWhitelist';
-import { adminJsRootPath, getAdminJsRouter } from './adminJs/adminJs';
+import {
+  adminJsRootPath,
+  getAdminJsRouter,
+  getCurrentAdminJsSession,
+} from './adminJs/adminJs';
+import { createDownloadAdminJsExportHandler } from './adminJsExportDownload';
 // import { apiGivRouter } from '../routers/apiGivRoutes';
 import { AppDataSource, CronDataSource } from '../orm';
 import {
@@ -209,21 +213,14 @@ export async function bootstrap() {
       limit: (config.get('UPLOAD_FILE_MAX_SIZE') as number) || '5mb',
     });
 
-    // To download email addresses of projects in AdminJS projects tab
-    app.get('/admin/download/:filename', (req, res) => {
-      const exportsDir = path.join(__dirname, '/adminJs/tabs/exports');
-      // Prevent path traversal: reduce to a bare filename (strips any `../`),
-      // then confirm the resolved path is directly inside the exports dir.
-      const filePath = path.join(
-        exportsDir,
-        path.basename(req.params.filename),
-      );
-      if (path.dirname(filePath) !== exportsDir) {
-        res.status(400).send('Invalid filename');
-        return;
-      }
-      res.download(filePath);
-    });
+    // Download email-address CSV exports generated from the AdminJS projects
+    // tab. These contain PII and this route lives outside the AdminJS
+    // authenticated router, so the handler enforces a valid admin session
+    // itself (see createDownloadAdminJsExportHandler).
+    app.get(
+      '/admin/download/:filename',
+      createDownloadAdminJsExportHandler(getCurrentAdminJsSession),
+    );
 
     // Lightweight "hello world" health check for deploy verification.
     // Defined BEFORE global CORS middleware so it's always reachable from any origin.


### PR DESCRIPTION
## Problem

`app.get('/admin/download/:filename', ...)` in `src/server/bootstrap.ts` is **unauthenticated**. It is registered as a plain Express route *before* and *outside* the AdminJS authenticated router (`app.use(adminJsRootPath, await getAdminJsRouter())`), so Express matches it first and never runs any auth check.

The route serves the CSV exports written by the AdminJS projects tab to `src/server/adminJs/tabs/exports` — these contain **PII (project/donor email addresses)**. As a result, anyone on the internet could download them, e.g. `GET /admin/download/emails.csv`.

> Note: path-traversal on this route was already fixed previously (`path.basename` + a containment check). That logic is preserved here unchanged — this PR only adds authentication.

## Fix

Extract the handler into `createDownloadAdminJsExportHandler` (new `src/server/adminJsExportDownload.ts`). It now requires a valid AdminJS admin session via `getCurrentAdminJsSession` and returns **401** otherwise:

- `getCurrentAdminJsSession` throws a `TypeError` when the request carries no cookie header (`cookie.parse(undefined)`), so the call is wrapped in `try/catch` and **both thrown errors and falsy results** are treated as unauthenticated.
- The auth check runs **before** any file resolution, so unauthenticated callers learn nothing about the exports directory.
- The existing path-traversal protection (`path.basename` + `path.dirname(filePath) !== exportsDir`) is copied verbatim.

The session resolver is passed in (dependency injection) rather than imported directly, so the handler can be unit-tested without booting Redis/Postgres/AdminJS. `bootstrap.ts` wires in the real `getCurrentAdminJsSession`; the now-unused `path` import was removed.

The legitimate flow is unchanged: when an admin exports from the AdminJS panel, the browser follows the `/admin/download/...` redirect with the `adminjs` session cookie, so `getCurrentAdminJsSession` resolves and the file downloads.

## Tests

New `src/server/adminJsExportDownload.test.ts` (hermetic — no DB/Redis), all passing:

- No admin session → **401**, `res.download` not called.
- Session lookup throws (no cookie header) → **401**, `res.download` not called.
- Valid admin session → file served from the exports dir, no 401.

## Verification

- `npx tsc --noEmit` — clean across the project.
- `eslint` — clean (also enforced by the husky pre-commit hook).
- New test suite passes.

A full live end-to-end run (real server + cookies) wasn't possible in my environment (no Postgres/Redis available), so behaviour is covered by the unit tests above plus the type/lint checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure download endpoint for AdminJS CSV exports with mandatory admin authentication and built-in path traversal protection.

* **Tests**
  * Added comprehensive test suite verifying authentication requirements and security validations for export downloads.

* **Refactor**
  * Integrated new export handler into server bootstrap, replacing inline implementation with dedicated secure module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->