### PR TITLE
fix: skip GIVeconomy power-sync events with unresolvable references

### DIFF
--- a/src/services/giveconomyPowerSyncService.test.ts
+++ b/src/services/giveconomyPowerSyncService.test.ts
@@ -415,4 +415,66 @@ describe('pullGiveconomyPowerSync', () => {
     assert.equal(savePowerSyncCursorStub.callCount, 1);
     assert.equal(savePowerSyncCursorStub.firstCall.args[0].lastEventId, 194);
   });
+
+  it('skips events when the FK violation code is nested under driverError', async () => {
+    sinon.stub(powerSyncCursorRepository, 'getPowerSyncCursor').resolves({
+      sourceSystem: 'giveconomy',
+      lastEventId: 194,
+    } as any);
+    const savePowerSyncCursorStub = sinon
+      .stub(powerSyncCursorRepository, 'savePowerSyncCursor')
+      .resolves({} as any);
+    sinon
+      .stub(powerSyncOutboxRepository, 'getLatestPowerSyncOutboxEventForUser')
+      .resolves(null);
+
+    // TypeORM's QueryFailedError exposes the Postgres error code on the nested
+    // driverError rather than the top level, so exercise that branch too.
+    const foreignKeyError = Object.assign(
+      new Error(
+        'insert or update on table "power_boosting" violates foreign key ' +
+          'constraint "FK_e22ae58004aa092dcb637bedd09"',
+      ),
+      { driverError: { code: '23503' } },
+    );
+    sinon
+      .stub(powerBoostingRepository, 'setMultipleBoosting')
+      .rejects(foreignKeyError);
+
+    sinon.stub(axios, 'get').resolves({
+      status: 200,
+      data: {
+        data: [
+          {
+            id: 195,
+            sourceSystem: 'giveconomy',
+            eventType: 'power-boosting.updated',
+            entityType: 'power-boosting',
+            userId: 266,
+            sourceUpdatedAt: '2026-07-20T18:40:00.000Z',
+            payload: {
+              userId: 266,
+              boostings: [
+                {
+                  projectId: 999999,
+                  percentage: 100,
+                  updatedAt: '2026-07-20T18:40:00.000Z',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    } as any);
+
+    const result = await pullGiveconomyPowerSync();
+
+    assert.deepEqual(result, {
+      fetched: 1,
+      applied: 0,
+      skipped: 1,
+    });
+    assert.equal(savePowerSyncCursorStub.callCount, 1);
+    assert.equal(savePowerSyncCursorStub.firstCall.args[0].lastEventId, 195);
+  });
 });

--- a/src/services/giveconomyPowerSyncService.test.ts
+++ b/src/services/giveconomyPowerSyncService.test.ts
@@ -353,4 +353,66 @@ describe('pullGiveconomyPowerSync', () => {
     assert.equal(savePowerSyncCursorStub.callCount, 1);
     assert.equal(savePowerSyncCursorStub.firstCall.args[0].lastEventId, 44);
   });
+
+  it('skips events that hit a foreign key violation and advances the cursor', async () => {
+    sinon.stub(powerSyncCursorRepository, 'getPowerSyncCursor').resolves({
+      sourceSystem: 'giveconomy',
+      lastEventId: 193,
+    } as any);
+    const savePowerSyncCursorStub = sinon
+      .stub(powerSyncCursorRepository, 'savePowerSyncCursor')
+      .resolves({} as any);
+    sinon
+      .stub(powerSyncOutboxRepository, 'getLatestPowerSyncOutboxEventForUser')
+      .resolves(null);
+
+    // Mirrors a QueryFailedError raised when a boosting references a project
+    // that does not exist in this environment (Postgres foreign_key_violation).
+    const foreignKeyError = Object.assign(
+      new Error(
+        'insert or update on table "power_boosting" violates foreign key ' +
+          'constraint "FK_e22ae58004aa092dcb637bedd09"',
+      ),
+      { code: '23503' },
+    );
+    sinon
+      .stub(powerBoostingRepository, 'setMultipleBoosting')
+      .rejects(foreignKeyError);
+
+    sinon.stub(axios, 'get').resolves({
+      status: 200,
+      data: {
+        data: [
+          {
+            id: 194,
+            sourceSystem: 'giveconomy',
+            eventType: 'power-boosting.updated',
+            entityType: 'power-boosting',
+            userId: 266,
+            sourceUpdatedAt: '2026-07-20T18:37:32.003Z',
+            payload: {
+              userId: 266,
+              boostings: [
+                {
+                  projectId: 235268,
+                  percentage: 100,
+                  updatedAt: '2026-07-20T18:37:32.003Z',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    } as any);
+
+    const result = await pullGiveconomyPowerSync();
+
+    assert.deepEqual(result, {
+      fetched: 1,
+      applied: 0,
+      skipped: 1,
+    });
+    assert.equal(savePowerSyncCursorStub.callCount, 1);
+    assert.equal(savePowerSyncCursorStub.firstCall.args[0].lastEventId, 194);
+  });
 });

--- a/src/services/giveconomyPowerSyncService.ts
+++ b/src/services/giveconomyPowerSyncService.ts
@@ -41,6 +41,20 @@ const hasErrorMessage = (
 const isStaleGiveconomyPowerSyncError = (error: unknown): boolean =>
   hasErrorMessage(error) && error.message === STALE_GIVECONOMY_POWER_SYNC_EVENT;
 
+// Postgres foreign_key_violation error code.
+const PG_FOREIGN_KEY_VIOLATION = '23503';
+
+const isForeignKeyViolation = (error: unknown): boolean => {
+  const err = error as {
+    code?: string;
+    driverError?: { code?: string };
+  };
+  return (
+    err?.code === PG_FOREIGN_KEY_VIOLATION ||
+    err?.driverError?.code === PG_FOREIGN_KEY_VIOLATION
+  );
+};
+
 const getSyncedPercentagePrecision = (): number => {
   const precision = Number(process.env.GIVPOWER_BOOSTING_PERCENTAGE_PRECISION);
   return Number.isInteger(precision) && precision >= 0
@@ -224,6 +238,24 @@ const applyGiveconomyPowerSyncEvent = async (
     });
   } catch (error) {
     if (isStaleGiveconomyPowerSyncError(error)) {
+      return false;
+    }
+
+    if (isForeignKeyViolation(error)) {
+      // A boosting referenced a project/user that does not exist in this
+      // environment (e.g. a project never imported into staging). Skip the
+      // event so the cursor advances instead of failing on every run and
+      // permanently wedging the whole sync pipeline for all users. Transient
+      // errors (e.g. DB connection timeouts) still bubble up so the event is
+      // retried on the next run.
+      logger.warn(
+        'Skipping GIVeconomy power sync event: foreign key violation',
+        {
+          eventId: event.id,
+          userId: event.userId,
+          error: hasErrorMessage(error) ? error.message : undefined,
+        },
+      );
       return false;
     }
 


### PR DESCRIPTION
## Problem

The GIVeconomy → impact-graph power-boosting sync (`pullGiveconomyPowerSync`, runs every minute on the jobs instance) has been stuck on **staging** since a single bad event appeared.

Event `#194` (`power-boosting.updated`, `userId=266`) boosts **`projectId=235268` at 100%**, but project `235268` does not exist in the staging `staging2` DB. `setMultipleBoosting` therefore throws a Postgres `foreign_key_violation` (`23503`) on `FK_e22ae58004aa092dcb637bedd09` (`power_boosting.projectId → project.id`).

That error propagated out of the pull loop **before** `savePowerSyncCursor` ran, so the cursor never advanced past event 193. Every subsequent run re-fetched event 194, failed the same way, and logged `GIVeconomy power sync cron job failed` — permanently blocking the entire power-boosting sync **for all users** (`power_boosting` / `power_sync_cursor` were stale for weeks).

## Fix

Treat foreign-key violations as **skippable**: log a warning with the event id / user id and return `false` so the caller advances the cursor past the poison event. One unresolvable event can no longer wedge the whole pipeline, and the sync becomes self-healing.

Transient failures (e.g. `timeout exceeded when trying to connect`) still bubble up unchanged, so those events are retried on the next run rather than being silently skipped.

## Test

Adds a unit test that reproduces the incident (event 194 → project 235268 → `23503`) and asserts the pull returns `{fetched:1, applied:0, skipped:1}` and advances the cursor to `lastEventId=194`. Mirrors the existing "skips stale events" tests.

## Notes / follow-ups (not in this PR)
- The root data issue — why giveconomy-v6-staging emits a boosting for a project absent from impact-graph `staging2` (an environment / project-ID mismatch) — should be investigated separately.
- Operationally, the stuck cursor was unblocked by advancing `power_sync_cursor.lastEventId` past 194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience during power synchronization when an event references missing related data (including PostgreSQL foreign-key violations).
  * Affected events are now skipped instead of halting the sync pipeline.
  * Synchronization progress continues and is recorded so future runs can proceed normally.
* **Tests**
  * Added coverage for foreign-key violation scenarios to ensure skipped-event behavior and cursor advancement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->