### PR TITLE
Hotfix: re-enable QF Round edit action in prod admin panel

### DIFF
--- a/src/server/adminJs/tabs/qfRoundTab.ts
+++ b/src/server/adminJs/tabs/qfRoundTab.ts
@@ -589,8 +589,8 @@ export const qfRoundTab = {
         after: fillProjects,
       },
       edit: {
-        isAccessible: false, // Disabled - QF Rounds are now managed in v6-core admin panel
-        isVisible: false,
+        isAccessible: ({ currentAdmin }) =>
+          canAccessQfRoundAction({ currentAdmin }, ResourceActions.EDIT),
         handler: async (
           request: AdminJsRequestInterface,
           response,


### PR DESCRIPTION
## Summary

Re-enables the **QF Round → Edit** action in the V5 admin panel on production. It is currently hard-disabled on `master`, so **no admin can edit QF rounds on prod** — the record menu only shows *Show* and *Return All Donation Data*.

This cherry-picks `850b62f0` (already on `staging`) onto `master`.

```diff
       edit: {
-        isAccessible: false, // Disabled - QF Rounds are now managed in v6-core admin panel
-        isVisible: false,
+        isAccessible: ({ currentAdmin }) =>
+          canAccessQfRoundAction({ currentAdmin }, ResourceActions.EDIT),
```

## Why

- Edit was disabled on `master` under the assumption QF rounds would be managed in v6-core.
- That still leaves rounds that must be managed in V5 (e.g. **Stellar** QF rounds) uneditable on prod. Reported for the test Stellar QF round (record #22) on `mainnet.serve.giveth.io`.
- `staging` already re-enabled it via `850b62f0`; this brings prod in line.

## Behavior after merge

Edit becomes **role-gated** (not open to everyone): `canAccessQfRoundAction(currentAdmin, EDIT)` — i.e. `ADMIN` and `QF_MANAGER` roles per `qfRoundPermissions`. Other roles remain unable to edit.

## Testing

- Verified on `staging` (same code path): an `admin`-role user sees and can use the QF Round **Edit** action.
- Diff is identical to the proven `staging` commit; imports (`canAccessQfRoundAction`, `ResourceActions`) already present on `master`.

## Deploy note

Requires a **production redeploy** of impact-graph after merge for the change to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
