### PR TITLE
fix: prevent Stellar QR draft donation race conditions and add bounded reconciliation

### DIFF
--- a/scripts/reconcile-failed-qr-drafts.sql
+++ b/scripts/reconcile-failed-qr-drafts.sql
@@ -1,0 +1,46 @@
+-- One-off data repair for Stellar QR draft donations that were overwritten to
+-- 'failed' by the cron race fixed in fix/stellar-draft-race-conditions
+-- (see https://github.com/Giveth/giveth-v6-core/issues/444, staging draft 2271).
+--
+-- Runtime reconciliation (reconcileDraftWithMatchedDonation) treats every
+-- non-failed donation as live — 'verified', 'pending' and 'swapPending' alike
+-- — so this script uses the same rule: a failed draft referencing any
+-- non-failed donation is repaired to 'matched'. Drafts referencing a
+-- genuinely failed donation are never touched.
+--
+-- The script is idempotent: repaired rows have status = 'matched' and no
+-- longer match the WHERE clause on a second run. Historical failed drafts
+-- outside the cron's reconciliation window only self-heal when the donor
+-- revisits the donation page, so run this once on staging/production
+-- alongside the deploy.
+
+-- 1) Inspect the affected rows first:
+SELECT
+  d.id AS draft_id,
+  d.status AS draft_status,
+  d."matchedDonationId",
+  d."fromWalletAddress" AS draft_from,
+  dn.status AS donation_status,
+  dn."transactionId",
+  dn."createdAt" AS donation_created_at
+FROM draft_donation d
+JOIN donation dn ON dn.id = d."matchedDonationId"
+WHERE d."isQRDonation" = true
+  AND d.status = 'failed'
+  AND dn.status != 'failed';
+
+-- 2) Repair: a failed QR draft that references a non-failed donation is a
+--    successful donation. Also backfill fromWalletAddress from the donation,
+--    but only when the draft's value is null or empty.
+UPDATE draft_donation d
+SET
+  status = 'matched',
+  "fromWalletAddress" = CASE
+    WHEN COALESCE(d."fromWalletAddress", '') = '' THEN dn."fromWalletAddress"
+    ELSE d."fromWalletAddress"
+  END
+FROM donation dn
+WHERE dn.id = d."matchedDonationId"
+  AND d."isQRDonation" = true
+  AND d.status = 'failed'
+  AND dn.status != 'failed';

--- a/scripts/reconcile-failed-qr-drafts.sql
+++ b/scripts/reconcile-failed-qr-drafts.sql
@@ -8,13 +8,21 @@
 -- non-failed donation is repaired to 'matched'. Drafts referencing a
 -- genuinely failed donation are never touched.
 --
+-- The whole script runs in a single transaction and the inspection SELECT
+-- locks the affected draft and donation rows (FOR UPDATE OF d, dn), so a
+-- concurrent status transition (e.g. the blockchain sync job failing a
+-- donation) cannot slip in between inspection and repair and leave a matched
+-- draft referencing a failed donation.
+--
 -- The script is idempotent: repaired rows have status = 'matched' and no
 -- longer match the WHERE clause on a second run. Historical failed drafts
 -- outside the cron's reconciliation window only self-heal when the donor
 -- revisits the donation page, so run this once on staging/production
 -- alongside the deploy.
 
--- 1) Inspect the affected rows first:
+BEGIN;
+
+-- 1) Inspect the affected rows, locking them for the repair below:
 SELECT
   d.id AS draft_id,
   d.status AS draft_status,
@@ -27,11 +35,13 @@ FROM draft_donation d
 JOIN donation dn ON dn.id = d."matchedDonationId"
 WHERE d."isQRDonation" = true
   AND d.status = 'failed'
-  AND dn.status != 'failed';
+  AND dn.status != 'failed'
+FOR UPDATE OF d, dn;
 
 -- 2) Repair: a failed QR draft that references a non-failed donation is a
 --    successful donation. Also backfill fromWalletAddress from the donation,
---    but only when the draft's value is null or empty.
+--    but only when the draft's value is null or empty. The donation rows are
+--    locked by the SELECT above, so dn.status here is the locked state.
 UPDATE draft_donation d
 SET
   status = 'matched',
@@ -44,3 +54,5 @@ WHERE dn.id = d."matchedDonationId"
   AND d."isQRDonation" = true
   AND d.status = 'failed'
   AND dn.status != 'failed';
+
+COMMIT;

--- a/src/repositories/draftDonationRepository.test.ts
+++ b/src/repositories/draftDonationRepository.test.ts
@@ -304,8 +304,9 @@ function updateDraftDonationStatusTestCases() {
 }
 
 function reconcileFailedQrDraftsSqlTestCases() {
-  // Only the UPDATE statement is executed here; the file's leading SELECT is
-  // the manual inspection step for staging/production runs.
+  // The whole script (BEGIN, inspection SELECT ... FOR UPDATE, repair UPDATE,
+  // COMMIT) is executed as one multi-statement query, exactly as it would run
+  // on staging/production.
   // Resolved from the repo root (not __dirname): CI compiles tests to
   // build/src/... and runs them from there, but scripts/ is not copied into
   // the build output.
@@ -313,7 +314,6 @@ function reconcileFailedQrDraftsSqlTestCases() {
     path.resolve(process.cwd(), 'scripts', 'reconcile-failed-qr-drafts.sql'),
     'utf8',
   );
-  const updateSql = sql.slice(sql.indexOf('UPDATE draft_donation'));
 
   beforeEach(async () => {
     await DraftDonation.clear();
@@ -371,9 +371,9 @@ function reconcileFailedQrDraftsSqlTestCases() {
       matchedDonationId: verifiedDonation.id,
     });
 
-    await AppDataSource.getDataSource().query(updateSql);
+    await AppDataSource.getDataSource().query(sql);
     // Idempotency: a second run changes nothing further.
-    await AppDataSource.getDataSource().query(updateSql);
+    await AppDataSource.getDataSource().query(sql);
 
     const freshRepairable = await DraftDonation.findOne({
       where: { id: repairable.id },

--- a/src/repositories/draftDonationRepository.test.ts
+++ b/src/repositories/draftDonationRepository.test.ts
@@ -306,14 +306,11 @@ function updateDraftDonationStatusTestCases() {
 function reconcileFailedQrDraftsSqlTestCases() {
   // Only the UPDATE statement is executed here; the file's leading SELECT is
   // the manual inspection step for staging/production runs.
+  // Resolved from the repo root (not __dirname): CI compiles tests to
+  // build/src/... and runs them from there, but scripts/ is not copied into
+  // the build output.
   const sql = fs.readFileSync(
-    path.join(
-      __dirname,
-      '..',
-      '..',
-      'scripts',
-      'reconcile-failed-qr-drafts.sql',
-    ),
+    path.resolve(process.cwd(), 'scripts', 'reconcile-failed-qr-drafts.sql'),
     'utf8',
   );
   const updateSql = sql.slice(sql.indexOf('UPDATE draft_donation'));

--- a/src/repositories/draftDonationRepository.test.ts
+++ b/src/repositories/draftDonationRepository.test.ts
@@ -1,15 +1,26 @@
 // Create a draft donation
 
+import fs from 'fs';
+import path from 'path';
 import { assert, expect } from 'chai';
-import { generateRandomEtheriumAddress } from '../../test/testUtils';
+import {
+  createDonationData,
+  createProjectData,
+  generateRandomEtheriumAddress,
+  saveDonationDirectlyToDb,
+  saveProjectDirectlyToDb,
+} from '../../test/testUtils';
 import {
   DRAFT_DONATION_STATUS,
   DraftDonation,
 } from '../entities/draftDonation';
+import { DONATION_STATUS } from '../entities/donation';
+import { AppDataSource } from '../orm';
 import {
   countPendingDraftDonations,
   delecteExpiredDraftDonations,
   markDraftDonationStatusMatched,
+  updateDraftDonationStatus,
 } from './draftDonationRepository';
 
 // Mark the draft donation as matched
@@ -92,6 +103,310 @@ describe(
   'countPendingDraftDonations() test cases',
   countPendingDraftDonationsTestCase,
 );
+
+describe(
+  'updateDraftDonationStatus() test cases',
+  updateDraftDonationStatusTestCases,
+);
+
+describe(
+  'scripts/reconcile-failed-qr-drafts.sql test cases',
+  reconcileFailedQrDraftsSqlTestCases,
+);
+
+function updateDraftDonationStatusTestCases() {
+  beforeEach(async () => {
+    await DraftDonation.clear();
+  });
+
+  function createQrDraft(overrides: Partial<DraftDonation> = {}) {
+    return DraftDonation.create({
+      networkId: 1500,
+      status: DRAFT_DONATION_STATUS.PENDING,
+      toWalletAddress: generateRandomEtheriumAddress(),
+      fromWalletAddress: '',
+      currency: 'XLM',
+      anonymous: false,
+      amount: 10,
+      isQRDonation: true,
+      expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+      ...overrides,
+    }).save();
+  }
+
+  it('should mark a pending draft donation as failed', async () => {
+    const draft = await createQrDraft();
+
+    const updated = await updateDraftDonationStatus({
+      donationId: draft.id,
+      status: DRAFT_DONATION_STATUS.FAILED,
+      source: 'test',
+    });
+
+    assert.isTrue(updated);
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    assert.equal(fresh?.status, DRAFT_DONATION_STATUS.FAILED);
+  });
+
+  it('should never mark a matched draft donation as failed', async () => {
+    const draft = await createQrDraft({
+      status: DRAFT_DONATION_STATUS.MATCHED,
+      matchedDonationId: 12345,
+    });
+
+    const updated = await updateDraftDonationStatus({
+      donationId: draft.id,
+      status: DRAFT_DONATION_STATUS.FAILED,
+      source: 'test',
+    });
+
+    assert.isFalse(updated);
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    assert.equal(fresh?.status, DRAFT_DONATION_STATUS.MATCHED);
+    assert.equal(fresh?.matchedDonationId, 12345);
+  });
+
+  it('should never fail a draft whose matchedDonationId references a live donation, even if still pending', async () => {
+    const project = await saveProjectDirectlyToDb(createProjectData());
+    const donation = await saveDonationDirectlyToDb(
+      createDonationData({ status: DONATION_STATUS.VERIFIED }),
+      undefined,
+      project.id,
+    );
+    const draft = await createQrDraft({
+      matchedDonationId: donation.id,
+    });
+
+    const updated = await updateDraftDonationStatus({
+      donationId: draft.id,
+      status: DRAFT_DONATION_STATUS.FAILED,
+      source: 'test',
+    });
+
+    assert.isFalse(updated);
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    assert.equal(fresh?.status, DRAFT_DONATION_STATUS.PENDING);
+    assert.equal(fresh?.matchedDonationId, donation.id);
+  });
+
+  it('should never fail a draft whose matchedDonationId references a pending (live) donation', async () => {
+    const project = await saveProjectDirectlyToDb(createProjectData());
+    const donation = await saveDonationDirectlyToDb(
+      createDonationData({ status: DONATION_STATUS.PENDING }),
+      undefined,
+      project.id,
+    );
+    const draft = await createQrDraft({
+      matchedDonationId: donation.id,
+    });
+
+    const updated = await updateDraftDonationStatus({
+      donationId: draft.id,
+      status: DRAFT_DONATION_STATUS.FAILED,
+      source: 'test',
+    });
+
+    assert.isFalse(updated);
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    assert.equal(fresh?.status, DRAFT_DONATION_STATUS.PENDING);
+    assert.equal(fresh?.matchedDonationId, donation.id);
+  });
+
+  it('should fail a pending draft whose matchedDonationId references a failed donation', async () => {
+    const project = await saveProjectDirectlyToDb(createProjectData());
+    const donation = await saveDonationDirectlyToDb(
+      createDonationData({ status: DONATION_STATUS.FAILED }),
+      undefined,
+      project.id,
+    );
+    const draft = await createQrDraft({
+      matchedDonationId: donation.id,
+    });
+
+    const updated = await updateDraftDonationStatus({
+      donationId: draft.id,
+      status: DRAFT_DONATION_STATUS.FAILED,
+      source: 'test',
+    });
+
+    assert.isTrue(updated);
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    assert.equal(fresh?.status, DRAFT_DONATION_STATUS.FAILED);
+    assert.equal(fresh?.matchedDonationId, donation.id);
+  });
+
+  it('should not fail a draft whose expiresAt was renewed (expiresBefore condition)', async () => {
+    const draft = await createQrDraft({
+      // Renewed: expires in the future
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+    });
+
+    // A stale job believes the draft is expired and tries to fail it
+    const updated = await updateDraftDonationStatus({
+      donationId: draft.id,
+      status: DRAFT_DONATION_STATUS.FAILED,
+      expiresBefore: new Date(Date.now() - 60 * 1000),
+      source: 'test',
+    });
+
+    assert.isFalse(updated);
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    assert.equal(fresh?.status, DRAFT_DONATION_STATUS.PENDING);
+  });
+
+  it('should reconcile a failed draft back to matched', async () => {
+    const fromWalletAddress = generateRandomEtheriumAddress();
+    const draft = await createQrDraft({
+      status: DRAFT_DONATION_STATUS.FAILED,
+    });
+
+    const updated = await updateDraftDonationStatus({
+      donationId: draft.id,
+      status: DRAFT_DONATION_STATUS.MATCHED,
+      fromWalletAddress,
+      matchedDonationId: 777,
+      source: 'reconciliation',
+    });
+
+    assert.isTrue(updated);
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    assert.equal(fresh?.status, DRAFT_DONATION_STATUS.MATCHED);
+    assert.equal(fresh?.matchedDonationId, 777);
+    assert.equal(fresh?.fromWalletAddress, fromWalletAddress);
+  });
+
+  it('should skip matching an already matched draft (idempotent)', async () => {
+    const draft = await createQrDraft({
+      status: DRAFT_DONATION_STATUS.MATCHED,
+      matchedDonationId: 111,
+    });
+
+    const updated = await updateDraftDonationStatus({
+      donationId: draft.id,
+      status: DRAFT_DONATION_STATUS.MATCHED,
+      matchedDonationId: 222,
+      source: 'test',
+    });
+
+    assert.isFalse(updated);
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    assert.equal(fresh?.matchedDonationId, 111);
+  });
+
+  it('should return false for a non-existent draft', async () => {
+    const updated = await updateDraftDonationStatus({
+      donationId: 999999999,
+      status: DRAFT_DONATION_STATUS.FAILED,
+      source: 'test',
+    });
+    assert.isFalse(updated);
+  });
+}
+
+function reconcileFailedQrDraftsSqlTestCases() {
+  // Only the UPDATE statement is executed here; the file's leading SELECT is
+  // the manual inspection step for staging/production runs.
+  const sql = fs.readFileSync(
+    path.join(
+      __dirname,
+      '..',
+      '..',
+      'scripts',
+      'reconcile-failed-qr-drafts.sql',
+    ),
+    'utf8',
+  );
+  const updateSql = sql.slice(sql.indexOf('UPDATE draft_donation'));
+
+  beforeEach(async () => {
+    await DraftDonation.clear();
+  });
+
+  function createQrDraft(overrides: Partial<DraftDonation> = {}) {
+    return DraftDonation.create({
+      networkId: 1500,
+      status: DRAFT_DONATION_STATUS.FAILED,
+      toWalletAddress: generateRandomEtheriumAddress(),
+      fromWalletAddress: '',
+      currency: 'XLM',
+      anonymous: false,
+      amount: 10,
+      isQRDonation: true,
+      expiresAt: new Date(Date.now() - 15 * 60 * 1000),
+      ...overrides,
+    }).save();
+  }
+
+  it('repairs failed QR drafts referencing non-failed donations, is idempotent, and leaves the rest alone', async () => {
+    const project = await saveProjectDirectlyToDb(createProjectData());
+    const verifiedDonation = await saveDonationDirectlyToDb(
+      createDonationData({ status: DONATION_STATUS.VERIFIED }),
+      undefined,
+      project.id,
+    );
+    const pendingDonation = await saveDonationDirectlyToDb(
+      createDonationData({ status: DONATION_STATUS.PENDING }),
+      undefined,
+      project.id,
+    );
+    const failedDonation = await saveDonationDirectlyToDb(
+      createDonationData({ status: DONATION_STATUS.FAILED }),
+      undefined,
+      project.id,
+    );
+
+    // Repairable: failed draft, live donation, empty fromWalletAddress.
+    const repairable = await createQrDraft({
+      matchedDonationId: verifiedDonation.id,
+    });
+    // Repairable via the non-failed rule, but its own address must be kept.
+    const withOwnAddress = await createQrDraft({
+      matchedDonationId: pendingDonation.id,
+      fromWalletAddress: generateRandomEtheriumAddress(),
+    });
+    // Genuinely failed on-chain: must never be converted.
+    const genuinelyFailed = await createQrDraft({
+      matchedDonationId: failedDonation.id,
+    });
+    // Not failed: must not be touched.
+    const stillPending = await createQrDraft({
+      status: DRAFT_DONATION_STATUS.PENDING,
+      matchedDonationId: verifiedDonation.id,
+    });
+
+    await AppDataSource.getDataSource().query(updateSql);
+    // Idempotency: a second run changes nothing further.
+    await AppDataSource.getDataSource().query(updateSql);
+
+    const freshRepairable = await DraftDonation.findOne({
+      where: { id: repairable.id },
+    });
+    assert.equal(freshRepairable?.status, DRAFT_DONATION_STATUS.MATCHED);
+    assert.equal(
+      freshRepairable?.fromWalletAddress,
+      verifiedDonation.fromWalletAddress,
+    );
+
+    const freshWithOwnAddress = await DraftDonation.findOne({
+      where: { id: withOwnAddress.id },
+    });
+    assert.equal(freshWithOwnAddress?.status, DRAFT_DONATION_STATUS.MATCHED);
+    assert.equal(
+      freshWithOwnAddress?.fromWalletAddress,
+      withOwnAddress.fromWalletAddress,
+    );
+
+    const freshGenuinelyFailed = await DraftDonation.findOne({
+      where: { id: genuinelyFailed.id },
+    });
+    assert.equal(freshGenuinelyFailed?.status, DRAFT_DONATION_STATUS.FAILED);
+
+    const freshStillPending = await DraftDonation.findOne({
+      where: { id: stillPending.id },
+    });
+    assert.equal(freshStillPending?.status, DRAFT_DONATION_STATUS.PENDING);
+  });
+}
 
 function countPendingDraftDonationsTestCase() {
   beforeEach(async () => {

--- a/src/repositories/draftDonationRepository.ts
+++ b/src/repositories/draftDonationRepository.ts
@@ -80,11 +80,36 @@ export async function findDraftDonationByMatchedDonationId(
   });
 }
 
+// Single definition of the invariant "this draft references no live donation",
+// as a SQL predicate over the draft_donation row being updated. Callers must
+// bind `:failedDonationStatus`. Every guarded transition and the renew
+// mutation share it, so what counts as a live donation is defined once.
+export const noLiveMatchedDonationSql = (
+  matchedDonationIdColumn: string,
+): string => `(${matchedDonationIdColumn} IS NULL OR NOT EXISTS (
+      SELECT 1 FROM donation d
+      WHERE d.id = ${matchedDonationIdColumn}
+        AND d.status != :failedDonationStatus
+    ))`;
+
+// True only when matchedDonationId points at a donation that genuinely
+// failed, as opposed to one that is missing: the single case in which an
+// already-matched draft may be moved back to failed.
+const matchedDonationFailedSql = (
+  matchedDonationIdColumn: string,
+): string => `EXISTS (
+      SELECT 1 FROM donation d
+      WHERE d.id = ${matchedDonationIdColumn}
+        AND d.status = :failedDonationStatus
+    )`;
+
 // Atomic, guarded status transition for draft donations.
-// - `failed` is never applied to a matched draft, nor to a draft whose
-//   matchedDonationId references a live (non-failed) donation, so a stale job
-//   can never overwrite a successful match. A draft linked to a failed or
-//   deleted donation may still be failed (or re-linked while failing).
+// - `failed` is never applied to a draft whose matchedDonationId references a
+//   live (non-failed) donation, so a stale job can never overwrite a
+//   successful match. A draft linked to a failed or deleted donation may still
+//   be failed (or re-linked while failing). A matched draft is only failed
+//   when its donation actually failed — the repair path for a donation that
+//   fails on-chain after the draft was already matched.
 // - `matched` is applied to any draft that isn't already matched (this allows
 //   reconciling a wrongly-failed draft back to matched).
 // - `expiresBefore` additionally requires the draft's expiresAt to be older
@@ -112,26 +137,6 @@ export const updateDraftDonationStatus = async (params: {
     errorMessage,
   } = params;
   try {
-    // Loaded only to log the previous status; the update below is conditional
-    // on the database state, not on this read.
-    const current = await DraftDonation.createQueryBuilder('draftDonation')
-      .select([
-        'draftDonation.id',
-        'draftDonation.status',
-        'draftDonation.matchedDonationId',
-      ])
-      .where('draftDonation.id = :id', { id: donationId })
-      .getOne();
-
-    if (!current) {
-      logger.info('draftDonationStatusTransition skipped, draft not found', {
-        draftDonationId: donationId,
-        requestedStatus: status,
-        source,
-      });
-      return false;
-    }
-
     const updateValues: Record<string, unknown> = { status };
     if (fromWalletAddress !== undefined) {
       updateValues.fromWalletAddress = fromWalletAddress;
@@ -149,18 +154,20 @@ export const updateDraftDonationStatus = async (params: {
       .where('id = :id', { id: donationId });
 
     if (status === DRAFT_DONATION_STATUS.FAILED) {
+      const matchedDonationIdColumn = 'draft_donation."matchedDonationId"';
       queryBuilder
-        .andWhere('status != :matchedStatus', {
-          matchedStatus: DRAFT_DONATION_STATUS.MATCHED,
-        })
         .andWhere(
-          `("matchedDonationId" IS NULL OR NOT EXISTS (
-            SELECT 1 FROM donation d
-            WHERE d.id = draft_donation."matchedDonationId"
-              AND d.status != :failedDonationStatus
-          ))`,
-          { failedDonationStatus: DONATION_STATUS.FAILED },
-        );
+          `(status != :matchedStatus OR ${matchedDonationFailedSql(
+            matchedDonationIdColumn,
+          )})`,
+          {
+            matchedStatus: DRAFT_DONATION_STATUS.MATCHED,
+            failedDonationStatus: DONATION_STATUS.FAILED,
+          },
+        )
+        .andWhere(noLiveMatchedDonationSql(matchedDonationIdColumn), {
+          failedDonationStatus: DONATION_STATUS.FAILED,
+        });
       if (expiresBefore) {
         queryBuilder.andWhere(
           '("expiresAt" IS NULL OR "expiresAt" < :expiresBefore)',
@@ -178,11 +185,12 @@ export const updateDraftDonationStatus = async (params: {
 
     logger.info('draftDonationStatusTransition', {
       draftDonationId: donationId,
-      previousStatus: current.status,
       requestedStatus: status,
-      matchedDonationId: matchedDonationId ?? current.matchedDonationId,
+      matchedDonationId,
       txHash,
       source,
+      // Skipped means the draft is gone or a guard clause did not hold; the
+      // stored state is authoritative, so no pre-read is taken to log it.
       skipped,
     });
 

--- a/src/repositories/draftDonationRepository.ts
+++ b/src/repositories/draftDonationRepository.ts
@@ -2,6 +2,7 @@ import {
   DRAFT_DONATION_STATUS,
   DraftDonation,
 } from '../entities/draftDonation';
+import { DONATION_STATUS } from '../entities/donation';
 import { logger } from '../utils/logger';
 import { AppDataSource } from '../orm';
 
@@ -79,21 +80,117 @@ export async function findDraftDonationByMatchedDonationId(
   });
 }
 
+// Atomic, guarded status transition for draft donations.
+// - `failed` is never applied to a matched draft, nor to a draft whose
+//   matchedDonationId references a live (non-failed) donation, so a stale job
+//   can never overwrite a successful match. A draft linked to a failed or
+//   deleted donation may still be failed (or re-linked while failing).
+// - `matched` is applied to any draft that isn't already matched (this allows
+//   reconciling a wrongly-failed draft back to matched).
+// - `expiresBefore` additionally requires the draft's expiresAt to be older
+//   than the given date (a missing expiresAt counts as expired), protecting
+//   renewed drafts from stale expiry checks.
+// Returns true when the update was applied, false when it was skipped.
 export const updateDraftDonationStatus = async (params: {
   donationId: number;
   status: string;
   fromWalletAddress?: string;
   matchedDonationId?: number;
-}) => {
+  txHash?: string;
+  source?: string;
+  expiresBefore?: Date;
+  errorMessage?: string;
+}): Promise<boolean> => {
+  const {
+    donationId,
+    status,
+    fromWalletAddress,
+    matchedDonationId,
+    txHash,
+    source,
+    expiresBefore,
+    errorMessage,
+  } = params;
   try {
-    const { donationId, status, fromWalletAddress, matchedDonationId } = params;
-    await DraftDonation.update(
-      { id: donationId },
-      { status, fromWalletAddress, matchedDonationId },
-    );
+    // Loaded only to log the previous status; the update below is conditional
+    // on the database state, not on this read.
+    const current = await DraftDonation.createQueryBuilder('draftDonation')
+      .select([
+        'draftDonation.id',
+        'draftDonation.status',
+        'draftDonation.matchedDonationId',
+      ])
+      .where('draftDonation.id = :id', { id: donationId })
+      .getOne();
+
+    if (!current) {
+      logger.info('draftDonationStatusTransition skipped, draft not found', {
+        draftDonationId: donationId,
+        requestedStatus: status,
+        source,
+      });
+      return false;
+    }
+
+    const updateValues: Record<string, unknown> = { status };
+    if (fromWalletAddress !== undefined) {
+      updateValues.fromWalletAddress = fromWalletAddress;
+    }
+    if (matchedDonationId !== undefined) {
+      updateValues.matchedDonationId = matchedDonationId;
+    }
+    if (errorMessage !== undefined) {
+      updateValues.errorMessage = errorMessage;
+    }
+
+    const queryBuilder = DraftDonation.createQueryBuilder()
+      .update()
+      .set(updateValues)
+      .where('id = :id', { id: donationId });
+
+    if (status === DRAFT_DONATION_STATUS.FAILED) {
+      queryBuilder
+        .andWhere('status != :matchedStatus', {
+          matchedStatus: DRAFT_DONATION_STATUS.MATCHED,
+        })
+        .andWhere(
+          `("matchedDonationId" IS NULL OR NOT EXISTS (
+            SELECT 1 FROM donation d
+            WHERE d.id = draft_donation."matchedDonationId"
+              AND d.status != :failedDonationStatus
+          ))`,
+          { failedDonationStatus: DONATION_STATUS.FAILED },
+        );
+      if (expiresBefore) {
+        queryBuilder.andWhere(
+          '("expiresAt" IS NULL OR "expiresAt" < :expiresBefore)',
+          { expiresBefore },
+        );
+      }
+    } else if (status === DRAFT_DONATION_STATUS.MATCHED) {
+      queryBuilder.andWhere('status != :matchedStatus', {
+        matchedStatus: DRAFT_DONATION_STATUS.MATCHED,
+      });
+    }
+
+    const result = await queryBuilder.execute();
+    const skipped = !result.affected;
+
+    logger.info('draftDonationStatusTransition', {
+      draftDonationId: donationId,
+      previousStatus: current.status,
+      requestedStatus: status,
+      matchedDonationId: matchedDonationId ?? current.matchedDonationId,
+      txHash,
+      source,
+      skipped,
+    });
+
+    return !skipped;
   } catch (e) {
     logger.error(
       `Error in updateDraftDonationStatus - params: ${params} - error: ${e.message}`,
     );
+    return false;
   }
 };

--- a/src/repositories/draftDonationRepository.ts
+++ b/src/repositories/draftDonationRepository.ts
@@ -189,7 +189,7 @@ export const updateDraftDonationStatus = async (params: {
     return !skipped;
   } catch (e) {
     logger.error(
-      `Error in updateDraftDonationStatus - params: ${params} - error: ${e.message}`,
+      `Error in updateDraftDonationStatus - params: ${JSON.stringify(params)} - error: ${e.message}`,
     );
     return false;
   }

--- a/src/resolvers/draftDonationResolver.test.ts
+++ b/src/resolvers/draftDonationResolver.test.ts
@@ -1,21 +1,25 @@
 import { assert, expect } from 'chai';
 import axios from 'axios';
 import moment from 'moment';
+import sinon from 'sinon';
 import {
   generateTestAccessToken,
   graphqlUrl,
   saveProjectDirectlyToDb,
   createProjectData,
+  createDonationData,
   generateRandomEvmTxHash,
   generateRandomStellarTxHash,
   generateRandomEtheriumAddress,
   saveRecurringDonationDirectlyToDb,
   generateRandomStellarAddress,
   saveDonationDirectlyToDb,
+  saveUserDirectlyToDb,
 } from '../../test/testUtils';
 import {
   createDraftDonationMutation,
   createDraftRecurringDonationMutation,
+  getDraftDonationByIdQuery,
   markDraftDonationAsFailedDateMutation,
   renewDraftDonationExpirationDateMutation,
   createDonationMutation,
@@ -37,6 +41,17 @@ import { ProjectAddress } from '../entities/projectAddress';
 import { i18n, translationErrorMessagesKeys } from '../utils/errorMessages';
 import { QfRound } from '../entities/qfRound';
 import { ProjectQfRound } from '../entities/projectQfRound';
+import { DONATION_STATUS } from '../entities/donation';
+import { Token } from '../entities/token';
+import {
+  checkTransactions,
+  processPendingQRDraftDonations,
+  QR_CRON_RUN_LOCK_ID,
+  QR_DRAFT_DONATION_LOCK_NAMESPACE,
+} from '../services/cronJobs/checkQRTransactionJob';
+import * as donationService from '../services/donationService';
+import { CoingeckoPriceAdapter } from '../adapters/price/CoingeckoPriceAdapter';
+import { AppDataSource } from '../orm';
 
 describe('createDraftDonation() test cases', createDraftDonationTestCases);
 describe(
@@ -54,6 +69,10 @@ describe(
 describe(
   'markDraftDonationAsFailed() test cases',
   markDraftDonationAsFailedTestCases,
+);
+describe(
+  'stellar QR draft donation race condition test cases',
+  stellarQRDraftRaceConditionTestCases,
 );
 
 function createDraftDonationTestCases() {
@@ -778,6 +797,124 @@ function renewDraftDonationExpirationDateTestCases() {
     expect(renewedExpirationDate).to.be.not.null;
     expect(renewedExpirationDate).to.be.greaterThan(originalExpirationDate);
   });
+
+  async function createQrDraftForRenewal(
+    overrides: Partial<DraftDonation> = {},
+  ): Promise<DraftDonation> {
+    const project = await saveProjectDirectlyToDb(createProjectData());
+    return DraftDonation.create({
+      networkId: NETWORK_IDS.STELLAR_MAINNET,
+      chainType: ChainType.STELLAR,
+      status: DRAFT_DONATION_STATUS.PENDING,
+      toWalletAddress: generateRandomStellarAddress(),
+      fromWalletAddress: '',
+      currency: 'XLM',
+      anonymous: false,
+      amount: 10,
+      projectId: project.id,
+      toWalletMemo: '123321',
+      qrCodeDataUrl: 'data:image/png;base64,123',
+      isQRDonation: true,
+      expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+      ...overrides,
+    }).save();
+  }
+
+  it('should renew a failed draft donation that has no matchedDonationId', async () => {
+    const draft = await createQrDraftForRenewal({
+      status: DRAFT_DONATION_STATUS.FAILED,
+    });
+    const originalExpiresAt = new Date(draft.expiresAt!).getTime();
+
+    const response = await axios.post(graphqlUrl, {
+      query: renewDraftDonationExpirationDateMutation,
+      variables: { id: draft.id },
+    });
+
+    const renewedExpiresAt = new Date(
+      response.data.data.renewDraftDonationExpirationDate.expiresAt,
+    ).getTime();
+    expect(renewedExpiresAt).to.be.greaterThan(originalExpiresAt);
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.PENDING);
+  });
+
+  it('should not renew a draft donation that references a live donation', async () => {
+    const draft = await createQrDraftForRenewal({
+      status: DRAFT_DONATION_STATUS.FAILED,
+    });
+    const donation = await saveDonationDirectlyToDb(
+      createDonationData({ status: DONATION_STATUS.VERIFIED }),
+      undefined,
+      draft.projectId,
+    );
+    await DraftDonation.update(
+      { id: draft.id },
+      { matchedDonationId: donation.id },
+    );
+    const originalExpiresAt = new Date(draft.expiresAt!).getTime();
+
+    const response = await axios.post(graphqlUrl, {
+      query: renewDraftDonationExpirationDateMutation,
+      variables: { id: draft.id },
+    });
+
+    expect(response.data.data?.renewDraftDonationExpirationDate ?? null).to.be
+      .null;
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.FAILED);
+    expect(fresh!.matchedDonationId).to.equal(donation.id);
+    expect(new Date(fresh!.expiresAt!).getTime()).to.equal(originalExpiresAt);
+  });
+
+  it('should renew a draft donation whose referenced donation failed, so the donor can retry', async () => {
+    const draft = await createQrDraftForRenewal({
+      status: DRAFT_DONATION_STATUS.FAILED,
+    });
+    const donation = await saveDonationDirectlyToDb(
+      createDonationData({ status: DONATION_STATUS.FAILED }),
+      undefined,
+      draft.projectId,
+    );
+    await DraftDonation.update(
+      { id: draft.id },
+      { matchedDonationId: donation.id },
+    );
+    const originalExpiresAt = new Date(draft.expiresAt!).getTime();
+
+    const response = await axios.post(graphqlUrl, {
+      query: renewDraftDonationExpirationDateMutation,
+      variables: { id: draft.id },
+    });
+
+    const renewedExpiresAt = new Date(
+      response.data.data.renewDraftDonationExpirationDate.expiresAt,
+    ).getTime();
+    expect(renewedExpiresAt).to.be.greaterThan(originalExpiresAt);
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.PENDING);
+  });
+
+  it('should not renew a matched draft donation', async () => {
+    const draft = await createQrDraftForRenewal({
+      status: DRAFT_DONATION_STATUS.MATCHED,
+      matchedDonationId: 424243,
+    });
+
+    const response = await axios.post(graphqlUrl, {
+      query: renewDraftDonationExpirationDateMutation,
+      variables: { id: draft.id },
+    });
+
+    expect(response.data.data?.renewDraftDonationExpirationDate ?? null).to.be
+      .null;
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+  });
 }
 
 function markDraftDonationAsFailedTestCases() {
@@ -957,5 +1094,537 @@ function markDraftDonationAsFailedTestCases() {
     expect(updatedDraftDonation!.status).to.be.equal(
       DRAFT_DONATION_STATUS.MATCHED,
     );
+  });
+
+  it('should not mark a draft donation as failed if it references a live donation, and repair it to matched', async () => {
+    const project = await saveProjectDirectlyToDb(createProjectData());
+    const donation = await saveDonationDirectlyToDb(
+      createDonationData({ status: DONATION_STATUS.VERIFIED }),
+      undefined,
+      project.id,
+    );
+
+    const draftDonation = await DraftDonation.create({
+      networkId: NETWORK_IDS.STELLAR_MAINNET,
+      chainType: ChainType.STELLAR,
+      status: DRAFT_DONATION_STATUS.PENDING,
+      toWalletAddress: generateRandomStellarAddress(),
+      fromWalletAddress: '',
+      currency: 'XLM',
+      anonymous: false,
+      amount: 10,
+      projectId: project.id,
+      toWalletMemo: '123321',
+      qrCodeDataUrl: 'data:image/png;base64,123',
+      isQRDonation: true,
+      expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+      matchedDonationId: donation.id,
+    }).save();
+
+    const {
+      data: {
+        data: { markDraftDonationAsFailed },
+      },
+    } = await axios.post(graphqlUrl, {
+      query: markDraftDonationAsFailedDateMutation,
+      variables: {
+        id: draftDonation.id,
+      },
+    });
+
+    const updatedDraftDonation = await DraftDonation.findOne({
+      where: { id: draftDonation.id },
+    });
+
+    expect(markDraftDonationAsFailed).to.be.false;
+    expect(updatedDraftDonation!.status).to.be.equal(
+      DRAFT_DONATION_STATUS.MATCHED,
+    );
+    expect(updatedDraftDonation!.matchedDonationId).to.be.equal(donation.id);
+  });
+}
+
+function stellarQRDraftRaceConditionTestCases() {
+  let project;
+  let user;
+
+  before(async () => {
+    // The QR matcher requires a Stellar XLM token flagged with isQR
+    const existingToken = await Token.findOne({
+      where: { symbol: 'XLM', networkId: NETWORK_IDS.STELLAR_MAINNET },
+    });
+    if (!existingToken) {
+      await Token.create({
+        name: 'Stellar Lumens',
+        symbol: 'XLM',
+        address: 'native',
+        networkId: NETWORK_IDS.STELLAR_MAINNET,
+        decimals: 7,
+        chainType: ChainType.STELLAR,
+        isQR: true,
+        coingeckoId: 'stellar',
+      }).save();
+    } else if (!existingToken.isQR) {
+      existingToken.isQR = true;
+      await existingToken.save();
+    }
+  });
+
+  beforeEach(async () => {
+    project = await saveProjectDirectlyToDb(createProjectData());
+    user = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+    sinon.stub(CoingeckoPriceAdapter.prototype, 'getTokenPrice').resolves(0.5);
+    sinon
+      .stub(donationService, 'syncDonationStatusWithBlockchainNetwork')
+      .resolves({} as any);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  async function createStellarDraft(
+    overrides: Partial<DraftDonation> = {},
+  ): Promise<DraftDonation> {
+    return DraftDonation.create({
+      networkId: NETWORK_IDS.STELLAR_MAINNET,
+      chainType: ChainType.STELLAR,
+      status: DRAFT_DONATION_STATUS.PENDING,
+      toWalletAddress: generateRandomStellarAddress(),
+      fromWalletAddress: '',
+      currency: 'XLM',
+      anonymous: false,
+      amount: 10,
+      projectId: project.id,
+      userId: user.id,
+      toWalletMemo: '123321',
+      qrCodeDataUrl: 'data:image/png;base64,123',
+      isQRDonation: true,
+      createdAt: new Date(Date.now() - 5 * 60 * 1000),
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+      ...overrides,
+    }).save();
+  }
+
+  function stellarPayment(
+    draft: DraftDonation,
+    opts: {
+      txHash?: string;
+      createdAt?: Date;
+      memo?: string;
+      successful?: boolean;
+      amount?: number;
+    } = {},
+  ) {
+    return {
+      type: 'payment',
+      asset_type: 'native',
+      to: draft.toWalletAddress,
+      amount: String(opts.amount ?? draft.amount),
+      source_account: generateRandomStellarAddress(),
+      transaction_hash: opts.txHash ?? generateRandomStellarTxHash(),
+      created_at: (opts.createdAt ?? new Date()).toISOString(),
+      transaction_successful: opts.successful ?? true,
+      transaction: { memo: opts.memo ?? draft.toWalletMemo },
+    };
+  }
+
+  function stubHorizonPayments(records: any[]) {
+    return sinon
+      .stub(axios, 'get')
+      .resolves({ data: { _embedded: { records } } });
+  }
+
+  it('should mark a pending draft as failed after expiration', async () => {
+    const draft = await createStellarDraft({
+      createdAt: new Date(Date.now() - 30 * 60 * 1000),
+      expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+    });
+    stubHorizonPayments([]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.FAILED);
+  });
+
+  it('should not let a stale cron execution fail a draft matched meanwhile', async () => {
+    const draft = await createStellarDraft();
+
+    // A stale execution loaded the draft while it was still pending, with an
+    // already-passed expiry date
+    const staleCopy = await DraftDonation.findOne({ where: { id: draft.id } });
+    staleCopy!.expiresAt = new Date(Date.now() - 10 * 60 * 1000);
+    staleCopy!.createdAt = new Date(Date.now() - 30 * 60 * 1000);
+
+    // Meanwhile a newer execution matches the draft
+    const donation = await saveDonationDirectlyToDb(
+      {
+        transactionId: generateRandomStellarTxHash(),
+        transactionNetworkId: NETWORK_IDS.STELLAR_MAINNET,
+        toWalletAddress: draft.toWalletAddress,
+        fromWalletAddress: generateRandomStellarAddress(),
+        currency: 'XLM',
+        anonymous: false,
+        amount: draft.amount,
+        createdAt: new Date(),
+        status: DONATION_STATUS.VERIFIED,
+        projectId: project.id,
+      },
+      undefined,
+      project.id,
+    );
+    await DraftDonation.update(
+      { id: draft.id },
+      {
+        status: DRAFT_DONATION_STATUS.MATCHED,
+        matchedDonationId: donation.id,
+        fromWalletAddress: donation.fromWalletAddress,
+      },
+    );
+
+    // The stale execution now processes its outdated entity
+    stubHorizonPayments([]);
+    await checkTransactions(staleCopy!, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+    expect(fresh!.matchedDonationId).to.equal(donation.id);
+  });
+
+  it('should create only one donation when two matcher executions run concurrently', async () => {
+    const draft = await createStellarDraft();
+    const payment = stellarPayment(draft);
+    stubHorizonPayments([payment]);
+
+    const copy1 = await DraftDonation.findOne({ where: { id: draft.id } });
+    const copy2 = await DraftDonation.findOne({ where: { id: draft.id } });
+
+    await Promise.all([
+      checkTransactions(copy1!, 'stellar-cron'),
+      checkTransactions(copy2!, 'graphql-verify'),
+    ]);
+
+    const donations = await Donation.find({
+      where: { transactionId: payment.transaction_hash.toLowerCase() },
+    });
+    expect(donations.length).to.equal(1);
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+    expect(fresh!.matchedDonationId).to.equal(donations[0].id);
+    expect(fresh!.fromWalletAddress).to.equal(payment.source_account);
+  });
+
+  it('should reconcile the draft when a donation for the transaction already exists', async () => {
+    const draft = await createStellarDraft();
+    const txHash = generateRandomStellarTxHash();
+    const existingDonation = await saveDonationDirectlyToDb(
+      {
+        transactionId: txHash.toLowerCase(),
+        transactionNetworkId: NETWORK_IDS.STELLAR_MAINNET,
+        toWalletAddress: draft.toWalletAddress,
+        fromWalletAddress: generateRandomStellarAddress(),
+        currency: 'XLM',
+        anonymous: false,
+        amount: draft.amount,
+        createdAt: new Date(),
+        status: DONATION_STATUS.VERIFIED,
+        projectId: project.id,
+      },
+      undefined,
+      project.id,
+    );
+    stubHorizonPayments([stellarPayment(draft, { txHash })]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const donations = await Donation.find({
+      where: { transactionId: txHash.toLowerCase() },
+    });
+    expect(donations.length).to.equal(1);
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+    expect(fresh!.matchedDonationId).to.equal(existingDonation.id);
+    expect(fresh!.fromWalletAddress).to.equal(
+      existingDonation.fromWalletAddress,
+    );
+  });
+
+  it('should match an expired draft when the payment happened within its validity window', async () => {
+    const draft = await createStellarDraft({
+      createdAt: new Date(Date.now() - 30 * 60 * 1000),
+      expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+    });
+    // Payment made before expiry, but the matcher only sees it now
+    const payment = stellarPayment(draft, {
+      createdAt: new Date(Date.now() - 15 * 60 * 1000),
+    });
+    stubHorizonPayments([payment]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+    expect(fresh!.matchedDonationId).to.be.not.null;
+  });
+
+  it('should not match a payment made after the validity window and fail the expired draft', async () => {
+    const draft = await createStellarDraft({
+      createdAt: new Date(Date.now() - 30 * 60 * 1000),
+      expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+    });
+    // Payment made after expiry (+ grace minute)
+    const payment = stellarPayment(draft, { createdAt: new Date() });
+    stubHorizonPayments([payment]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const donations = await Donation.find({
+      where: { transactionId: payment.transaction_hash.toLowerCase() },
+    });
+    expect(donations.length).to.equal(0);
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.FAILED);
+    expect(fresh!.matchedDonationId).to.be.null;
+  });
+
+  it('should not match a payment with a wrong memo or wrong amount', async () => {
+    const draft = await createStellarDraft();
+    stubHorizonPayments([
+      stellarPayment(draft, { memo: 'wrong-memo' }),
+      stellarPayment(draft, { amount: draft.amount + 1 }),
+    ]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.PENDING);
+    expect(fresh!.matchedDonationId).to.be.null;
+
+    const donationsCount = await Donation.count({
+      where: { toWalletAddress: draft.toWalletAddress },
+    });
+    expect(donationsCount).to.equal(0);
+  });
+
+  it('getDraftDonationById should reconcile a wrongly-failed draft that has a verified donation', async () => {
+    const draft = await createStellarDraft();
+    const donation = await saveDonationDirectlyToDb(
+      {
+        transactionId: generateRandomStellarTxHash(),
+        transactionNetworkId: NETWORK_IDS.STELLAR_MAINNET,
+        toWalletAddress: draft.toWalletAddress,
+        fromWalletAddress: generateRandomStellarAddress(),
+        currency: 'XLM',
+        anonymous: false,
+        amount: draft.amount,
+        createdAt: new Date(),
+        status: DONATION_STATUS.VERIFIED,
+        projectId: project.id,
+      },
+      undefined,
+      project.id,
+    );
+    // Simulate the production bug: matched draft overwritten to failed while
+    // keeping its matchedDonationId
+    await DraftDonation.update(
+      { id: draft.id },
+      {
+        status: DRAFT_DONATION_STATUS.FAILED,
+        matchedDonationId: donation.id,
+      },
+    );
+
+    const result = await axios.post(graphqlUrl, {
+      query: getDraftDonationByIdQuery,
+      variables: { id: draft.id },
+    });
+
+    expect(result.data.data.getDraftDonationById.status).to.equal(
+      DRAFT_DONATION_STATUS.MATCHED,
+    );
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+  });
+
+  it('getDraftDonationById should not hide a genuinely failed donation', async () => {
+    const draft = await createStellarDraft();
+    const donation = await saveDonationDirectlyToDb(
+      {
+        transactionId: generateRandomStellarTxHash(),
+        transactionNetworkId: NETWORK_IDS.STELLAR_MAINNET,
+        toWalletAddress: draft.toWalletAddress,
+        fromWalletAddress: generateRandomStellarAddress(),
+        currency: 'XLM',
+        anonymous: false,
+        amount: draft.amount,
+        createdAt: new Date(),
+        status: DONATION_STATUS.FAILED,
+        projectId: project.id,
+      },
+      undefined,
+      project.id,
+    );
+    await DraftDonation.update(
+      { id: draft.id },
+      {
+        status: DRAFT_DONATION_STATUS.FAILED,
+        matchedDonationId: donation.id,
+      },
+    );
+
+    const result = await axios.post(graphqlUrl, {
+      query: getDraftDonationByIdQuery,
+      variables: { id: draft.id },
+    });
+
+    expect(result.data.data.getDraftDonationById.status).to.equal(
+      DRAFT_DONATION_STATUS.FAILED,
+    );
+  });
+
+  it('should reconcile a recently failed draft when its payment shows up on Horizon later', async () => {
+    // Frontend timed the draft out (markDraftDonationAsFailed) while Horizon
+    // had not indexed the payment yet.
+    const draft = await createStellarDraft({
+      createdAt: new Date(Date.now() - 20 * 60 * 1000),
+      expiresAt: new Date(Date.now() - 5 * 60 * 1000),
+      status: DRAFT_DONATION_STATUS.FAILED,
+    });
+    // The payment was made inside the draft's validity window.
+    const payment = stellarPayment(draft, {
+      createdAt: new Date(Date.now() - 10 * 60 * 1000),
+    });
+    stubHorizonPayments([payment]);
+
+    await processPendingQRDraftDonations();
+
+    const donations = await Donation.find({
+      where: { transactionId: payment.transaction_hash.toLowerCase() },
+    });
+    expect(donations.length).to.equal(1);
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+    expect(fresh!.matchedDonationId).to.equal(donations[0].id);
+
+    // A second run must be idempotent: no duplicate donation.
+    await processPendingQRDraftDonations();
+    const donationsAfterRerun = await Donation.find({
+      where: { transactionId: payment.transaction_hash.toLowerCase() },
+    });
+    expect(donationsAfterRerun.length).to.equal(1);
+  });
+
+  it('should not rescan a failed draft after the reconciliation window has passed', async () => {
+    const draft = await createStellarDraft({
+      createdAt: new Date(Date.now() - 90 * 60 * 1000),
+      expiresAt: new Date(Date.now() - 60 * 60 * 1000),
+      status: DRAFT_DONATION_STATUS.FAILED,
+    });
+    // Even a payment inside the old validity window must not be picked up.
+    const payment = stellarPayment(draft, {
+      createdAt: new Date(Date.now() - 70 * 60 * 1000),
+    });
+    stubHorizonPayments([payment]);
+
+    await processPendingQRDraftDonations();
+
+    const donations = await Donation.find({
+      where: { transactionId: payment.transaction_hash.toLowerCase() },
+    });
+    expect(donations.length).to.equal(0);
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.FAILED);
+    expect(fresh!.matchedDonationId).to.be.null;
+  });
+
+  it('should keep a failed draft failed when no transaction appears during the reconciliation window', async () => {
+    const draft = await createStellarDraft({
+      createdAt: new Date(Date.now() - 20 * 60 * 1000),
+      expiresAt: new Date(Date.now() - 5 * 60 * 1000),
+      status: DRAFT_DONATION_STATUS.FAILED,
+    });
+    stubHorizonPayments([]);
+
+    await processPendingQRDraftDonations();
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.FAILED);
+    expect(fresh!.matchedDonationId).to.be.null;
+  });
+
+  it('should create only one donation when two different drafts inspect the same transaction concurrently', async () => {
+    // Two donors, same project address, same project-level memo, same amount:
+    // the payment satisfies both drafts' matching predicates.
+    const draft1 = await createStellarDraft();
+    const draft2 = await createStellarDraft({
+      toWalletAddress: draft1.toWalletAddress,
+    });
+    const payment = stellarPayment(draft1);
+    stubHorizonPayments([payment]);
+
+    await Promise.all([
+      checkTransactions(draft1, 'stellar-cron'),
+      checkTransactions(draft2, 'graphql-verify'),
+    ]);
+
+    const donations = await Donation.find({
+      where: { transactionId: payment.transaction_hash.toLowerCase() },
+    });
+    expect(donations.length).to.equal(1);
+
+    const fresh1 = await DraftDonation.findOne({ where: { id: draft1.id } });
+    const fresh2 = await DraftDonation.findOne({ where: { id: draft2.id } });
+    const claimants = [fresh1, fresh2].filter(
+      d => d!.matchedDonationId === donations[0].id,
+    );
+    expect(claimants.length).to.equal(1);
+    const matched = [fresh1, fresh2].filter(
+      d => d!.status === DRAFT_DONATION_STATUS.MATCHED,
+    );
+    expect(matched.length).to.equal(1);
+    const untouched = [fresh1, fresh2].find(
+      d => d!.matchedDonationId !== donations[0].id,
+    );
+    expect(untouched!.status).to.equal(DRAFT_DONATION_STATUS.PENDING);
+    expect(untouched!.matchedDonationId).to.be.null;
+  });
+
+  it('should skip the cron run while another execution holds the lock, then process normally', async () => {
+    const draft = await createStellarDraft({
+      createdAt: new Date(Date.now() - 30 * 60 * 1000),
+      expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+    });
+    stubHorizonPayments([]);
+
+    const queryRunner = AppDataSource.getDataSource().createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.query('SELECT pg_advisory_lock($1, $2)', [
+      QR_DRAFT_DONATION_LOCK_NAMESPACE,
+      QR_CRON_RUN_LOCK_ID,
+    ]);
+    try {
+      await processPendingQRDraftDonations();
+      const untouched = await DraftDonation.findOne({
+        where: { id: draft.id },
+      });
+      expect(untouched!.status).to.equal(DRAFT_DONATION_STATUS.PENDING);
+    } finally {
+      await queryRunner.query('SELECT pg_advisory_unlock($1, $2)', [
+        QR_DRAFT_DONATION_LOCK_NAMESPACE,
+        QR_CRON_RUN_LOCK_ID,
+      ]);
+      await queryRunner.release();
+    }
+
+    await processPendingQRDraftDonations();
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.FAILED);
   });
 }

--- a/src/resolvers/draftDonationResolver.test.ts
+++ b/src/resolvers/draftDonationResolver.test.ts
@@ -46,12 +46,11 @@ import { Token } from '../entities/token';
 import {
   checkTransactions,
   processPendingQRDraftDonations,
-  QR_CRON_RUN_LOCK_ID,
-  QR_DRAFT_DONATION_LOCK_NAMESPACE,
+  QR_CRON_RUN_LOCK_KEY,
 } from '../services/cronJobs/checkQRTransactionJob';
 import * as donationService from '../services/donationService';
 import { CoingeckoPriceAdapter } from '../adapters/price/CoingeckoPriceAdapter';
-import { AppDataSource } from '../orm';
+import { redis } from '../redis';
 
 describe('createDraftDonation() test cases', createDraftDonationTestCases);
 describe(
@@ -1596,19 +1595,14 @@ function stellarQRDraftRaceConditionTestCases() {
     expect(untouched!.matchedDonationId).to.be.null;
   });
 
-  it('should skip the cron run while another execution holds the lock, then process normally', async () => {
+  it('should skip the cron run while another execution holds the run lease, then process normally', async () => {
     const draft = await createStellarDraft({
       createdAt: new Date(Date.now() - 30 * 60 * 1000),
       expiresAt: new Date(Date.now() - 10 * 60 * 1000),
     });
     stubHorizonPayments([]);
 
-    const queryRunner = AppDataSource.getDataSource().createQueryRunner();
-    await queryRunner.connect();
-    await queryRunner.query('SELECT pg_advisory_lock($1, $2)', [
-      QR_DRAFT_DONATION_LOCK_NAMESPACE,
-      QR_CRON_RUN_LOCK_ID,
-    ]);
+    await redis.set(QR_CRON_RUN_LOCK_KEY, 'another-runner', 'PX', 60 * 1000);
     try {
       await processPendingQRDraftDonations();
       const untouched = await DraftDonation.findOne({
@@ -1616,15 +1610,118 @@ function stellarQRDraftRaceConditionTestCases() {
       });
       expect(untouched!.status).to.equal(DRAFT_DONATION_STATUS.PENDING);
     } finally {
-      await queryRunner.query('SELECT pg_advisory_unlock($1, $2)', [
-        QR_DRAFT_DONATION_LOCK_NAMESPACE,
-        QR_CRON_RUN_LOCK_ID,
-      ]);
-      await queryRunner.release();
+      await redis.del(QR_CRON_RUN_LOCK_KEY);
     }
 
     await processPendingQRDraftDonations();
     const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
     expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.FAILED);
+  });
+
+  it('should match a draft via its own older payment when a newer payment already belongs to another draft', async () => {
+    // Same project address, same project-level memo, same amount: donor A's
+    // newer payment appears first in Horizon's desc list, is already claimed
+    // by draft A, and must not stop draft B's scan from reaching B's own
+    // older payment.
+    const draftA = await createStellarDraft();
+    const draftB = await createStellarDraft({
+      toWalletAddress: draftA.toWalletAddress,
+    });
+
+    const paymentA = stellarPayment(draftA, { createdAt: new Date() });
+    const donationA = await saveDonationDirectlyToDb(
+      {
+        transactionId: paymentA.transaction_hash.toLowerCase(),
+        transactionNetworkId: NETWORK_IDS.STELLAR_MAINNET,
+        toWalletAddress: draftA.toWalletAddress,
+        fromWalletAddress: paymentA.source_account,
+        currency: 'XLM',
+        anonymous: false,
+        amount: draftA.amount,
+        createdAt: new Date(),
+        status: DONATION_STATUS.VERIFIED,
+        projectId: project.id,
+      },
+      undefined,
+      project.id,
+    );
+    await DraftDonation.update(
+      { id: draftA.id },
+      {
+        status: DRAFT_DONATION_STATUS.MATCHED,
+        matchedDonationId: donationA.id,
+      },
+    );
+
+    const paymentB = stellarPayment(draftB, {
+      createdAt: new Date(Date.now() - 2 * 60 * 1000),
+    });
+    stubHorizonPayments([paymentA, paymentB]);
+
+    await checkTransactions(draftB, 'stellar-cron');
+
+    const donationB = await Donation.findOne({
+      where: { transactionId: paymentB.transaction_hash.toLowerCase() },
+    });
+    expect(donationB).to.not.be.null;
+
+    const freshB = await DraftDonation.findOne({ where: { id: draftB.id } });
+    expect(freshB!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+    expect(freshB!.matchedDonationId).to.equal(donationB!.id);
+
+    // Draft A keeps its own donation
+    const freshA = await DraftDonation.findOne({ where: { id: draftA.id } });
+    expect(freshA!.matchedDonationId).to.equal(donationA.id);
+  });
+
+  it('should fail an expired draft whose only candidate payment belongs to another draft', async () => {
+    const draftA = await createStellarDraft();
+    const draftB = await createStellarDraft({
+      toWalletAddress: draftA.toWalletAddress,
+      createdAt: new Date(Date.now() - 30 * 60 * 1000),
+      expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+    });
+
+    // A payment inside draft B's window, but already claimed by draft A: it
+    // must neither match draft B nor leave it pending forever.
+    const paymentA = stellarPayment(draftA, {
+      createdAt: new Date(Date.now() - 15 * 60 * 1000),
+    });
+    const donationA = await saveDonationDirectlyToDb(
+      {
+        transactionId: paymentA.transaction_hash.toLowerCase(),
+        transactionNetworkId: NETWORK_IDS.STELLAR_MAINNET,
+        toWalletAddress: draftA.toWalletAddress,
+        fromWalletAddress: paymentA.source_account,
+        currency: 'XLM',
+        anonymous: false,
+        amount: draftA.amount,
+        createdAt: new Date(Date.now() - 15 * 60 * 1000),
+        status: DONATION_STATUS.VERIFIED,
+        projectId: project.id,
+      },
+      undefined,
+      project.id,
+    );
+    await DraftDonation.update(
+      { id: draftA.id },
+      {
+        status: DRAFT_DONATION_STATUS.MATCHED,
+        matchedDonationId: donationA.id,
+      },
+    );
+    stubHorizonPayments([paymentA]);
+
+    await checkTransactions(draftB, 'stellar-cron');
+
+    const freshB = await DraftDonation.findOne({ where: { id: draftB.id } });
+    expect(freshB!.status).to.equal(DRAFT_DONATION_STATUS.FAILED);
+    expect(freshB!.matchedDonationId).to.be.null;
+
+    // No second donation was created for the claimed payment
+    const donations = await Donation.find({
+      where: { transactionId: paymentA.transaction_hash.toLowerCase() },
+    });
+    expect(donations.length).to.equal(1);
   });
 }

--- a/src/resolvers/draftDonationResolver.ts
+++ b/src/resolvers/draftDonationResolver.ts
@@ -26,9 +26,15 @@ import {
   findRecurringDonationByProjectIdAndUserIdAndCurrency,
 } from '../repositories/recurringDonationRepository';
 import { RecurringDonation } from '../entities/recurringDonation';
-import { checkTransactions } from '../services/cronJobs/checkQRTransactionJob';
+import {
+  checkTransactions,
+  reconcileDraftWithMatchedDonation,
+  DRAFT_DONATION_EXPIRY_GRACE_MS,
+} from '../services/cronJobs/checkQRTransactionJob';
 import { findProjectById } from '../repositories/projectRepository';
 import { notifyDonationFailed } from '../services/sse/sse';
+import { updateDraftDonationStatus } from '../repositories/draftDonationRepository';
+import { DONATION_STATUS } from '../entities/donation';
 
 const draftDonationEnabled = process.env.ENABLE_DRAFT_DONATION === 'true';
 const draftRecurringDonationEnabled =
@@ -431,12 +437,39 @@ export class DraftDonationResolver {
 
     if (!draftDonation) return null;
 
+    // Repair inconsistent state: a draft that references a non-failed
+    // donation is a successful donation, whatever its stored status says.
+    if (draftDonation.matchedDonationId) {
+      const matchedDonation = await reconcileDraftWithMatchedDonation(
+        draftDonation,
+        'graphql-get',
+      );
+      if (matchedDonation) {
+        draftDonation.status = DRAFT_DONATION_STATUS.MATCHED;
+        draftDonation.matchedDonationId = matchedDonation.id;
+        draftDonation.fromWalletAddress = matchedDonation.fromWalletAddress;
+        return draftDonation;
+      }
+    }
+
     if (
+      draftDonation.status === DRAFT_DONATION_STATUS.PENDING &&
       draftDonation.expiresAt &&
-      new Date(draftDonation.expiresAt).getTime < new Date().getTime
+      new Date(draftDonation.expiresAt).getTime() +
+        DRAFT_DONATION_EXPIRY_GRACE_MS <
+        Date.now()
     ) {
-      await DraftDonation.update({ id }, { status: 'failed' });
-      draftDonation.status = 'failed';
+      // Conditional update, with the same grace minute the matcher gives a
+      // late payment: skipped if the draft got matched or renewed meanwhile.
+      const failed = await updateDraftDonationStatus({
+        donationId: id,
+        status: DRAFT_DONATION_STATUS.FAILED,
+        expiresBefore: new Date(Date.now() - DRAFT_DONATION_EXPIRY_GRACE_MS),
+        source: 'graphql-get',
+      });
+      if (failed) {
+        draftDonation.status = DRAFT_DONATION_STATUS.FAILED;
+      }
     }
 
     return draftDonation;
@@ -455,6 +488,18 @@ export class DraftDonationResolver {
 
       if (!draftDonation) return false;
 
+      // A draft referencing a live donation is a successful donation,
+      // whatever its stored status says; repair it instead of confirming
+      // the failure. A failed or deleted referenced donation falls through
+      // to the normal failure handling below.
+      if (draftDonation.matchedDonationId) {
+        const matchedDonation = await reconcileDraftWithMatchedDonation(
+          draftDonation,
+          'graphql-timeout',
+        );
+        if (matchedDonation) return false;
+      }
+
       if (draftDonation.status === DRAFT_DONATION_STATUS.FAILED) {
         return true;
       }
@@ -465,10 +510,20 @@ export class DraftDonationResolver {
       )
         return false;
 
-      await DraftDonation.update(
-        { id },
-        { status: DRAFT_DONATION_STATUS.FAILED },
-      );
+      // Conditional update: refuses to fail a draft that got matched (or
+      // linked to a live donation) after the read above.
+      const updated = await updateDraftDonationStatus({
+        donationId: id,
+        status: DRAFT_DONATION_STATUS.FAILED,
+        source: 'graphql-timeout',
+      });
+
+      if (!updated) {
+        const freshDraftDonation = await DraftDonation.findOne({
+          where: { id },
+        });
+        return freshDraftDonation?.status === DRAFT_DONATION_STATUS.FAILED;
+      }
 
       // Notify clients of new donation
       notifyDonationFailed({
@@ -504,16 +559,48 @@ export class DraftDonationResolver {
         .andWhere('draftDonation.status != :status', {
           status: DRAFT_DONATION_STATUS.MATCHED,
         })
+        .andWhere(
+          `("draftDonation"."matchedDonationId" IS NULL OR NOT EXISTS (
+            SELECT 1 FROM donation d
+            WHERE d.id = "draftDonation"."matchedDonationId"
+              AND d.status != :failedDonationStatus
+          ))`,
+          { failedDonationStatus: DONATION_STATUS.FAILED },
+        )
         .getOne();
 
       if (!draftDonation) {
         throw new Error(translationErrorMessagesKeys.DRAFT_DONATION_NOT_FOUND);
       }
 
-      await DraftDonation.update({ id }, { expiresAt, status: 'pending' });
+      // Conditional update: if the draft got matched (or linked to a live
+      // donation) between the read above and this write, the match wins and
+      // the renewal is rejected. A draft whose referenced donation failed
+      // may be renewed so the donor can retry the payment.
+      const result = await DraftDonation.createQueryBuilder()
+        .update()
+        .set({ expiresAt, status: DRAFT_DONATION_STATUS.PENDING })
+        .where('id = :id', { id })
+        .andWhere('status != :status', {
+          status: DRAFT_DONATION_STATUS.MATCHED,
+        })
+        .andWhere(
+          `("matchedDonationId" IS NULL OR NOT EXISTS (
+            SELECT 1 FROM donation d
+            WHERE d.id = draft_donation."matchedDonationId"
+              AND d.status != :failedDonationStatus
+          ))`,
+          { failedDonationStatus: DONATION_STATUS.FAILED },
+        )
+        .execute();
+
+      if (!result.affected) {
+        throw new Error(translationErrorMessagesKeys.DRAFT_DONATION_NOT_FOUND);
+      }
 
       return {
         ...draftDonation,
+        status: DRAFT_DONATION_STATUS.PENDING,
         expiresAt,
       } as DraftDonation;
     } catch (e) {
@@ -538,7 +625,7 @@ export class DraftDonationResolver {
       if (!draftDonation) return null;
 
       if (draftDonation.isQRDonation) {
-        await checkTransactions(draftDonation);
+        await checkTransactions(draftDonation, 'graphql-verify');
       }
 
       return await DraftDonation.createQueryBuilder('draftDonation')

--- a/src/resolvers/draftDonationResolver.ts
+++ b/src/resolvers/draftDonationResolver.ts
@@ -33,7 +33,10 @@ import {
 } from '../services/cronJobs/checkQRTransactionJob';
 import { findProjectById } from '../repositories/projectRepository';
 import { notifyDonationFailed } from '../services/sse/sse';
-import { updateDraftDonationStatus } from '../repositories/draftDonationRepository';
+import {
+  noLiveMatchedDonationSql,
+  updateDraftDonationStatus,
+} from '../repositories/draftDonationRepository';
 import { DONATION_STATUS } from '../entities/donation';
 
 const draftDonationEnabled = process.env.ENABLE_DRAFT_DONATION === 'true';
@@ -450,6 +453,13 @@ export class DraftDonationResolver {
         draftDonation.fromWalletAddress = matchedDonation.fromWalletAddress;
         return draftDonation;
       }
+      if (draftDonation.status === DRAFT_DONATION_STATUS.MATCHED) {
+        // The donation this draft was matched to has failed since, and the
+        // reconciliation above moved the draft to failed: report the stored
+        // state rather than the success we read a moment ago.
+        const repaired = await DraftDonation.findOne({ where: { id } });
+        if (repaired) return repaired;
+      }
     }
 
     if (
@@ -560,11 +570,7 @@ export class DraftDonationResolver {
           status: DRAFT_DONATION_STATUS.MATCHED,
         })
         .andWhere(
-          `("draftDonation"."matchedDonationId" IS NULL OR NOT EXISTS (
-            SELECT 1 FROM donation d
-            WHERE d.id = "draftDonation"."matchedDonationId"
-              AND d.status != :failedDonationStatus
-          ))`,
+          noLiveMatchedDonationSql('"draftDonation"."matchedDonationId"'),
           { failedDonationStatus: DONATION_STATUS.FAILED },
         )
         .getOne();
@@ -585,11 +591,7 @@ export class DraftDonationResolver {
           status: DRAFT_DONATION_STATUS.MATCHED,
         })
         .andWhere(
-          `("matchedDonationId" IS NULL OR NOT EXISTS (
-            SELECT 1 FROM donation d
-            WHERE d.id = draft_donation."matchedDonationId"
-              AND d.status != :failedDonationStatus
-          ))`,
+          noLiveMatchedDonationSql('draft_donation."matchedDonationId"'),
           { failedDonationStatus: DONATION_STATUS.FAILED },
         )
         .execute();

--- a/src/services/chains/evm/draftDonationService.ts
+++ b/src/services/chains/evm/draftDonationService.ts
@@ -16,6 +16,7 @@ import { ApolloContext } from '../../../types/ApolloContext';
 import { logger } from '../../../utils/logger';
 import { DraftDonationWorker } from '../../../workers/draftDonationMatchWorker';
 import { normalizeAmount } from '../../../utils/utils';
+import { updateDraftDonationStatus } from '../../../repositories/draftDonationRepository';
 
 export const isAmountWithinTolerance = (
   transactionInput,
@@ -245,13 +246,14 @@ async function submitMatchedDraftDonation(
   });
 
   if (existingDonation) {
-    // Check whether the donation has not been saved during matching procedure
-    await draftDonation.reload();
-    if (draftDonation.status === DRAFT_DONATION_STATUS.PENDING) {
-      draftDonation.status = DRAFT_DONATION_STATUS.FAILED;
-      draftDonation.errorMessage = `Donation with same networkId and txHash with ID ${existingDonation.id} already exists`;
-      await draftDonation.save();
-    }
+    // Guarded conditional update: skipped if the draft was matched during
+    // the matching procedure, so failed never overwrites matched.
+    await updateDraftDonationStatus({
+      donationId: draftDonation.id,
+      status: DRAFT_DONATION_STATUS.FAILED,
+      errorMessage: `Donation with same networkId and txHash with ID ${existingDonation.id} already exists`,
+      source: 'evm-matcher',
+    });
     return;
   }
 
@@ -311,9 +313,14 @@ async function submitMatchedDraftDonation(
       `Error on creating donation for draftDonation with ID ${draftDonation.id}`,
       e,
     );
-    draftDonation.status = DRAFT_DONATION_STATUS.FAILED;
-    draftDonation.errorMessage = e.message;
-    await draftDonation.save();
+    // Guarded conditional update: createDonation may already have marked the
+    // draft matched before the error, and that must never be overwritten.
+    await updateDraftDonationStatus({
+      donationId: draftDonation.id,
+      status: DRAFT_DONATION_STATUS.FAILED,
+      errorMessage: e.message,
+      source: 'evm-matcher',
+    });
   }
 }
 

--- a/src/services/chains/evm/draftRecurringDonationService.ts
+++ b/src/services/chains/evm/draftRecurringDonationService.ts
@@ -1,6 +1,5 @@
 import { ModuleThread, Pool, spawn, Worker } from 'threads';
 import { WorkerModule } from 'threads/dist/types/worker';
-import { DRAFT_DONATION_STATUS } from '../../../entities/draftDonation';
 import { ApolloContext } from '../../../types/ApolloContext';
 import { logger } from '../../../utils/logger';
 import {
@@ -68,6 +67,33 @@ export async function matchDraftRecurringDonations(
   }
 }
 
+// Atomic, guarded failure transition: only applied while the draft is still in
+// `requiredStatus` (or, by default, anything but matched), so a concurrent
+// match can never be overwritten by a late failure.
+async function failDraftRecurringDonation(
+  draftRecurringDonationId: number,
+  errorMessage: string,
+  requiredStatus?: string,
+): Promise<void> {
+  const queryBuilder = DraftRecurringDonation.createQueryBuilder()
+    .update()
+    .set({
+      status: DRAFT_RECURRING_DONATION_STATUS.FAILED,
+      errorMessage,
+    })
+    .where('id = :id', { id: draftRecurringDonationId });
+
+  if (requiredStatus) {
+    queryBuilder.andWhere('status = :requiredStatus', { requiredStatus });
+  } else {
+    queryBuilder.andWhere('status != :matchedStatus', {
+      matchedStatus: DRAFT_RECURRING_DONATION_STATUS.MATCHED,
+    });
+  }
+
+  await queryBuilder.execute();
+}
+
 async function submitMatchedDraftRecurringDonation(
   draftRecurringDonation: DraftRecurringDonation,
   tx: FlowUpdatedEvent,
@@ -87,13 +113,13 @@ async function submitMatchedDraftRecurringDonation(
   });
 
   if (existingRecurringDonation) {
-    // Check whether the donation has not been saved during matching procedure
-    await draftRecurringDonation.reload();
-    if (draftRecurringDonation.status === DRAFT_DONATION_STATUS.PENDING) {
-      draftRecurringDonation.status = DRAFT_DONATION_STATUS.FAILED;
-      draftRecurringDonation.errorMessage = `Recurring donation with same networkId and txHash with ID ${existingRecurringDonation.id} already exists`;
-      await draftRecurringDonation.save();
-    }
+    // Guarded update instead of reload-check-save: a draft that got matched
+    // between the read and the write must not be overwritten to failed.
+    await failDraftRecurringDonation(
+      draftRecurringDonation.id,
+      `Recurring donation with same networkId and txHash with ID ${existingRecurringDonation.id} already exists`,
+      DRAFT_RECURRING_DONATION_STATUS.PENDING,
+    );
     return;
   }
 
@@ -169,9 +195,7 @@ async function submitMatchedDraftRecurringDonation(
       `Error on creating donation for draftDonation with ID ${draftRecurringDonation.id}`,
       e,
     );
-    draftRecurringDonation.status = DRAFT_RECURRING_DONATION_STATUS.FAILED;
-    draftRecurringDonation.errorMessage = e.message;
-    await draftRecurringDonation.save();
+    await failDraftRecurringDonation(draftRecurringDonation.id, e.message);
   }
 }
 

--- a/src/services/cronJobs/checkQRTransactionJob.ts
+++ b/src/services/cronJobs/checkQRTransactionJob.ts
@@ -19,13 +19,12 @@ import {
   updateDraftDonationStatus,
 } from '../../repositories/draftDonationRepository';
 import { AppDataSource } from '../../orm';
+import { redis } from '../../redis';
+import { Project } from '../../entities/project';
+import { User } from '../../entities/user';
 import { CoingeckoPriceAdapter } from '../../adapters/price/CoingeckoPriceAdapter';
 import { findUserById } from '../../repositories/userRepository';
-import { relatedActiveQfRoundForProject } from '../qfRoundService';
-import {
-  selectQfRoundForProject,
-  QfRoundSmartSelectError,
-} from '../qfRoundSmartSelectService';
+import { selectQfRoundForProjectWithFallback } from '../qfRoundSmartSelectService';
 import { QfRound } from '../../entities/qfRound';
 import { syncDonationStatusWithBlockchainNetwork } from '../donationService';
 import { notifyClients } from '../sse/sse';
@@ -46,8 +45,20 @@ export const QR_DRAFT_DONATION_LOCK_NAMESPACE = 48_205;
 // from the Stellar transaction hash. A separate namespace from the draft/run
 // locks, so hash-derived keys can never collide with draft-id keys.
 export const QR_TX_LOCK_NAMESPACE = 48_206;
-// Draft ids start at 1, so 0 is reserved for the whole-cron-run lock.
-export const QR_CRON_RUN_LOCK_ID = 0;
+// Redis lease guarding a whole cron run against routine overlap. This is an
+// efficiency guard only — correctness always comes from the per-transaction/
+// per-draft advisory locks plus the guarded status updates. A lease (instead
+// of a pg session advisory lock) because session-scoped locks are unreliable
+// behind a transaction-mode pooler (PgBouncer/DO, see src/orm.ts), and it
+// self-heals: if a runner dies mid-run the key simply expires.
+export const QR_CRON_RUN_LOCK_KEY = 'checkQRTransactionJob:run-lock';
+// A run longer than this may overlap the next tick, which is safe (see
+// above); a crashed runner blocks the cron for at most this long.
+const QR_CRON_RUN_LEASE_TTL_MS = 10 * 60 * 1000;
+// Delete-if-owner, atomically: never release a lease that has expired and
+// been re-acquired by another runner.
+const RELEASE_QR_CRON_RUN_LEASE_SCRIPT =
+  "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end";
 // One minute of grace after expiresAt during which a payment is still
 // accepted and the draft is not yet failed. Shared with the resolver so the
 // read path can never fail a draft the matcher would still accept.
@@ -63,6 +74,19 @@ export const QR_FAILED_DRAFT_RECONCILIATION_WINDOW_MS = 30 * 60 * 1000;
 const QR_DRAFT_LOCK_WAIT_MS = 30 * 1000;
 const HORIZON_REQUEST_TIMEOUT_MS = 30 * 1000;
 
+// Only the cron waits for a contended lock: it is a single sequential runner,
+// and waiting lets it finish a draft this tick. The public
+// verifyQRDonationTransaction query must never wait — each waiter holds a
+// pooled connection inside an open transaction, so a burst of concurrent
+// verifications would exhaust the connection pool (src/orm.ts) and stall
+// unrelated queries. Skipping costs a verification nothing: the caller polls
+// again, and the cron retries the draft regardless.
+const lockWaitMsForSource = (source: string): number =>
+  source === 'stellar-cron' ? QR_DRAFT_LOCK_WAIT_MS : 0;
+// How often the lock-carrying transaction runs a no-op, so it is never idle
+// long enough for the server or the pooler to end it (see withQrXactLocks).
+const QR_LOCK_HEARTBEAT_INTERVAL_MS = 5 * 1000;
+
 // Deterministic 32-bit advisory-lock key for a Stellar transaction hash
 // (first 8 hex chars as a signed int32). A collision between two different
 // hashes only causes unnecessary serialization, never a correctness issue.
@@ -70,40 +94,64 @@ export function txHashToLockId(txHash: string): number {
   return (parseInt(txHash.slice(0, 8), 16) || 0) | 0;
 }
 
-// Runs fn while holding a PostgreSQL advisory lock, which is safe across
-// multiple Node processes/containers sharing the same database. The lock is
-// polled with pg_try_advisory_lock for at most waitMs (0 = single attempt)
-// instead of blocking in pg_advisory_lock, so a stuck holder can never pin
-// waiters' pool connections indefinitely. Returns false when the lock could
-// not be acquired within waitMs and fn was skipped.
-async function withQrAdvisoryLock(
-  namespace: number,
-  lockId: number,
+// Runs fn while holding transaction-scoped PostgreSQL advisory locks
+// (pg_try_advisory_xact_lock inside one explicit transaction), which stay
+// correct behind a transaction-mode pooler (PgBouncer/DO, see src/orm.ts):
+// the open transaction pins all statements to one backend, and the locks are
+// released by that same backend at commit/rollback — a crashed or timing-out
+// holder can never leak a lock the way a failed pg_advisory_unlock on a
+// pooled session can. Locks are acquired strictly in the order given (the
+// callers' fixed tx -> draft order), polled for at most waitMs total
+// (0 = single attempt); on timeout the transaction is rolled back, which
+// atomically releases any locks already acquired, and fn is skipped
+// (returns false). fn's own database work runs on ordinary pooled
+// connections and commits independently; this transaction only carries the
+// locks.
+async function withQrXactLocks(
+  locks: Array<{ namespace: number; lockId: number }>,
   waitMs: number,
   fn: () => Promise<void>,
 ): Promise<boolean> {
   const queryRunner = AppDataSource.getDataSource().createQueryRunner();
   await queryRunner.connect();
   try {
-    const deadline = Date.now() + waitMs;
-    for (;;) {
-      const result = await queryRunner.query(
-        'SELECT pg_try_advisory_lock($1, $2) as acquired',
-        [namespace, lockId],
-      );
-      if (result?.[0]?.acquired) break;
-      if (Date.now() >= deadline) return false;
-      await new Promise(resolve => setTimeout(resolve, 500));
-    }
+    await queryRunner.startTransaction();
     try {
-      await fn();
-    } finally {
-      await queryRunner.query('SELECT pg_advisory_unlock($1, $2)', [
-        namespace,
-        lockId,
-      ]);
+      const deadline = Date.now() + waitMs;
+      for (const lock of locks) {
+        for (;;) {
+          const result = await queryRunner.query(
+            'SELECT pg_try_advisory_xact_lock($1, $2) as acquired',
+            [lock.namespace, lock.lockId],
+          );
+          if (result?.[0]?.acquired) break;
+          if (Date.now() >= deadline) {
+            await queryRunner.rollbackTransaction();
+            return false;
+          }
+          await new Promise(resolve => setTimeout(resolve, 500));
+        }
+      }
+      // fn's own work runs on other connections, so without this the lock
+      // transaction would sit idle-in-transaction for the whole critical
+      // section — long enough for an idle_in_transaction_session_timeout (or a
+      // pooler pruning idle backends) to end it and release the locks while fn
+      // is still running. A cheap statement keeps the backend busy; failures
+      // are ignored because the commit below reports a lost transaction.
+      const heartbeat = setInterval(() => {
+        queryRunner.query('SELECT 1').catch(() => undefined);
+      }, QR_LOCK_HEARTBEAT_INTERVAL_MS);
+      try {
+        await fn();
+      } finally {
+        clearInterval(heartbeat);
+      }
+      await queryRunner.commitTransaction();
+      return true;
+    } catch (e) {
+      await queryRunner.rollbackTransaction();
+      throw e;
     }
-    return true;
   } finally {
     await queryRunner.release();
   }
@@ -112,11 +160,12 @@ async function withQrAdvisoryLock(
 // Single source of truth for aligning a draft with a donation (the one it
 // references, or an explicitly provided one). Returns the donation when it is
 // live (non-failed) — the draft is made MATCHED, including fromWalletAddress.
-// Returns null when the donation is missing or failed: the draft is left
-// untouched so callers can keep scanning for a retry payment or fail it via
-// the guarded expiry update. With linkFailedDonation=true a failed donation
-// is instead recorded on the draft (status failed + matchedDonationId), used
-// when a payment has just been attributed to the draft.
+// Returns null when the donation is missing or failed: a pending draft is left
+// untouched so callers can keep scanning for a retry payment or fail it via the
+// guarded expiry update, while a draft still reported as matched is corrected
+// to failed (its success is stale). With linkFailedDonation=true a failed
+// donation is also recorded on the draft (status failed + matchedDonationId),
+// used when a payment has just been attributed to the draft.
 export async function reconcileDraftWithMatchedDonation(
   draftDonation: DraftDonation,
   source: string,
@@ -132,7 +181,14 @@ export async function reconcileDraftWithMatchedDonation(
   });
   if (!matchedDonation) return null;
   if (matchedDonation.status === DONATION_STATUS.FAILED) {
-    if (options.linkFailedDonation) {
+    // A draft already reported as matched must not keep showing success once
+    // its donation has failed (it can fail on-chain long after the match, so
+    // this read is the only place that notices). The guarded update only
+    // permits matched -> failed when the donation genuinely failed.
+    if (
+      options.linkFailedDonation ||
+      draftDonation.status === DRAFT_DONATION_STATUS.MATCHED
+    ) {
       await updateDraftDonationStatus({
         donationId: draftDonation.id,
         status: DRAFT_DONATION_STATUS.FAILED,
@@ -196,10 +252,123 @@ const getToken = async (
     .getOne();
 };
 
+// Everything a donation insert needs that does not depend on lock-protected
+// state. Prepared before the advisory locks are taken, so slow externals
+// (Coingecko price, givback factor) never extend the lock hold time.
+interface QrDonationCreationContext {
+  token: Token;
+  project: Project;
+  tokenPrice: number;
+  donor: User | undefined;
+  qfRound?: QfRound;
+  givbackFactor?: number;
+  projectRank?: number;
+  bottomRankInRound?: number;
+  powerRound?: number;
+}
+
+// Returns null when the environment cannot produce a donation at all
+// (missing QR token or project) — callers should retry on a later tick
+// rather than fail the draft on that evidence.
+async function prepareQrDonationCreationContext(
+  donation: DraftDonation,
+): Promise<QrDonationCreationContext | null> {
+  // Retrieve token object
+  const token = await getToken('STELLAR', 'XLM');
+  if (!token) {
+    logger.debug('Token not found for donation ID', donation.id);
+    return null;
+  }
+
+  // Retrieve project object
+  const project = await findProjectById(donation.projectId);
+  if (!project) {
+    logger.debug(`Project not found for donation ID ${donation.id}`);
+    return null;
+  }
+
+  // Get token price
+  const tokenPrice = await new CoingeckoPriceAdapter().getTokenPrice({
+    symbol: token.coingeckoId,
+    networkId: token.networkId,
+  });
+
+  // Retrieve donor object
+  const donor = (await findUserById(donation.userId)) || undefined;
+
+  // Use QF round from draft donation if available, otherwise fall back to smart select
+  let qfRound: QfRound | undefined;
+  if (donation.qfRoundId) {
+    // Use the QF round specified in the draft donation - this should always be respected
+    const foundQfRound = await QfRound.findOneBy({
+      id: donation.qfRoundId,
+    });
+    if (foundQfRound) {
+      qfRound = foundQfRound;
+      logger.debug(
+        `Using QF round ID ${donation.qfRoundId} from draft donation for QR donation ID ${donation.id}`,
+      );
+    } else {
+      logger.warn(
+        `QF round with ID ${donation.qfRoundId} not found for QR donation ID ${donation.id}, falling back to smart select`,
+      );
+      // Only fall back to smart select if the specified QF round doesn't exist
+      qfRound = await selectQfRoundForProjectWithFallback(
+        token.networkId,
+        project.id,
+        { draftDonationId: donation.id },
+      );
+    }
+  } else {
+    // Fall back to smart select logic if no QF round specified in draft donation
+    qfRound = await selectQfRoundForProjectWithFallback(
+      token.networkId,
+      project.id,
+      { draftDonationId: donation.id },
+    );
+  }
+
+  const { givbackFactor, projectRank, bottomRankInRound, powerRound } =
+    await calculateGivbackFactor(project.id);
+
+  return {
+    token,
+    project,
+    tokenPrice,
+    donor,
+    qfRound,
+    givbackFactor,
+    projectRank,
+    bottomRankInRound,
+    powerRound,
+  };
+}
+
+// One Horizon page per account, optionally reused within a single run. Drafts
+// for the same project share a toWalletAddress, so without the cache the
+// identical 200-record page is fetched once per draft every tick. A payment
+// that lands mid-run is simply picked up by the next tick.
+async function fetchAccountPayments(
+  toWalletAddress: string,
+  paymentsByAddress?: Map<string, any[]>,
+): Promise<any[]> {
+  const cachedPayments = paymentsByAddress?.get(toWalletAddress);
+  if (cachedPayments) return cachedPayments;
+
+  const response = await axios.get(
+    `${STELLAR_HORIZON_API}/accounts/${toWalletAddress}/payments?limit=200&order=desc&join=transactions&include_failed=true`,
+    { timeout: HORIZON_REQUEST_TIMEOUT_MS },
+  );
+  const payments = response.data._embedded.records || [];
+  paymentsByAddress?.set(toWalletAddress, payments);
+  return payments;
+}
+
 // Check for transactions
 export async function checkTransactions(
   donation: DraftDonation,
   source: string = 'stellar-cron',
+  paymentsByAddress?: Map<string, any[]>,
 ): Promise<void> {
   const { toWalletAddress, amount, toWalletMemo, expiresAt, id } = donation;
 
@@ -232,12 +401,10 @@ export async function checkTransactions(
     // update that never overwrites a concurrent match.
     const isExpired = now > expiresAtDate;
 
-    const response = await axios.get(
-      `${STELLAR_HORIZON_API}/accounts/${toWalletAddress}/payments?limit=200&order=desc&join=transactions&include_failed=true`,
-      { timeout: HORIZON_REQUEST_TIMEOUT_MS },
+    const transactions = await fetchAccountPayments(
+      toWalletAddress,
+      paymentsByAddress,
     );
-
-    const transactions = response.data._embedded.records || [];
 
     // Only consider payments made at/after this draft was created (with a small
     // clock-skew allowance). The memo + amount already uniquely identify the
@@ -246,6 +413,15 @@ export async function checkTransactions(
     // doesn't inspect it within 120s (e.g. when the jobs worker lags).
     const CLOCK_SKEW = 60 * 1000;
     const draftCreatedAt = new Date(donation.createdAt).getTime();
+
+    // Prepared at most once per draft (it depends only on the draft), so a
+    // payment that turns out to belong to another draft does not repeat the
+    // Coingecko price call and the token/project/user/QF-round queries.
+    let preparedContext: QrDonationCreationContext | null = null;
+    // Set when a matching payment could not be turned into a donation for
+    // reasons outside this draft (missing configuration, lock contention, a
+    // failed insert). Scanning stops for this tick; see the handling below.
+    let abortReason: string | undefined;
 
     for (const transaction of transactions) {
       const transactionCreatedAt = new Date(transaction.created_at).getTime();
@@ -302,6 +478,42 @@ export async function checkTransactions(
           continue;
         }
         let createdDonationId: number | undefined;
+        // What this payment amounted to for this draft:
+        // - created: a donation was created and the draft updated — stop
+        //   scanning and run the post-creation side effects.
+        // - settled: the draft already references a live donation (or a
+        //   concurrent execution matched it) — nothing left to do.
+        // - skip: this payment cannot serve this draft (it belongs to
+        //   another draft, or its donation mismatches) — keep scanning older
+        //   payments and leave the expiry handling below reachable.
+        // - abort: environmental or lock failure (missing token/project,
+        //   lock wait timeout, donation insert failure) — stop scanning
+        //   without failing the draft; the next tick retries from scratch.
+        // (an object property, not a let, so TypeScript doesn't narrow the
+        // value across the lock closure that mutates it)
+        const matchOutcome: {
+          verdict: 'created' | 'settled' | 'skip' | 'abort';
+        } = { verdict: 'abort' };
+
+        // Slow externals run before the locks so the critical section is
+        // only the existence re-checks and the insert itself. This unlocked
+        // existing-donation pre-check merely skips the preparation when the
+        // donation obviously exists already; the authoritative check runs
+        // under the locks below.
+        let creationContext: QrDonationCreationContext | null = null;
+        if (!(await findDonationsByTransactionId(txHash))) {
+          if (!preparedContext) {
+            preparedContext = await prepareQrDonationCreationContext(donation);
+          }
+          creationContext = preparedContext;
+          // Missing token/project configuration: nothing can be created this
+          // tick, and the draft must not be failed on that evidence alone.
+          if (!creationContext) {
+            abortReason =
+              'QR donation configuration unavailable (missing token or project)';
+            break;
+          }
+        }
 
         const matchUnderLocks = async () => {
           // Re-check under the locks: another execution may have already
@@ -316,15 +528,23 @@ export async function checkTransactions(
               existingDonation.id,
             );
             if (
-              (!claimingDraft || claimingDraft.id === donation.id) &&
-              existingDonation.toWalletAddress === donation.toWalletAddress &&
-              Number(existingDonation.amount) === amount
+              (claimingDraft && claimingDraft.id !== donation.id) ||
+              existingDonation.toWalletAddress !== donation.toWalletAddress ||
+              Number(existingDonation.amount) !== amount
             ) {
-              await reconcileDraftWithMatchedDonation(donation, source, {
-                donation: existingDonation,
-                linkFailedDonation: true,
-              });
+              // This payment is spoken for by another draft; an older
+              // payment further down the list may still be this draft's own.
+              matchOutcome.verdict = 'skip';
+              return;
             }
+            const liveDonation = await reconcileDraftWithMatchedDonation(
+              donation,
+              source,
+              { donation: existingDonation, linkFailedDonation: true },
+            );
+            // When the linked donation failed on-chain, keep scanning: the
+            // donor may have retried with another payment.
+            matchOutcome.verdict = liveDonation ? 'settled' : 'skip';
             return;
           }
 
@@ -338,6 +558,7 @@ export async function checkTransactions(
             !freshDraft ||
             freshDraft.status === DRAFT_DONATION_STATUS.MATCHED
           ) {
+            matchOutcome.verdict = 'settled';
             return;
           }
           if (freshDraft.matchedDonationId) {
@@ -348,156 +569,50 @@ export async function checkTransactions(
               linkedDonation &&
               linkedDonation.status !== DONATION_STATUS.FAILED
             ) {
+              matchOutcome.verdict = 'settled';
               return;
             }
           }
 
-          // Retrieve token object
-          const token = await getToken('STELLAR', 'XLM');
-          if (!token) {
-            logger.debug('Token not found for donation ID', donation.id);
+          if (!creationContext) {
+            // The unlocked pre-check saw a donation for this hash, but it is
+            // gone now and nothing was prepared to create one. Leave the
+            // 'abort' verdict: the next tick retries with a clean view.
             return;
           }
-
-          // Retrieve project object
-          const project = await findProjectById(donation.projectId);
-          if (!project) {
-            logger.debug(`Project not found for donation ID ${donation.id}`);
-            return;
-          }
-
-          // Get token price
-          const tokenPrice = await new CoingeckoPriceAdapter().getTokenPrice({
-            symbol: token.coingeckoId,
-            networkId: token.networkId,
-          });
-
-          // Retrieve donor object
-          const donor = await findUserById(donation.userId);
-
-          // Use QF round from draft donation if available, otherwise fall back to smart select
-          let qfRound: QfRound | undefined;
-          if (donation.qfRoundId) {
-            // Use the QF round specified in the draft donation - this should always be respected
-            const foundQfRound = await QfRound.findOneBy({
-              id: donation.qfRoundId,
-            });
-            if (foundQfRound) {
-              qfRound = foundQfRound;
-              logger.debug(
-                `Using QF round ID ${donation.qfRoundId} from draft donation for QR donation ID ${donation.id}`,
-              );
-            } else {
-              logger.warn(
-                `QF round with ID ${donation.qfRoundId} not found for QR donation ID ${donation.id}, falling back to smart select`,
-              );
-              // Only fall back to smart select if the specified QF round doesn't exist
-              try {
-                const smartSelectedQfRound = await selectQfRoundForProject(
-                  token.networkId,
-                  project.id,
-                );
-
-                // Find the actual QfRound entity to assign to the donation
-                qfRound =
-                  (await QfRound.findOneBy({
-                    id: smartSelectedQfRound.qfRoundId,
-                  })) || undefined;
-              } catch (error) {
-                // If smart select fails (no eligible QF rounds), fall back to the old logic
-                if (error instanceof QfRoundSmartSelectError) {
-                  logger.debug(
-                    `Smart select failed for QR donation, falling back to old logic: ${error.message}`,
-                    {
-                      projectId: project.id,
-                      networkId: token.networkId,
-                      draftDonationId: donation.id,
-                    },
-                  );
-
-                  const activeQfRoundForProject =
-                    await relatedActiveQfRoundForProject(project.id);
-
-                  if (
-                    activeQfRoundForProject &&
-                    activeQfRoundForProject.isEligibleNetwork(token.networkId)
-                  ) {
-                    qfRound = activeQfRoundForProject;
-                  }
-                }
-              }
-            }
-          } else {
-            // Fall back to smart select logic if no QF round specified in draft donation
-            try {
-              const smartSelectedQfRound = await selectQfRoundForProject(
-                token.networkId,
-                project.id,
-              );
-
-              // Find the actual QfRound entity to assign to the donation
-              qfRound =
-                (await QfRound.findOneBy({
-                  id: smartSelectedQfRound.qfRoundId,
-                })) || undefined;
-            } catch (error) {
-              // If smart select fails (no eligible QF rounds), fall back to the old logic
-              if (error instanceof QfRoundSmartSelectError) {
-                logger.debug(
-                  `Smart select failed for QR donation, falling back to old logic: ${error.message}`,
-                  {
-                    projectId: project.id,
-                    networkId: token.networkId,
-                    draftDonationId: donation.id,
-                  },
-                );
-
-                const activeQfRoundForProject =
-                  await relatedActiveQfRoundForProject(project.id);
-
-                if (
-                  activeQfRoundForProject &&
-                  activeQfRoundForProject.isEligibleNetwork(token.networkId)
-                ) {
-                  qfRound = activeQfRoundForProject;
-                }
-              }
-            }
-          }
-
-          const { givbackFactor, projectRank, bottomRankInRound, powerRound } =
-            await calculateGivbackFactor(project.id);
 
           const returnedDonation = await createDonation({
             amount: donation.amount,
-            project,
+            project: creationContext.project,
             transactionNetworkId: donation.networkId,
             fromWalletAddress: transaction.source_account,
             transactionId: transaction.transaction_hash,
             tokenAddress: donation.tokenAddress,
-            isProjectGivbackEligible: project.isGivbackEligible,
-            donorUser: donor,
-            isTokenEligibleForGivback: token.isGivbackEligible,
+            isProjectGivbackEligible: creationContext.project.isGivbackEligible,
+            donorUser: creationContext.donor,
+            isTokenEligibleForGivback: creationContext.token.isGivbackEligible,
             segmentNotified: false,
             toWalletAddress: donation.toWalletAddress,
             donationAnonymous: false,
             transakId: '',
             token: donation.currency,
-            valueUsd: donation.amount * tokenPrice,
-            priceUsd: tokenPrice,
+            valueUsd: donation.amount * creationContext.tokenPrice,
+            priceUsd: creationContext.tokenPrice,
             status: transaction.transaction_successful ? 'verified' : 'failed',
             isQRDonation: true,
             toWalletMemo,
-            qfRound,
-            chainType: token.chainType,
-            givbackFactor,
-            projectRank,
-            bottomRankInRound,
-            powerRound,
+            qfRound: creationContext.qfRound,
+            chainType: creationContext.token.chainType,
+            givbackFactor: creationContext.givbackFactor,
+            projectRank: creationContext.projectRank,
+            bottomRankInRound: creationContext.bottomRankInRound,
+            powerRound: creationContext.powerRound,
           });
 
           if (!returnedDonation) {
-            logger.debug(
+            // info, not debug: a real payment matched this draft but no
+            // donation row could be created — that needs eyes in production.
+            logger.info(
               `Error creating donation for draft donation ID ${donation.id}`,
             );
             return;
@@ -516,27 +631,30 @@ export async function checkTransactions(
           });
 
           createdDonationId = returnedDonation.id;
+          matchOutcome.verdict = 'created';
         };
 
-        // Serialize the match across processes at two levels, always in this
-        // order (tx lock outer, draft lock inner — a fixed order plus bounded
-        // waits means no deadlock):
+        // Serialize the match across processes at two levels, acquired in a
+        // single lock transaction, always in this order (tx first, then
+        // draft — a fixed order plus bounded try-lock polling means no
+        // deadlock):
         // - per transaction: two different drafts sharing address, memo and
         //   amount must not both turn this payment into a donation;
         // - per draft: overlapping cron runs and concurrent GraphQL
         //   verifications must not match this draft twice.
-        await withQrAdvisoryLock(
-          QR_TX_LOCK_NAMESPACE,
-          txHashToLockId(txHash),
-          QR_DRAFT_LOCK_WAIT_MS,
-          async () => {
-            await withQrAdvisoryLock(
-              QR_DRAFT_DONATION_LOCK_NAMESPACE,
-              donation.id,
-              QR_DRAFT_LOCK_WAIT_MS,
-              matchUnderLocks,
-            );
-          },
+        await withQrXactLocks(
+          [
+            {
+              namespace: QR_TX_LOCK_NAMESPACE,
+              lockId: txHashToLockId(txHash),
+            },
+            {
+              namespace: QR_DRAFT_DONATION_LOCK_NAMESPACE,
+              lockId: donation.id,
+            },
+          ],
+          lockWaitMsForSource(source),
+          matchUnderLocks,
         );
 
         // Outside the advisory locks: slow external calls that don't touch
@@ -556,8 +674,38 @@ export async function checkTransactions(
           });
         }
 
-        return;
+        // Only 'skip' keeps scanning older payments (and leaves the expiry
+        // handling below reachable): 'created' and 'settled' mean the draft
+        // is resolved, 'abort' means the environment must recover before
+        // anything is decided — see the abort handling below.
+        if (matchOutcome.verdict === 'abort') {
+          abortReason = 'no donation could be created for the matched payment';
+          break;
+        }
+        if (matchOutcome.verdict !== 'skip') return;
       }
+    }
+
+    if (abortReason) {
+      // Retrying is right while a later tick may still succeed. But once the
+      // draft is past the window in which scanning can still help it, retrying
+      // forever would leave it pending until the hard delete, with the donor
+      // never told anything — so give it a terminal status carrying the reason.
+      if (now > expiresAtDate + QR_FAILED_DRAFT_RECONCILIATION_WINDOW_MS) {
+        // info, not debug: a real payment matched and never became a donation.
+        logger.info(
+          `Failing QR draft donation ID ${id} after repeated match failures`,
+          { abortReason, source },
+        );
+        await updateDraftDonationStatus({
+          donationId: id,
+          status: DRAFT_DONATION_STATUS.FAILED,
+          expiresBefore: new Date(now - DRAFT_DONATION_EXPIRY_GRACE_MS),
+          errorMessage: abortReason,
+          source,
+        });
+      }
+      return;
     }
 
     if (isExpired && donation.status !== DRAFT_DONATION_STATUS.FAILED) {
@@ -580,30 +728,60 @@ export async function checkTransactions(
   }
 }
 
-// Processes all pending QR drafts under a no-overlap advisory lock, so a
-// slow run can never race a newer one (in this process or in another
-// container) with stale in-memory draft entities.
+// Processes all scannable QR drafts under a no-overlap Redis lease, so a
+// slow run does not routinely race a newer one (in this process or in
+// another container) with stale in-memory draft entities. The lease is only
+// an efficiency guard: even if two runs do overlap (e.g. after a lease
+// expiry), the per-transaction/per-draft locks and the guarded status
+// updates keep the outcome correct.
 export const processPendingQRDraftDonations = async (): Promise<void> => {
   try {
-    const acquired = await withQrAdvisoryLock(
-      QR_DRAFT_DONATION_LOCK_NAMESPACE,
-      QR_CRON_RUN_LOCK_ID,
-      0,
-      async () => {
-        const scannableDonations = await getScannableDraftDonations();
-
-        for (const donation of scannableDonations) {
-          await checkTransactions(donation, 'stellar-cron');
-        }
-      },
-    );
-    if (!acquired) {
-      // info (not debug) on purpose: if this line appears on every tick, the
-      // run lock is stuck (e.g. an unlock failed on a still-alive connection)
-      // and the cron is being starved.
-      logger.info(
-        'checkQRTransactionJob skipped, another execution is still running',
+    const leaseToken = `${process.pid}:${Date.now()}:${Math.random()}`;
+    let leaseHeld = false;
+    try {
+      const acquired = await redis.set(
+        QR_CRON_RUN_LOCK_KEY,
+        leaseToken,
+        'PX',
+        QR_CRON_RUN_LEASE_TTL_MS,
+        'NX',
       );
+      if (acquired !== 'OK') {
+        // A previous run is still going, or a crashed runner's lease has not
+        // expired yet (self-heals within QR_CRON_RUN_LEASE_TTL_MS).
+        logger.info(
+          'checkQRTransactionJob skipped, another execution is still running',
+        );
+        return;
+      }
+      leaseHeld = true;
+    } catch (e) {
+      // The lease is an efficiency guard only, so a Redis outage must not stop
+      // matching: drafts paid during the outage would otherwise age out of the
+      // reconciliation window and stay failed with the payment on-chain.
+      // Correctness still comes from the advisory locks and guarded updates.
+      logger.error(
+        `checkQRTransactionJob could not acquire its Redis lease, running without it: ${e.message}`,
+      );
+    }
+    try {
+      const scannableDonations = await getScannableDraftDonations();
+      // Shared across this run only: drafts for one project reuse a single
+      // Horizon page instead of re-fetching it per draft.
+      const paymentsByAddress = new Map<string, any[]>();
+
+      for (const donation of scannableDonations) {
+        await checkTransactions(donation, 'stellar-cron', paymentsByAddress);
+      }
+    } finally {
+      if (leaseHeld) {
+        await redis.eval(
+          RELEASE_QR_CRON_RUN_LEASE_SCRIPT,
+          1,
+          QR_CRON_RUN_LOCK_KEY,
+          leaseToken,
+        );
+      }
     }
   } catch (e) {
     logger.error(`Error in processPendingQRDraftDonations: ${e.message}`);

--- a/src/services/cronJobs/checkQRTransactionJob.ts
+++ b/src/services/cronJobs/checkQRTransactionJob.ts
@@ -2,14 +2,23 @@ import { schedule } from 'node-cron';
 import axios from 'axios';
 import config from '../../config';
 import { logger } from '../../utils/logger';
-import { DraftDonation } from '../../entities/draftDonation';
+import {
+  DRAFT_DONATION_STATUS,
+  DraftDonation,
+} from '../../entities/draftDonation';
+import { DONATION_STATUS, Donation } from '../../entities/donation';
 import { Token } from '../../entities/token';
 import {
   createDonation,
+  findDonationById,
   findDonationsByTransactionId,
 } from '../../repositories/donationRepository';
 import { findProjectById } from '../../repositories/projectRepository';
-import { updateDraftDonationStatus } from '../../repositories/draftDonationRepository';
+import {
+  findDraftDonationByMatchedDonationId,
+  updateDraftDonationStatus,
+} from '../../repositories/draftDonationRepository';
+import { AppDataSource } from '../../orm';
 import { CoingeckoPriceAdapter } from '../../adapters/price/CoingeckoPriceAdapter';
 import { findUserById } from '../../repositories/userRepository';
 import { relatedActiveQfRoundForProject } from '../qfRoundService';
@@ -29,10 +38,150 @@ const cronJobTime =
   (config.get('CHECK_QR_TRANSACTIONS_CRONJOB_EXPRESSION') as string) ||
   '0 */1 * * * *';
 
-const getPendingDraftDonations = async () => {
+// Namespace for pg advisory locks used by the QR draft-donation flow.
+// Must not collide with other advisory-lock namespaces in the project
+// (e.g. POWER_BOOSTING_USER_LOCK_KEY = 48_103).
+export const QR_DRAFT_DONATION_LOCK_NAMESPACE = 48_205;
+// Namespace for per-transaction advisory locks, keyed by a value derived
+// from the Stellar transaction hash. A separate namespace from the draft/run
+// locks, so hash-derived keys can never collide with draft-id keys.
+export const QR_TX_LOCK_NAMESPACE = 48_206;
+// Draft ids start at 1, so 0 is reserved for the whole-cron-run lock.
+export const QR_CRON_RUN_LOCK_ID = 0;
+// One minute of grace after expiresAt during which a payment is still
+// accepted and the draft is not yet failed. Shared with the resolver so the
+// read path can never fail a draft the matcher would still accept.
+export const DRAFT_DONATION_EXPIRY_GRACE_MS = 60 * 1000;
+// A failed QR draft stays eligible for transaction scanning this long after
+// its expiry, so a payment Horizon indexed late (after the frontend timed
+// the draft out via markDraftDonationAsFailed) can still be reconciled to
+// matched. Bounded so failed drafts are not Horizon-scanned forever.
+export const QR_FAILED_DRAFT_RECONCILIATION_WINDOW_MS = 30 * 60 * 1000;
+// How long a matcher waits for another execution's per-draft or per-tx lock,
+// and the cap on any single Horizon request. Bounded so a hung execution can
+// only delay a draft, never pin connections or wedge the cron indefinitely.
+const QR_DRAFT_LOCK_WAIT_MS = 30 * 1000;
+const HORIZON_REQUEST_TIMEOUT_MS = 30 * 1000;
+
+// Deterministic 32-bit advisory-lock key for a Stellar transaction hash
+// (first 8 hex chars as a signed int32). A collision between two different
+// hashes only causes unnecessary serialization, never a correctness issue.
+export function txHashToLockId(txHash: string): number {
+  return (parseInt(txHash.slice(0, 8), 16) || 0) | 0;
+}
+
+// Runs fn while holding a PostgreSQL advisory lock, which is safe across
+// multiple Node processes/containers sharing the same database. The lock is
+// polled with pg_try_advisory_lock for at most waitMs (0 = single attempt)
+// instead of blocking in pg_advisory_lock, so a stuck holder can never pin
+// waiters' pool connections indefinitely. Returns false when the lock could
+// not be acquired within waitMs and fn was skipped.
+async function withQrAdvisoryLock(
+  namespace: number,
+  lockId: number,
+  waitMs: number,
+  fn: () => Promise<void>,
+): Promise<boolean> {
+  const queryRunner = AppDataSource.getDataSource().createQueryRunner();
+  await queryRunner.connect();
+  try {
+    const deadline = Date.now() + waitMs;
+    for (;;) {
+      const result = await queryRunner.query(
+        'SELECT pg_try_advisory_lock($1, $2) as acquired',
+        [namespace, lockId],
+      );
+      if (result?.[0]?.acquired) break;
+      if (Date.now() >= deadline) return false;
+      await new Promise(resolve => setTimeout(resolve, 500));
+    }
+    try {
+      await fn();
+    } finally {
+      await queryRunner.query('SELECT pg_advisory_unlock($1, $2)', [
+        namespace,
+        lockId,
+      ]);
+    }
+    return true;
+  } finally {
+    await queryRunner.release();
+  }
+}
+
+// Single source of truth for aligning a draft with a donation (the one it
+// references, or an explicitly provided one). Returns the donation when it is
+// live (non-failed) — the draft is made MATCHED, including fromWalletAddress.
+// Returns null when the donation is missing or failed: the draft is left
+// untouched so callers can keep scanning for a retry payment or fail it via
+// the guarded expiry update. With linkFailedDonation=true a failed donation
+// is instead recorded on the draft (status failed + matchedDonationId), used
+// when a payment has just been attributed to the draft.
+export async function reconcileDraftWithMatchedDonation(
+  draftDonation: DraftDonation,
+  source: string,
+  options: { donation?: Donation; linkFailedDonation?: boolean } = {},
+): Promise<Donation | null> {
+  const matchedDonation =
+    options.donation ??
+    (await findDonationById(draftDonation.matchedDonationId!));
+  logger.debug('reconcileDraftWithMatchedDonation() has been called', {
+    draftDonationId: draftDonation.id,
+    matchedDonationId: matchedDonation?.id,
+    source,
+  });
+  if (!matchedDonation) return null;
+  if (matchedDonation.status === DONATION_STATUS.FAILED) {
+    if (options.linkFailedDonation) {
+      await updateDraftDonationStatus({
+        donationId: draftDonation.id,
+        status: DRAFT_DONATION_STATUS.FAILED,
+        fromWalletAddress: matchedDonation.fromWalletAddress,
+        matchedDonationId: matchedDonation.id,
+        txHash: matchedDonation.transactionId,
+        source: 'reconciliation',
+      });
+    }
+    // The on-chain transaction genuinely failed; don't hide it.
+    return null;
+  }
+  if (
+    draftDonation.status !== DRAFT_DONATION_STATUS.MATCHED ||
+    draftDonation.matchedDonationId !== matchedDonation.id
+  ) {
+    await updateDraftDonationStatus({
+      donationId: draftDonation.id,
+      status: DRAFT_DONATION_STATUS.MATCHED,
+      fromWalletAddress: matchedDonation.fromWalletAddress,
+      matchedDonationId: matchedDonation.id,
+      txHash: matchedDonation.transactionId,
+      source: 'reconciliation',
+    });
+  }
+  return matchedDonation;
+}
+
+// Pending QR drafts, plus recently-failed ones still inside the
+// reconciliation window: their payment may have reached Horizon only after
+// the frontend timed the draft out, and checkTransactions can then reconcile
+// failed -> matched. Failed drafts older than the window (and legacy failed
+// rows without expiresAt) stay failed and are no longer scanned.
+const getScannableDraftDonations = async () => {
+  const reconcileAfter = new Date(
+    Date.now() - QR_FAILED_DRAFT_RECONCILIATION_WINDOW_MS,
+  );
   return await DraftDonation.createQueryBuilder('draftDonation')
-    .where('draftDonation.status = :status', { status: 'pending' })
-    .andWhere('draftDonation.isQRDonation = true')
+    .where('draftDonation.isQRDonation = true')
+    .andWhere(
+      `(draftDonation.status = :pendingStatus OR
+        (draftDonation.status = :failedStatus AND
+         draftDonation.expiresAt > :reconcileAfter))`,
+      {
+        pendingStatus: DRAFT_DONATION_STATUS.PENDING,
+        failedStatus: DRAFT_DONATION_STATUS.FAILED,
+        reconcileAfter,
+      },
+    )
     .getMany();
 };
 
@@ -50,6 +199,7 @@ const getToken = async (
 // Check for transactions
 export async function checkTransactions(
   donation: DraftDonation,
+  source: string = 'stellar-cron',
 ): Promise<void> {
   const { toWalletAddress, amount, toWalletMemo, expiresAt, id } = donation;
 
@@ -59,24 +209,35 @@ export async function checkTransactions(
       return;
     }
 
-    const now = Date.now();
-    const expiresAtDate = new Date(expiresAt!).getTime() + 1 * 60 * 1000;
-
-    if (now > expiresAtDate) {
-      logger.debug(`Donation ID ${id} has expired. Updating status to expired`);
-      await updateDraftDonationStatus({
-        donationId: id,
-        status: 'failed',
-      });
-      return;
+    // A draft that already points to a live donation only needs its status
+    // reconciled with that donation. When the referenced donation failed or
+    // was deleted, keep going: a retry payment may still match, and the
+    // expiry check below can fail the draft.
+    if (donation.matchedDonationId) {
+      const liveDonation = await reconcileDraftWithMatchedDonation(
+        donation,
+        source,
+      );
+      if (liveDonation) return;
     }
+
+    const now = Date.now();
+    // A missing expiresAt (legacy rows) counts as already expired.
+    const expiresAtDate = expiresAt
+      ? new Date(expiresAt).getTime() + DRAFT_DONATION_EXPIRY_GRACE_MS
+      : 0;
+    // An expired draft still gets this (last) scan, so a payment that arrived
+    // within the validity window is matched even when the cron lagged behind.
+    // If no such payment is found it is failed below, via a conditional
+    // update that never overwrites a concurrent match.
+    const isExpired = now > expiresAtDate;
 
     const response = await axios.get(
       `${STELLAR_HORIZON_API}/accounts/${toWalletAddress}/payments?limit=200&order=desc&join=transactions&include_failed=true`,
+      { timeout: HORIZON_REQUEST_TIMEOUT_MS },
     );
 
-    const transactions = response.data._embedded.records;
-    if (!transactions.length) return;
+    const transactions = response.data._embedded.records || [];
 
     // Only consider payments made at/after this draft was created (with a small
     // clock-skew allowance). The memo + amount already uniquely identify the
@@ -100,9 +261,13 @@ export async function checkTransactions(
         transaction.account === toWalletAddress &&
         Number(transaction.starting_balance) === amount;
 
+      // The payment must fall inside the draft's validity window: not before
+      // creation (minus clock skew) and not after expiry (plus the same grace
+      // minute the expiry check uses).
       const isMatchingTransaction =
         (isNativePayment || isCreateAccount) &&
-        transactionCreatedAt >= draftCreatedAt - CLOCK_SKEW;
+        transactionCreatedAt >= draftCreatedAt - CLOCK_SKEW &&
+        transactionCreatedAt <= expiresAtDate;
 
       if (isMatchingTransaction) {
         const memo = transaction.transaction.memo;
@@ -126,52 +291,135 @@ export async function checkTransactions(
           }
         }
 
-        // Check if donation already exists
-        const existingDonation = await findDonationsByTransactionId(
-          transaction.transaction_hash?.toLowerCase(),
-        );
-        if (existingDonation) return;
+        const txHash = transaction.transaction_hash?.toLowerCase();
+        let createdDonationId: number | undefined;
 
-        // Retrieve token object
-        const token = await getToken('STELLAR', 'XLM');
-        if (!token) {
-          logger.debug('Token not found for donation ID', donation.id);
-          return;
-        }
+        const matchUnderLocks = async () => {
+          // Re-check under the locks: another execution may have already
+          // created the donation for this transaction. Reconcile the draft
+          // with it only when the donation is positively this draft's: other
+          // pending drafts to the same project can share address, memo and
+          // amount, and a donation already claimed by another draft must not
+          // be claimed here too.
+          const existingDonation = await findDonationsByTransactionId(txHash);
+          if (existingDonation) {
+            const claimingDraft = await findDraftDonationByMatchedDonationId(
+              existingDonation.id,
+            );
+            if (
+              (!claimingDraft || claimingDraft.id === donation.id) &&
+              existingDonation.toWalletAddress === donation.toWalletAddress &&
+              Number(existingDonation.amount) === amount
+            ) {
+              await reconcileDraftWithMatchedDonation(donation, source, {
+                donation: existingDonation,
+                linkFailedDonation: true,
+              });
+            }
+            return;
+          }
 
-        // Retrieve project object
-        const project = await findProjectById(donation.projectId);
-        if (!project) {
-          logger.debug(`Project not found for donation ID ${donation.id}`);
-          return;
-        }
-
-        // Get token price
-        const tokenPrice = await new CoingeckoPriceAdapter().getTokenPrice({
-          symbol: token.coingeckoId,
-          networkId: token.networkId,
-        });
-
-        // Retrieve donor object
-        const donor = await findUserById(donation.userId);
-
-        // Use QF round from draft donation if available, otherwise fall back to smart select
-        let qfRound: QfRound | undefined;
-        if (donation.qfRoundId) {
-          // Use the QF round specified in the draft donation - this should always be respected
-          const foundQfRound = await QfRound.findOneBy({
-            id: donation.qfRoundId,
+          // Re-read the draft under the lock; the in-memory entity may be
+          // stale if another execution matched it meanwhile. A draft linked
+          // to a failed donation may still be re-matched by a retry payment.
+          const freshDraft = await DraftDonation.findOne({
+            where: { id: donation.id },
           });
-          if (foundQfRound) {
-            qfRound = foundQfRound;
-            logger.debug(
-              `Using QF round ID ${donation.qfRoundId} from draft donation for QR donation ID ${donation.id}`,
+          if (
+            !freshDraft ||
+            freshDraft.status === DRAFT_DONATION_STATUS.MATCHED
+          ) {
+            return;
+          }
+          if (freshDraft.matchedDonationId) {
+            const linkedDonation = await findDonationById(
+              freshDraft.matchedDonationId,
             );
+            if (
+              linkedDonation &&
+              linkedDonation.status !== DONATION_STATUS.FAILED
+            ) {
+              return;
+            }
+          }
+
+          // Retrieve token object
+          const token = await getToken('STELLAR', 'XLM');
+          if (!token) {
+            logger.debug('Token not found for donation ID', donation.id);
+            return;
+          }
+
+          // Retrieve project object
+          const project = await findProjectById(donation.projectId);
+          if (!project) {
+            logger.debug(`Project not found for donation ID ${donation.id}`);
+            return;
+          }
+
+          // Get token price
+          const tokenPrice = await new CoingeckoPriceAdapter().getTokenPrice({
+            symbol: token.coingeckoId,
+            networkId: token.networkId,
+          });
+
+          // Retrieve donor object
+          const donor = await findUserById(donation.userId);
+
+          // Use QF round from draft donation if available, otherwise fall back to smart select
+          let qfRound: QfRound | undefined;
+          if (donation.qfRoundId) {
+            // Use the QF round specified in the draft donation - this should always be respected
+            const foundQfRound = await QfRound.findOneBy({
+              id: donation.qfRoundId,
+            });
+            if (foundQfRound) {
+              qfRound = foundQfRound;
+              logger.debug(
+                `Using QF round ID ${donation.qfRoundId} from draft donation for QR donation ID ${donation.id}`,
+              );
+            } else {
+              logger.warn(
+                `QF round with ID ${donation.qfRoundId} not found for QR donation ID ${donation.id}, falling back to smart select`,
+              );
+              // Only fall back to smart select if the specified QF round doesn't exist
+              try {
+                const smartSelectedQfRound = await selectQfRoundForProject(
+                  token.networkId,
+                  project.id,
+                );
+
+                // Find the actual QfRound entity to assign to the donation
+                qfRound =
+                  (await QfRound.findOneBy({
+                    id: smartSelectedQfRound.qfRoundId,
+                  })) || undefined;
+              } catch (error) {
+                // If smart select fails (no eligible QF rounds), fall back to the old logic
+                if (error instanceof QfRoundSmartSelectError) {
+                  logger.debug(
+                    `Smart select failed for QR donation, falling back to old logic: ${error.message}`,
+                    {
+                      projectId: project.id,
+                      networkId: token.networkId,
+                      draftDonationId: donation.id,
+                    },
+                  );
+
+                  const activeQfRoundForProject =
+                    await relatedActiveQfRoundForProject(project.id);
+
+                  if (
+                    activeQfRoundForProject &&
+                    activeQfRoundForProject.isEligibleNetwork(token.networkId)
+                  ) {
+                    qfRound = activeQfRoundForProject;
+                  }
+                }
+              }
+            }
           } else {
-            logger.warn(
-              `QF round with ID ${donation.qfRoundId} not found for QR donation ID ${donation.id}, falling back to smart select`,
-            );
-            // Only fall back to smart select if the specified QF round doesn't exist
+            // Fall back to smart select logic if no QF round specified in draft donation
             try {
               const smartSelectedQfRound = await selectQfRoundForProject(
                 token.networkId,
@@ -207,105 +455,122 @@ export async function checkTransactions(
               }
             }
           }
-        } else {
-          // Fall back to smart select logic if no QF round specified in draft donation
-          try {
-            const smartSelectedQfRound = await selectQfRoundForProject(
-              token.networkId,
-              project.id,
+
+          const { givbackFactor, projectRank, bottomRankInRound, powerRound } =
+            await calculateGivbackFactor(project.id);
+
+          const returnedDonation = await createDonation({
+            amount: donation.amount,
+            project,
+            transactionNetworkId: donation.networkId,
+            fromWalletAddress: transaction.source_account,
+            transactionId: transaction.transaction_hash,
+            tokenAddress: donation.tokenAddress,
+            isProjectGivbackEligible: project.isGivbackEligible,
+            donorUser: donor,
+            isTokenEligibleForGivback: token.isGivbackEligible,
+            segmentNotified: false,
+            toWalletAddress: donation.toWalletAddress,
+            donationAnonymous: false,
+            transakId: '',
+            token: donation.currency,
+            valueUsd: donation.amount * tokenPrice,
+            priceUsd: tokenPrice,
+            status: transaction.transaction_successful ? 'verified' : 'failed',
+            isQRDonation: true,
+            toWalletMemo,
+            qfRound,
+            chainType: token.chainType,
+            givbackFactor,
+            projectRank,
+            bottomRankInRound,
+            powerRound,
+          });
+
+          if (!returnedDonation) {
+            logger.debug(
+              `Error creating donation for draft donation ID ${donation.id}`,
             );
-
-            // Find the actual QfRound entity to assign to the donation
-            qfRound =
-              (await QfRound.findOneBy({
-                id: smartSelectedQfRound.qfRoundId,
-              })) || undefined;
-          } catch (error) {
-            // If smart select fails (no eligible QF rounds), fall back to the old logic
-            if (error instanceof QfRoundSmartSelectError) {
-              logger.debug(
-                `Smart select failed for QR donation, falling back to old logic: ${error.message}`,
-                {
-                  projectId: project.id,
-                  networkId: token.networkId,
-                  draftDonationId: donation.id,
-                },
-              );
-
-              const activeQfRoundForProject =
-                await relatedActiveQfRoundForProject(project.id);
-
-              if (
-                activeQfRoundForProject &&
-                activeQfRoundForProject.isEligibleNetwork(token.networkId)
-              ) {
-                qfRound = activeQfRoundForProject;
-              }
-            }
+            return;
           }
-        }
 
-        const { givbackFactor, projectRank, bottomRankInRound, powerRound } =
-          await calculateGivbackFactor(project.id);
+          // Update draft donation status to matched and add matched donation ID with source address
+          await updateDraftDonationStatus({
+            donationId: donation.id,
+            status: transaction.transaction_successful
+              ? DRAFT_DONATION_STATUS.MATCHED
+              : DRAFT_DONATION_STATUS.FAILED,
+            fromWalletAddress: transaction.source_account,
+            matchedDonationId: returnedDonation.id,
+            txHash,
+            source,
+          });
 
-        const returnedDonation = await createDonation({
-          amount: donation.amount,
-          project,
-          transactionNetworkId: donation.networkId,
-          fromWalletAddress: transaction.source_account,
-          transactionId: transaction.transaction_hash,
-          tokenAddress: donation.tokenAddress,
-          isProjectGivbackEligible: project.isGivbackEligible,
-          donorUser: donor,
-          isTokenEligibleForGivback: token.isGivbackEligible,
-          segmentNotified: false,
-          toWalletAddress: donation.toWalletAddress,
-          donationAnonymous: false,
-          transakId: '',
-          token: donation.currency,
-          valueUsd: donation.amount * tokenPrice,
-          priceUsd: tokenPrice,
-          status: transaction.transaction_successful ? 'verified' : 'failed',
-          isQRDonation: true,
-          toWalletMemo,
-          qfRound,
-          chainType: token.chainType,
-          givbackFactor,
-          projectRank,
-          bottomRankInRound,
-          powerRound,
-        });
+          createdDonationId = returnedDonation.id;
+        };
 
-        if (!returnedDonation) {
-          logger.debug(
-            `Error creating donation for draft donation ID ${donation.id}`,
+        // Serialize the match across processes at two levels, always in this
+        // order (tx lock outer, draft lock inner — a fixed order plus bounded
+        // waits means no deadlock):
+        // - per transaction: two different drafts sharing address, memo and
+        //   amount must not both turn this payment into a donation;
+        // - per draft: overlapping cron runs and concurrent GraphQL
+        //   verifications must not match this draft twice.
+        if (txHash) {
+          await withQrAdvisoryLock(
+            QR_TX_LOCK_NAMESPACE,
+            txHashToLockId(txHash),
+            QR_DRAFT_LOCK_WAIT_MS,
+            async () => {
+              await withQrAdvisoryLock(
+                QR_DRAFT_DONATION_LOCK_NAMESPACE,
+                donation.id,
+                QR_DRAFT_LOCK_WAIT_MS,
+                matchUnderLocks,
+              );
+            },
           );
-          return;
+        } else {
+          await withQrAdvisoryLock(
+            QR_DRAFT_DONATION_LOCK_NAMESPACE,
+            donation.id,
+            QR_DRAFT_LOCK_WAIT_MS,
+            matchUnderLocks,
+          );
         }
 
-        // Update draft donation status to matched and add matched donation ID with source address
-        await updateDraftDonationStatus({
-          donationId: donation.id,
-          status: transaction.transaction_successful ? 'matched' : 'failed',
-          fromWalletAddress: transaction.source_account,
-          matchedDonationId: returnedDonation.id,
-        });
+        // Outside the advisory locks: slow external calls that don't touch
+        // lock-protected draft state must not extend the lock hold time.
+        if (createdDonationId) {
+          await syncDonationStatusWithBlockchainNetwork({
+            donationId: createdDonationId,
+          });
 
-        await syncDonationStatusWithBlockchainNetwork({
-          donationId: returnedDonation.id,
-        });
-
-        // Notify clients of new donation
-        notifyClients({
-          type: 'new-donation',
-          data: {
-            donationId: returnedDonation.id,
-            draftDonationId: donation.id,
-          },
-        });
+          // Notify clients of new donation
+          notifyClients({
+            type: 'new-donation',
+            data: {
+              donationId: createdDonationId,
+              draftDonationId: donation.id,
+            },
+          });
+        }
 
         return;
       }
+    }
+
+    if (isExpired && donation.status !== DRAFT_DONATION_STATUS.FAILED) {
+      logger.debug(`Donation ID ${id} has expired. Updating status to failed`);
+      // Conditional update: only fails the draft when it is still pending,
+      // has no matched donation, and its expiresAt (as stored right now, not
+      // as loaded by this possibly stale execution) is really in the past.
+      await updateDraftDonationStatus({
+        donationId: id,
+        status: DRAFT_DONATION_STATUS.FAILED,
+        expiresBefore: new Date(now - DRAFT_DONATION_EXPIRY_GRACE_MS),
+        source,
+      });
     }
   } catch (error) {
     logger.debug(
@@ -315,15 +580,41 @@ export async function checkTransactions(
   }
 }
 
+// Processes all pending QR drafts under a no-overlap advisory lock, so a
+// slow run can never race a newer one (in this process or in another
+// container) with stale in-memory draft entities.
+export const processPendingQRDraftDonations = async (): Promise<void> => {
+  try {
+    const acquired = await withQrAdvisoryLock(
+      QR_DRAFT_DONATION_LOCK_NAMESPACE,
+      QR_CRON_RUN_LOCK_ID,
+      0,
+      async () => {
+        const scannableDonations = await getScannableDraftDonations();
+
+        for (const donation of scannableDonations) {
+          await checkTransactions(donation, 'stellar-cron');
+        }
+      },
+    );
+    if (!acquired) {
+      // info (not debug) on purpose: if this line appears on every tick, the
+      // run lock is stuck (e.g. an unlock failed on a still-alive connection)
+      // and the cron is being starved.
+      logger.info(
+        'checkQRTransactionJob skipped, another execution is still running',
+      );
+    }
+  } catch (e) {
+    logger.error(`Error in processPendingQRDraftDonations: ${e.message}`);
+  }
+};
+
 // Cron job to check pending draft donations every 5 minutes
 export const runCheckQRTransactionJob = () => {
   logger.debug('checkQRTransactionJob() has been called', { cronJobTime });
 
   schedule(cronJobTime, async () => {
-    const pendingDonations = await getPendingDraftDonations();
-
-    for (const donation of pendingDonations) {
-      await checkTransactions(donation);
-    }
+    await processPendingQRDraftDonations();
   });
 };

--- a/src/services/cronJobs/checkQRTransactionJob.ts
+++ b/src/services/cronJobs/checkQRTransactionJob.ts
@@ -292,6 +292,15 @@ export async function checkTransactions(
         }
 
         const txHash = transaction.transaction_hash?.toLowerCase();
+        if (!txHash) {
+          // A payment without a transaction hash can neither be deduplicated
+          // nor recorded as a donation. Skip it and keep scanning, so other
+          // payments and the expiry handling below stay reachable.
+          logger.debug(
+            `Skipping payment without transaction hash for draft donation ID ${donation.id}`,
+          );
+          continue;
+        }
         let createdDonationId: number | undefined;
 
         const matchUnderLocks = async () => {
@@ -516,28 +525,19 @@ export async function checkTransactions(
         //   amount must not both turn this payment into a donation;
         // - per draft: overlapping cron runs and concurrent GraphQL
         //   verifications must not match this draft twice.
-        if (txHash) {
-          await withQrAdvisoryLock(
-            QR_TX_LOCK_NAMESPACE,
-            txHashToLockId(txHash),
-            QR_DRAFT_LOCK_WAIT_MS,
-            async () => {
-              await withQrAdvisoryLock(
-                QR_DRAFT_DONATION_LOCK_NAMESPACE,
-                donation.id,
-                QR_DRAFT_LOCK_WAIT_MS,
-                matchUnderLocks,
-              );
-            },
-          );
-        } else {
-          await withQrAdvisoryLock(
-            QR_DRAFT_DONATION_LOCK_NAMESPACE,
-            donation.id,
-            QR_DRAFT_LOCK_WAIT_MS,
-            matchUnderLocks,
-          );
-        }
+        await withQrAdvisoryLock(
+          QR_TX_LOCK_NAMESPACE,
+          txHashToLockId(txHash),
+          QR_DRAFT_LOCK_WAIT_MS,
+          async () => {
+            await withQrAdvisoryLock(
+              QR_DRAFT_DONATION_LOCK_NAMESPACE,
+              donation.id,
+              QR_DRAFT_LOCK_WAIT_MS,
+              matchUnderLocks,
+            );
+          },
+        );
 
         // Outside the advisory locks: slow external calls that don't touch
         // lock-protected draft state must not extend the lock hold time.

--- a/src/services/qfRoundSmartSelectService.ts
+++ b/src/services/qfRoundSmartSelectService.ts
@@ -1,5 +1,7 @@
 import { QfRound } from '../entities/qfRound';
 import { getProjectQfRoundStats } from '../repositories/donationRepository';
+import { logger } from '../utils/logger';
+import { relatedActiveQfRoundForProject } from './qfRoundService';
 
 export interface QfRoundSmartSelectResult {
   qfRoundId: number;
@@ -131,4 +133,46 @@ export async function selectQfRoundForProject(
     uniqueDonors: projectStats.uniqueDonorsCount,
     donationsCount: projectStats.donationsCount,
   };
+}
+
+/**
+ * selectQfRoundForProject plus the historical fallback, so every caller that
+ * needs a QfRound for a donation shares one definition of the rules: when
+ * smart select finds no eligible round, fall back to the project's active QF
+ * round, and only if that round is eligible for the network.
+ * @returns the selected QfRound, or undefined when neither path yields one
+ */
+export async function selectQfRoundForProjectWithFallback(
+  networkId: number,
+  projectId: number,
+  logContext: Record<string, unknown> = {},
+): Promise<QfRound | undefined> {
+  try {
+    const smartSelectedQfRound = await selectQfRoundForProject(
+      networkId,
+      projectId,
+    );
+    return (
+      (await QfRound.findOneBy({ id: smartSelectedQfRound.qfRoundId })) ||
+      undefined
+    );
+  } catch (error) {
+    if (error instanceof QfRoundSmartSelectError) {
+      logger.debug(
+        `Smart select failed, falling back to old logic: ${error.message}`,
+        { projectId, networkId, ...logContext },
+      );
+
+      const activeQfRoundForProject =
+        await relatedActiveQfRoundForProject(projectId);
+
+      if (
+        activeQfRoundForProject &&
+        activeQfRoundForProject.isEligibleNetwork(networkId)
+      ) {
+        return activeQfRoundForProject;
+      }
+    }
+    return undefined;
+  }
 }

--- a/src/services/recurringDonationService.ts
+++ b/src/services/recurringDonationService.ts
@@ -34,13 +34,8 @@ import {
 import { calculateGivbackFactor } from './givbackService';
 import { updateUserTotalDonated, updateUserTotalReceived } from './userService';
 import { User } from '../entities/user';
-import { QfRound } from '../entities/qfRound';
 import { NOTIFICATIONS_EVENT_NAMES } from '../analytics/analytics';
-import { relatedActiveQfRoundForProject } from './qfRoundService';
-import {
-  selectQfRoundForProject,
-  QfRoundSmartSelectError,
-} from './qfRoundSmartSelectService';
+import { selectQfRoundForProjectWithFallback } from './qfRoundSmartSelectService';
 import { updateProjectStatistics } from './projectService';
 import { ResourcesTotalPerMonthAndYear } from '../resolvers/donationResolver';
 
@@ -219,50 +214,17 @@ export const createRelatedDonationsToStream = async (
       });
 
       // Use smart select logic to find the best QF round for this project and network
-      try {
-        const smartSelectedQfRound = await selectQfRoundForProject(
-          networkId,
-          project.id,
-        );
-
-        // Find the actual QfRound entity to assign to the donation
-        const qfRound = await QfRound.findOneBy({
-          id: smartSelectedQfRound.qfRoundId,
+      const qfRound = await selectQfRoundForProjectWithFallback(
+        networkId,
+        project.id,
+        { recurringDonationId: recurringDonation.id },
+      );
+      if (qfRound) {
+        const projectOwner = await User.findOneBy({
+          id: project.adminUserId,
         });
-        if (qfRound) {
-          const projectOwner = await User.findOneBy({
-            id: project.adminUserId,
-          });
-          donation.qfRound = qfRound;
-          donation.qfRoundUserScore = projectOwner?.passportScore;
-        }
-      } catch (error) {
-        // If smart select fails (no eligible QF rounds), fall back to the old logic
-        if (error instanceof QfRoundSmartSelectError) {
-          logger.debug(
-            `Smart select failed for recurring donation, falling back to old logic: ${error.message}`,
-            {
-              projectId: project.id,
-              networkId,
-              recurringDonationId: recurringDonation.id,
-            },
-          );
-
-          const activeQfRoundForProject = await relatedActiveQfRoundForProject(
-            project.id,
-          );
-
-          if (
-            activeQfRoundForProject &&
-            activeQfRoundForProject.isEligibleNetwork(networkId)
-          ) {
-            const projectOwner = await User.findOneBy({
-              id: project.adminUserId,
-            });
-            donation.qfRound = activeQfRoundForProject;
-            donation.qfRoundUserScore = projectOwner?.passportScore;
-          }
-        }
+        donation.qfRound = qfRound;
+        donation.qfRoundUserScore = projectOwner?.passportScore;
       }
 
       const { givbackFactor, projectRank, bottomRankInRound, powerRound } =

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -172,6 +172,20 @@ export const renewDraftDonationExpirationDateMutation = `
   }
 `;
 
+export const getDraftDonationByIdQuery = `
+  query (
+    $id: Int!
+  ) {
+    getDraftDonationById(
+      id: $id
+    ) {
+      id
+      status
+      matchedDonationId
+    }
+  }
+`;
+
 export const markDraftDonationAsFailedDateMutation = `
   mutation (
     $id: Int!


### PR DESCRIPTION
## Issue

https://github.com/Giveth/giveth-v6-core/issues/444

## Summary

Fixes race conditions in the Stellar QR donation flow that could cause:

- A successfully matched draft to be incorrectly marked as failed.
- Duplicate donations when multiple matcher executions process the same payment.
- Late Horizon indexing to leave valid donations permanently failed.
- Overlapping cron executions to process stale draft state.

## Changes

- Added atomic, guarded draft-status transitions.
- Added PostgreSQL advisory locks for:
  - Individual draft donations.
  - Stellar transactions.
  - The complete QR cron execution.
- Added bounded lock waits and Horizon request timeouts.
- Re-checks draft and donation state while holding the appropriate locks.
- Scans expired drafts one final time before marking them as failed.
- Only accepts payments made within the draft’s validity window.
- Reconciles recently failed drafts when their Stellar payment appears later.
- Prevents matched drafts or drafts linked to live donations from being failed.
- Allows drafts linked to failed donations to be renewed and retried.
- Moves slow blockchain synchronization outside advisory-lock scopes.
- Adds an idempotent SQL script to repair historical failed drafts linked to successful donations.

## Reconciliation behavior

Recently failed drafts are rescanned for 30 minutes to account for delayed Horizon indexing. Older affected records can be repaired using:

`./scripts/reconcile-failed-qr-drafts.sql`

The script includes an inspection query and only updates failed QR drafts whose linked donation is not failed. It is safe to run repeatedly.

## Tests

Added coverage for:

- Concurrent matcher and cron executions.
- Two drafts attempting to claim the same transaction.
- Stale expiry updates racing with successful matches.
- Existing-transaction reconciliation.
- Late Horizon transaction discovery.
- Payment validity-window enforcement.
- Incorrect memo and amount handling.
- Draft renewal and failure guards.
- Cron overlap prevention.
- Repository-level atomic status transitions.
- Historical reconciliation script behavior and idempotency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR donation matching to avoid duplicate processing during concurrent activity.
  * Automatically reconciles incorrectly failed QR drafts with their existing donations.
  * Prevents valid matched donations from being incorrectly marked as failed.
  * Strengthened QR draft renewal/expiration and transaction validation (including grace-period handling).
  * Added safer duplicate-transaction handling and improved consistency for failure cases.
  * Added smart QF round selection with fallback when creating recurring donations.
* **Tests**
  * Expanded coverage for QR reconciliation, idempotency, locking, expiration/renewal rules, and concurrency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->