### PR TITLE
Fix Stellar QR donation matching for exchange withdrawal fees

### DIFF
--- a/src/adapters/chainvine/chainvineMockAdapter.ts
+++ b/src/adapters/chainvine/chainvineMockAdapter.ts
@@ -1,8 +1,20 @@
 import { ChainvineAdapterInterface } from './chainvineAdapterInterface';
-import {
-  generateRandomEtheriumAddress,
-  generateHexNumber,
-} from '../../utils/utils';
+
+// Local copies of the test-utils generators: this mock adapter is the only
+// production file that needs them, and importing test/testUtils here would
+// pull test-only dependencies (chai, sinon) into the production module graph.
+function generateHexNumber(len: number): string {
+  const hex = '0123456789abcdef';
+  let output = '';
+  for (let i = 0; i < len; i++) {
+    output += hex.charAt(Math.floor(Math.random() * hex.length));
+  }
+  return output;
+}
+
+function generateRandomEtheriumAddress(): string {
+  return `0x${generateHexNumber(40)}`;
+}
 
 export const cachedReferralIds = {};
 

--- a/src/adapters/chainvine/chainvineMockAdapter.ts
+++ b/src/adapters/chainvine/chainvineMockAdapter.ts
@@ -2,7 +2,7 @@ import { ChainvineAdapterInterface } from './chainvineAdapterInterface';
 import {
   generateRandomEtheriumAddress,
   generateHexNumber,
-} from '../../../test/testUtils';
+} from '../../utils/utils';
 
 export const cachedReferralIds = {};
 

--- a/src/resolvers/draftDonationResolver.test.ts
+++ b/src/resolvers/draftDonationResolver.test.ts
@@ -1773,13 +1773,14 @@ function stellarQRMatchingTestCases() {
   // A Horizon create_account operation record funding the draft's address.
   function stellarCreateAccount(
     draft: DraftDonation,
-    opts: { amount?: number; memo?: string } = {},
+    opts: { amount?: number; memo?: string; createdAt?: Date } = {},
   ) {
     return horizonPaymentRecord({
       type: 'create_account',
       to: draft.toWalletAddress,
       amount: opts.amount ?? draft.amount,
       memo: opts.memo ?? String(draft.id),
+      createdAt: opts.createdAt,
     });
   }
 
@@ -1980,8 +1981,9 @@ function stellarQRMatchingTestCases() {
 
   it('CASE 1: should credit the largest memo-carrying payment when a dust payment with the same memo is also on the page', async () => {
     const draft = await createStellarDraft({ amount: 20 });
-    // A newer dust payment front-running the real one; both carry the
-    // draft-id memo, so both identify the draft — the larger must win.
+    // A newer dust payment front-running the real one, both carrying the
+    // draft-id memo: the dust is rejected by the minimum-amount floor and
+    // the real payment must be the one credited.
     const dust = stellarPayment(draft, { amount: 0.0000001 });
     const real = stellarPayment(draft, {
       amount: 19.996,
@@ -2039,7 +2041,9 @@ function stellarQRMatchingTestCases() {
     expect(fresh!.matchedDonationId).to.equal(created!.id);
   });
 
-  it('CASE 1: should not match a create_account with the exact draft amount but without the draft-id memo', async () => {
+  it('CASE 1: should match a create_account with the exact draft amount even without the draft-id memo (legacy path)', async () => {
+    // Some wallets expose no memo field on account funding; the exact
+    // amount inside the tight validity window is accepted without one
     const draft = await createStellarDraft({ amount: 20 });
     const funding = stellarCreateAccount(draft, {
       amount: 20,
@@ -2050,9 +2054,52 @@ function stellarQRMatchingTestCases() {
     await checkTransactions(draft, 'stellar-cron');
 
     const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
-    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.PENDING);
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+
+    const created = await findDonationByTxHash(funding.transaction_hash);
+    expect(created).to.exist;
+    expect(created!.amount).to.equal(20);
+  });
+
+  it('CASE 1: should not match a memo-less create_account after expiry, even with the exact amount', async () => {
+    // The extended post-expiry window is justified by the memo alone; the
+    // memo-less legacy path keeps the tight window
+    const draft = await createStellarDraft({
+      amount: 20,
+      createdAt: new Date(Date.now() - 40 * 60 * 1000),
+      expiresAt: new Date(Date.now() - 24 * 60 * 1000),
+    });
+    const funding = stellarCreateAccount(draft, {
+      amount: 20,
+      memo: 'unrelated',
+      createdAt: new Date(Date.now() - 10 * 60 * 1000),
+    });
+    stubHorizonPayments([funding]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.FAILED);
     expect(fresh!.matchedDonationId).to.be.null;
     expect(await findDonationByTxHash(funding.transaction_hash)).to.not.exist;
+  });
+
+  it('CASE 1: should not match a payment below the minimum amount factor even with the correct memo', async () => {
+    // Dust (or a heavy underpayment) carrying a guessed draft-id memo must
+    // not claim the draft; the floor still passes any fee-reduced payment
+    const draft = await createStellarDraft({ amount: 20 });
+    const dust = stellarPayment(draft, { amount: 0.0000001 });
+    const underpayment = stellarPayment(draft, { amount: 17 });
+    stubHorizonPayments([dust, underpayment]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.PENDING);
+    expect(fresh!.matchedDonationId).to.be.null;
+    expect(await findDonationByTxHash(dust.transaction_hash)).to.not.exist;
+    expect(await findDonationByTxHash(underpayment.transaction_hash)).to.not
+      .exist;
   });
 
   it('CASE 1: should credit the successful retry over a larger failed payment attempt', async () => {

--- a/src/resolvers/draftDonationResolver.test.ts
+++ b/src/resolvers/draftDonationResolver.test.ts
@@ -15,6 +15,8 @@ import {
   generateRandomStellarAddress,
   saveDonationDirectlyToDb,
   saveUserDirectlyToDb,
+  stubStellarHorizonPayments as stubHorizonPayments,
+  horizonPaymentRecord,
 } from '../../test/testUtils';
 import {
   createDraftDonationMutation,
@@ -72,6 +74,10 @@ describe(
 describe(
   'stellar QR draft donation race condition test cases',
   stellarQRDraftRaceConditionTestCases,
+);
+describe(
+  'stellar QR donation matching test cases (memo-identified vs recipient-memo)',
+  stellarQRMatchingTestCases,
 );
 
 function createDraftDonationTestCases() {
@@ -1143,96 +1149,115 @@ function markDraftDonationAsFailedTestCases() {
   });
 }
 
+// ---- Shared Stellar QR test fixtures, used by the race-condition and the
+// ---- matching suites below (keep one copy; the suites only differ in the
+// ---- draft defaults they layer on top).
+
+const STELLAR_TEST_TOKEN_PRICE = 0.5;
+
+// The QR matcher requires a Stellar XLM token flagged with isQR
+async function ensureStellarQrXlmToken() {
+  const existingToken = await Token.findOne({
+    where: { symbol: 'XLM', networkId: NETWORK_IDS.STELLAR_MAINNET },
+  });
+  if (!existingToken) {
+    await Token.create({
+      name: 'Stellar Lumens',
+      symbol: 'XLM',
+      address: 'native',
+      networkId: NETWORK_IDS.STELLAR_MAINNET,
+      decimals: 7,
+      chainType: ChainType.STELLAR,
+      isQR: true,
+      coingeckoId: 'stellar',
+    }).save();
+  } else if (!existingToken.isQR) {
+    existingToken.isQR = true;
+    await existingToken.save();
+  }
+}
+
+async function setupStellarQrSuiteState() {
+  const project = await saveProjectDirectlyToDb(createProjectData());
+  const user = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+  sinon
+    .stub(CoingeckoPriceAdapter.prototype, 'getTokenPrice')
+    .resolves(STELLAR_TEST_TOKEN_PRICE);
+  sinon
+    .stub(donationService, 'syncDonationStatusWithBlockchainNetwork')
+    .resolves({} as any);
+  return { project, user };
+}
+
+async function createStellarDraftFor(
+  project: { id: number },
+  user: { id: number },
+  overrides: Partial<DraftDonation> = {},
+): Promise<DraftDonation> {
+  return DraftDonation.create({
+    networkId: NETWORK_IDS.STELLAR_MAINNET,
+    chainType: ChainType.STELLAR,
+    status: DRAFT_DONATION_STATUS.PENDING,
+    toWalletAddress: generateRandomStellarAddress(),
+    fromWalletAddress: '',
+    currency: 'XLM',
+    anonymous: false,
+    amount: 10,
+    projectId: project.id,
+    userId: user.id,
+    qrCodeDataUrl: 'data:image/png;base64,123',
+    isQRDonation: true,
+    createdAt: new Date(Date.now() - 5 * 60 * 1000),
+    expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+    ...overrides,
+  }).save();
+}
+
+// A Horizon payment-operation record for `draft`, delegating to the shared
+// horizonPaymentRecord shape. The memo defaults to the draft's recipient
+// memo when it has one (CASE 2) and to the draft id otherwise (CASE 1);
+// tests probing memo behavior pass `memo` explicitly.
+function stellarPayment(
+  draft: DraftDonation,
+  opts: {
+    txHash?: string;
+    createdAt?: Date;
+    memo?: string;
+    successful?: boolean;
+    amount?: number;
+    to?: string;
+  } = {},
+) {
+  return horizonPaymentRecord({
+    to: opts.to ?? draft.toWalletAddress,
+    amount: opts.amount ?? draft.amount,
+    txHash: opts.txHash,
+    createdAt: opts.createdAt,
+    successful: opts.successful,
+    memo: opts.memo ?? draft.toWalletMemo ?? String(draft.id),
+  });
+}
+
 function stellarQRDraftRaceConditionTestCases() {
   let project;
   let user;
 
-  before(async () => {
-    // The QR matcher requires a Stellar XLM token flagged with isQR
-    const existingToken = await Token.findOne({
-      where: { symbol: 'XLM', networkId: NETWORK_IDS.STELLAR_MAINNET },
-    });
-    if (!existingToken) {
-      await Token.create({
-        name: 'Stellar Lumens',
-        symbol: 'XLM',
-        address: 'native',
-        networkId: NETWORK_IDS.STELLAR_MAINNET,
-        decimals: 7,
-        chainType: ChainType.STELLAR,
-        isQR: true,
-        coingeckoId: 'stellar',
-      }).save();
-    } else if (!existingToken.isQR) {
-      existingToken.isQR = true;
-      await existingToken.save();
-    }
-  });
+  before(ensureStellarQrXlmToken);
 
   beforeEach(async () => {
-    project = await saveProjectDirectlyToDb(createProjectData());
-    user = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
-    sinon.stub(CoingeckoPriceAdapter.prototype, 'getTokenPrice').resolves(0.5);
-    sinon
-      .stub(donationService, 'syncDonationStatusWithBlockchainNetwork')
-      .resolves({} as any);
+    ({ project, user } = await setupStellarQrSuiteState());
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  async function createStellarDraft(
-    overrides: Partial<DraftDonation> = {},
-  ): Promise<DraftDonation> {
-    return DraftDonation.create({
-      networkId: NETWORK_IDS.STELLAR_MAINNET,
-      chainType: ChainType.STELLAR,
-      status: DRAFT_DONATION_STATUS.PENDING,
-      toWalletAddress: generateRandomStellarAddress(),
-      fromWalletAddress: '',
-      currency: 'XLM',
-      anonymous: false,
-      amount: 10,
-      projectId: project.id,
-      userId: user.id,
+  // Race-condition drafts default to a recipient-required memo (CASE 2).
+  const createStellarDraft = (overrides: Partial<DraftDonation> = {}) =>
+    createStellarDraftFor(project, user, {
       toWalletMemo: '123321',
-      qrCodeDataUrl: 'data:image/png;base64,123',
-      isQRDonation: true,
-      createdAt: new Date(Date.now() - 5 * 60 * 1000),
-      expiresAt: new Date(Date.now() + 10 * 60 * 1000),
       ...overrides,
-    }).save();
-  }
-
-  function stellarPayment(
-    draft: DraftDonation,
-    opts: {
-      txHash?: string;
-      createdAt?: Date;
-      memo?: string;
-      successful?: boolean;
-      amount?: number;
-    } = {},
-  ) {
-    return {
-      type: 'payment',
-      asset_type: 'native',
-      to: draft.toWalletAddress,
-      amount: String(opts.amount ?? draft.amount),
-      source_account: generateRandomStellarAddress(),
-      transaction_hash: opts.txHash ?? generateRandomStellarTxHash(),
-      created_at: (opts.createdAt ?? new Date()).toISOString(),
-      transaction_successful: opts.successful ?? true,
-      transaction: { memo: opts.memo ?? draft.toWalletMemo },
-    };
-  }
-
-  function stubHorizonPayments(records: any[]) {
-    return sinon
-      .stub(axios, 'get')
-      .resolves({ data: { _embedded: { records } } });
-  }
+    });
 
   it('should mark a pending draft as failed after expiration', async () => {
     const draft = await createStellarDraft({
@@ -1723,5 +1748,337 @@ function stellarQRDraftRaceConditionTestCases() {
       where: { transactionId: paymentA.transaction_hash.toLowerCase() },
     });
     expect(donations.length).to.equal(1);
+  });
+}
+
+function stellarQRMatchingTestCases() {
+  let project;
+  let user;
+
+  before(ensureStellarQrXlmToken);
+
+  beforeEach(async () => {
+    ({ project, user } = await setupStellarQrSuiteState());
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  // Matching-suite drafts default to CASE 1: no recipient-required memo, so
+  // the Stellar memo carries the draft donation id.
+  const createStellarDraft = (overrides: Partial<DraftDonation> = {}) =>
+    createStellarDraftFor(project, user, { amount: 20, ...overrides });
+
+  // A Horizon create_account operation record funding the draft's address.
+  function stellarCreateAccount(
+    draft: DraftDonation,
+    opts: { amount?: number; memo?: string } = {},
+  ) {
+    return horizonPaymentRecord({
+      type: 'create_account',
+      to: draft.toWalletAddress,
+      amount: opts.amount ?? draft.amount,
+      memo: opts.memo ?? String(draft.id),
+    });
+  }
+
+  async function findDonationByTxHash(txHash: string) {
+    return Donation.findOne({ where: { transactionId: txHash.toLowerCase() } });
+  }
+
+  it('CASE 1: should match a payment with the exact draft amount', async () => {
+    const draft = await createStellarDraft();
+    const payment = stellarPayment(draft);
+    stubHorizonPayments([payment]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+
+    const created = await findDonationByTxHash(payment.transaction_hash);
+    expect(created).to.exist;
+    expect(created!.amount).to.equal(20);
+    expect(fresh!.matchedDonationId).to.equal(created!.id);
+  });
+
+  it('CASE 1: should match a payment whose amount was reduced by an exchange withdrawal fee and store the actual on-chain amount', async () => {
+    // Draft asks for 20 XLM, Binance deducts its fee and broadcasts 19.996
+    const draft = await createStellarDraft({ amount: 20 });
+    const payment = stellarPayment(draft, { amount: 19.996 });
+    stubHorizonPayments([payment]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+    // The draft keeps the originally requested amount
+    expect(Number(fresh!.amount)).to.equal(20);
+
+    // The donation records what actually arrived on-chain, and derived
+    // values are computed from that actual amount
+    const created = await findDonationByTxHash(payment.transaction_hash);
+    expect(created).to.exist;
+    expect(created!.amount).to.be.closeTo(19.996, 1e-9);
+    expect(created!.priceUsd).to.equal(STELLAR_TEST_TOKEN_PRICE);
+    expect(created!.valueUsd).to.be.closeTo(
+      19.996 * STELLAR_TEST_TOKEN_PRICE,
+      1e-9,
+    );
+    expect(fresh!.matchedDonationId).to.equal(created!.id);
+  });
+
+  it('CASE 1: should not match a payment with the correct memo but a wrong destination', async () => {
+    const draft = await createStellarDraft();
+    const payment = stellarPayment(draft, {
+      to: generateRandomStellarAddress(),
+    });
+    stubHorizonPayments([payment]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.PENDING);
+    expect(fresh!.matchedDonationId).to.be.null;
+    expect(await findDonationByTxHash(payment.transaction_hash)).to.not.exist;
+  });
+
+  it('CASE 1: should not match a payment with a wrong draft-id memo', async () => {
+    const draft = await createStellarDraft();
+    const payment = stellarPayment(draft, { memo: String(draft.id + 1) });
+    stubHorizonPayments([payment]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.PENDING);
+    expect(fresh!.matchedDonationId).to.be.null;
+    expect(await findDonationByTxHash(payment.transaction_hash)).to.not.exist;
+  });
+
+  it('CASE 2: should keep matching on the exact amount when the recipient requires its own memo', async () => {
+    const draft = await createStellarDraft({ toWalletMemo: '424242' });
+    const payment = stellarPayment(draft, { memo: '424242' });
+    stubHorizonPayments([payment]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+
+    const created = await findDonationByTxHash(payment.transaction_hash);
+    expect(created).to.exist;
+    expect(created!.amount).to.equal(20);
+    expect(created!.toWalletMemo).to.equal('424242');
+  });
+
+  it('CASE 2: should not match a fee-reduced amount when the recipient requires its own memo', async () => {
+    const draft = await createStellarDraft({
+      toWalletMemo: '424242',
+      amount: 20,
+    });
+    const payment = stellarPayment(draft, { memo: '424242', amount: 19.996 });
+    stubHorizonPayments([payment]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.PENDING);
+    expect(fresh!.matchedDonationId).to.be.null;
+    expect(await findDonationByTxHash(payment.transaction_hash)).to.not.exist;
+  });
+
+  it('CASE 1: should match a payment an exchange broadcast only after the draft expired (delayed withdrawal)', async () => {
+    // Draft created 40 minutes ago and expired 24 minutes ago; the exchange
+    // broadcast the withdrawal only 10 minutes ago — long after the old
+    // 2-minute window and after the draft expiry, but within the
+    // reconciliation window during which the draft is still scanned.
+    const draft = await createStellarDraft({
+      createdAt: new Date(Date.now() - 40 * 60 * 1000),
+      expiresAt: new Date(Date.now() - 24 * 60 * 1000),
+    });
+    const payment = stellarPayment(draft, {
+      amount: 19.996,
+      createdAt: new Date(Date.now() - 10 * 60 * 1000),
+    });
+    stubHorizonPayments([payment]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+
+    const created = await findDonationByTxHash(payment.transaction_hash);
+    expect(created).to.exist;
+    expect(created!.amount).to.be.closeTo(19.996, 1e-9);
+  });
+
+  it('CASE 2: should not match a payment broadcast after expiry when the recipient requires its own memo', async () => {
+    const draft = await createStellarDraft({
+      toWalletMemo: '424242',
+      createdAt: new Date(Date.now() - 40 * 60 * 1000),
+      expiresAt: new Date(Date.now() - 24 * 60 * 1000),
+    });
+    const payment = stellarPayment(draft, {
+      memo: '424242',
+      createdAt: new Date(Date.now() - 10 * 60 * 1000),
+    });
+    stubHorizonPayments([payment]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.FAILED);
+    expect(fresh!.matchedDonationId).to.be.null;
+    expect(await findDonationByTxHash(payment.transaction_hash)).to.not.exist;
+  });
+
+  it('CASE 1: should not create a duplicate donation when the same transaction is seen again on a later run', async () => {
+    const draft = await createStellarDraft();
+    const payment = stellarPayment(draft, { amount: 19.996 });
+    stubHorizonPayments([payment]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    // Next cron tick re-reads the draft and sees the same Horizon page
+    const rescanned = await DraftDonation.findOne({ where: { id: draft.id } });
+    await checkTransactions(rescanned!, 'stellar-cron');
+
+    const donations = await Donation.find({
+      where: { transactionId: payment.transaction_hash.toLowerCase() },
+    });
+    expect(donations.length).to.equal(1);
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+    expect(fresh!.matchedDonationId).to.equal(donations[0].id);
+  });
+
+  it("CASE 1: should pick this draft's own payment out of several payments to the same address", async () => {
+    const draft = await createStellarDraft();
+    // A newer unrelated payment (wrong memo) and an older one that is ours
+    const ownPayment = stellarPayment(draft, {
+      amount: 19.996,
+      createdAt: new Date(Date.now() - 3 * 60 * 1000),
+    });
+    stubHorizonPayments([
+      stellarPayment(draft, { memo: 'unrelated', amount: 5 }),
+      ownPayment,
+    ]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+
+    const created = await findDonationByTxHash(ownPayment.transaction_hash);
+    expect(created).to.exist;
+    expect(created!.amount).to.be.closeTo(19.996, 1e-9);
+    expect(fresh!.matchedDonationId).to.equal(created!.id);
+  });
+
+  it('CASE 1: should credit the largest memo-carrying payment when a dust payment with the same memo is also on the page', async () => {
+    const draft = await createStellarDraft({ amount: 20 });
+    // A newer dust payment front-running the real one; both carry the
+    // draft-id memo, so both identify the draft — the larger must win.
+    const dust = stellarPayment(draft, { amount: 0.0000001 });
+    const real = stellarPayment(draft, {
+      amount: 19.996,
+      createdAt: new Date(Date.now() - 2 * 60 * 1000),
+    });
+    stubHorizonPayments([dust, real]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+
+    const created = await findDonationByTxHash(real.transaction_hash);
+    expect(created).to.exist;
+    expect(created!.amount).to.be.closeTo(19.996, 1e-9);
+    expect(fresh!.matchedDonationId).to.equal(created!.id);
+    expect(await findDonationByTxHash(dust.transaction_hash)).to.not.exist;
+  });
+
+  it('CASE 1: should credit the largest operation when one transaction pays the address more than once', async () => {
+    const draft = await createStellarDraft({ amount: 20 });
+    // One Stellar transaction (one tx-level memo) carrying two payment
+    // operations to the same address; the donation must record the larger.
+    const txHash = generateRandomStellarTxHash();
+    stubHorizonPayments([
+      stellarPayment(draft, { amount: 0.1, txHash }),
+      stellarPayment(draft, { amount: 19.9, txHash }),
+    ]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+
+    const created = await findDonationByTxHash(txHash);
+    expect(created).to.exist;
+    expect(created!.amount).to.be.closeTo(19.9, 1e-9);
+  });
+
+  it('CASE 1: should match a fee-reduced create_account funding that carries the draft-id memo', async () => {
+    // First-ever payment to an unfunded address: the exchange broadcasts a
+    // create_account op with the fee already deducted from starting_balance
+    const draft = await createStellarDraft({ amount: 20 });
+    const funding = stellarCreateAccount(draft, { amount: 19.996 });
+    stubHorizonPayments([funding]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+
+    const created = await findDonationByTxHash(funding.transaction_hash);
+    expect(created).to.exist;
+    expect(created!.amount).to.be.closeTo(19.996, 1e-9);
+    expect(fresh!.matchedDonationId).to.equal(created!.id);
+  });
+
+  it('CASE 1: should not match a create_account with the exact draft amount but without the draft-id memo', async () => {
+    const draft = await createStellarDraft({ amount: 20 });
+    const funding = stellarCreateAccount(draft, {
+      amount: 20,
+      memo: 'unrelated',
+    });
+    stubHorizonPayments([funding]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.PENDING);
+    expect(fresh!.matchedDonationId).to.be.null;
+    expect(await findDonationByTxHash(funding.transaction_hash)).to.not.exist;
+  });
+
+  it('CASE 1: should credit the successful retry over a larger failed payment attempt', async () => {
+    const draft = await createStellarDraft({ amount: 20 });
+    // The donor's direct 20 XLM attempt failed on-chain; their exchange
+    // retry landed 19.996 successfully. Both carry the draft-id memo.
+    const failedAttempt = stellarPayment(draft, {
+      amount: 20,
+      successful: false,
+    });
+    const retry = stellarPayment(draft, {
+      amount: 19.996,
+      createdAt: new Date(Date.now() - 2 * 60 * 1000),
+    });
+    stubHorizonPayments([failedAttempt, retry]);
+
+    await checkTransactions(draft, 'stellar-cron');
+
+    const fresh = await DraftDonation.findOne({ where: { id: draft.id } });
+    expect(fresh!.status).to.equal(DRAFT_DONATION_STATUS.MATCHED);
+
+    const created = await findDonationByTxHash(retry.transaction_hash);
+    expect(created).to.exist;
+    expect(created!.amount).to.be.closeTo(19.996, 1e-9);
+    expect(fresh!.matchedDonationId).to.equal(created!.id);
+    expect(await findDonationByTxHash(failedAttempt.transaction_hash)).to.not
+      .exist;
   });
 }

--- a/src/server/adminJs/tabs/donationTab.ts
+++ b/src/server/adminJs/tabs/donationTab.ts
@@ -539,10 +539,9 @@ export const createDonation = async (request: AdminJsRequestInterface) => {
         isProjectGivbackEligible: project.isGivbackEligible,
         donationType,
         isQRDonation: chainType === ChainType.STELLAR,
-        createdAt:
-          chainType === ChainType.STELLAR
-            ? new Date(transactionInfo?.timestamp)
-            : new Date(transactionInfo?.timestamp * 1000),
+        // transactionInfo.timestamp is epoch seconds on every chain (Stellar
+        // included — getStellarTransactionInfo converts Horizon's ISO string)
+        createdAt: new Date(transactionInfo?.timestamp * 1000),
         anonymous,
         isTokenEligibleForGivback,
         qfRoundId: qfRoundId ? Number(qfRoundId) : undefined,

--- a/src/services/chains/stellar/stellarOperations.ts
+++ b/src/services/chains/stellar/stellarOperations.ts
@@ -8,10 +8,8 @@
 // Addresses are compared case-insensitively deliberately: Stellar strkeys
 // are canonically uppercase, but stored wallet addresses are user-supplied
 // and must mean the same account in every layer regardless of casing.
-export const stellarOperationPaysAddress = (
-  record: any,
-  address: string,
-): boolean => {
+// Module-private: callers go through isNativeStellarDeposit below.
+const stellarOperationPaysAddress = (record: any, address: string): boolean => {
   const recipient =
     record?.type === 'payment'
       ? record.to

--- a/src/services/chains/stellar/stellarOperations.ts
+++ b/src/services/chains/stellar/stellarOperations.ts
@@ -1,0 +1,53 @@
+// Shared knowledge about Stellar Horizon operation records, used by both the
+// QR draft matcher (checkQRTransactionJob) and donation verification
+// (transactionService) so the two layers can never disagree about which
+// operation pays an address or how much it transferred. Add new operation
+// shapes (e.g. path_payment_strict_send) here, never inline at a call site.
+
+// Whether this Horizon operation record delivers funds to `address`.
+// Addresses are compared case-insensitively deliberately: Stellar strkeys
+// are canonically uppercase, but stored wallet addresses are user-supplied
+// and must mean the same account in every layer regardless of casing.
+export const stellarOperationPaysAddress = (
+  record: any,
+  address: string,
+): boolean => {
+  const recipient =
+    record?.type === 'payment'
+      ? record.to
+      : record?.type === 'create_account'
+        ? record.account
+        : undefined;
+  return (
+    typeof recipient === 'string' &&
+    recipient.toLowerCase() === address.toLowerCase()
+  );
+};
+
+// What this operation actually transferred on-chain: payments carry
+// `amount`, create_account carries `starting_balance`. An unknown operation
+// type (or a malformed record) yields NaN, which callers must treat as
+// "not a usable operation".
+export const stellarOperationAmount = (record: any): number =>
+  record?.type === 'create_account'
+    ? Number(record.starting_balance)
+    : Number(record?.amount);
+
+// The full "is this operation a usable XLM deposit to `address`" predicate:
+// the operation-type whitelist (native payments and create_account), the
+// recipient check, and a parseable amount, in one place — so the QR matcher
+// and donation verification can never disagree about which operations count.
+export const isNativeStellarDeposit = (record: any, address: string): boolean =>
+  (record?.type === 'payment'
+    ? record.asset_type === 'native'
+    : record?.type === 'create_account') &&
+  stellarOperationPaysAddress(record, address) &&
+  Number.isFinite(stellarOperationAmount(record));
+
+// The shared tie-breaking rule for which operation of one transaction a
+// donation refers to: the largest transferred amount. Callers layer their
+// own higher-priority keys on top (the QR matcher ranks successful
+// transactions first; verification prefers the amount closest to the
+// donation being verified).
+export const byLargestStellarOperation = (a: any, b: any): number =>
+  stellarOperationAmount(b) - stellarOperationAmount(a);

--- a/src/services/chains/stellar/transactionService.test.ts
+++ b/src/services/chains/stellar/transactionService.test.ts
@@ -1,0 +1,204 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { getStellarTransactionInfoFromNetwork } from './transactionService';
+import { ChainType } from '../../../types/network';
+import { NETWORK_IDS } from '../../../provider';
+import {
+  assertThrowsAsync,
+  generateRandomStellarAddress,
+  generateRandomStellarTxHash,
+  horizonPaymentRecord,
+  stubStellarHorizonPayments,
+} from '../../../../test/testUtils';
+
+describe(
+  'getStellarTransactionInfoFromNetwork test cases',
+  getStellarTransactionInfoFromNetworkTestCases,
+);
+
+function getStellarTransactionInfoFromNetworkTestCases() {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  function baseInput(overrides: Partial<any> = {}) {
+    return {
+      networkId: NETWORK_IDS.STELLAR_MAINNET,
+      chainType: ChainType.STELLAR,
+      symbol: 'XLM',
+      txHash: generateRandomStellarTxHash(),
+      fromAddress: generateRandomStellarAddress(),
+      toAddress: generateRandomStellarAddress(),
+      amount: 19.996,
+      timestamp: Math.floor(Date.now() / 1000),
+      ...overrides,
+    };
+  }
+
+  it('should validate a single-operation payment transaction (existing behavior)', async () => {
+    const input = baseInput();
+    stubStellarHorizonPayments([
+      horizonPaymentRecord({
+        txHash: input.txHash,
+        from: input.fromAddress,
+        to: input.toAddress,
+        amount: '19.9960000',
+      }),
+    ]);
+
+    const info = await getStellarTransactionInfoFromNetwork(input as any);
+    expect(info.to).to.equal(input.toAddress);
+    expect(info.amount).to.equal(19.996);
+  });
+
+  it('should pick the payment operation targeting the expected recipient in a multi-operation (exchange batch) transaction', async () => {
+    const input = baseInput();
+    stubStellarHorizonPayments([
+      // Another withdrawal in the same exchange batch, listed first
+      horizonPaymentRecord({
+        txHash: input.txHash,
+        from: input.fromAddress,
+        to: generateRandomStellarAddress(),
+        amount: '55.0000000',
+      }),
+      horizonPaymentRecord({
+        txHash: input.txHash,
+        from: input.fromAddress,
+        to: input.toAddress,
+        amount: '19.9960000',
+      }),
+    ]);
+
+    const info = await getStellarTransactionInfoFromNetwork(input as any);
+    expect(info.to).to.equal(input.toAddress);
+    expect(info.amount).to.equal(19.996);
+  });
+
+  it('should select the largest of several operations paying the same recipient, mirroring the QR matcher', async () => {
+    const input = baseInput();
+    stubStellarHorizonPayments([
+      // A smaller operation to the same recipient, listed first: the QR
+      // matcher credits the largest, so verification must resolve it too
+      horizonPaymentRecord({
+        txHash: input.txHash,
+        from: input.fromAddress,
+        to: input.toAddress,
+        amount: '0.1000000',
+      }),
+      horizonPaymentRecord({
+        txHash: input.txHash,
+        from: input.fromAddress,
+        to: input.toAddress,
+        amount: '19.9960000',
+      }),
+    ]);
+
+    const info = await getStellarTransactionInfoFromNetwork(input as any);
+    expect(info.to).to.equal(input.toAddress);
+    expect(info.amount).to.equal(19.996);
+  });
+
+  it('should prefer the operation matching the expected amount when a batch pays the recipient for two different donations', async () => {
+    // Two donors' withdrawals to the same project address in one exchange
+    // batch: this donation is the smaller op, so amount must outrank size
+    const input = baseInput({ amount: 5 });
+    stubStellarHorizonPayments([
+      horizonPaymentRecord({
+        txHash: input.txHash,
+        to: input.toAddress,
+        amount: '100.0000000',
+      }),
+      horizonPaymentRecord({
+        txHash: input.txHash,
+        from: input.fromAddress,
+        to: input.toAddress,
+        amount: '5.0000000',
+      }),
+    ]);
+
+    const info = await getStellarTransactionInfoFromNetwork(input as any);
+    expect(info.amount).to.equal(5);
+    expect(info.from).to.equal(input.fromAddress);
+  });
+
+  it('should break an equal-amount tie between operations by the expected sender', async () => {
+    // Two ops of the same amount to the same address, different senders;
+    // only the sender distinguishes which one this donation refers to
+    const input = baseInput({ amount: 5 });
+    stubStellarHorizonPayments([
+      horizonPaymentRecord({
+        txHash: input.txHash,
+        to: input.toAddress,
+        amount: '5.0000000',
+      }),
+      horizonPaymentRecord({
+        txHash: input.txHash,
+        from: input.fromAddress,
+        to: input.toAddress,
+        amount: '5.0000000',
+      }),
+    ]);
+
+    const info = await getStellarTransactionInfoFromNetwork(input as any);
+    expect(info.from).to.equal(input.fromAddress);
+    expect(info.amount).to.equal(5);
+  });
+
+  it('should reject a transaction much older than the donation (staleness check)', async () => {
+    const input = baseInput();
+    stubStellarHorizonPayments([
+      horizonPaymentRecord({
+        txHash: input.txHash,
+        from: input.fromAddress,
+        to: input.toAddress,
+        amount: '19.9960000',
+        createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
+      }),
+    ]);
+
+    await assertThrowsAsync(
+      () => getStellarTransactionInfoFromNetwork(input as any),
+      undefined,
+    );
+  });
+
+  it('should still reject a transaction none of whose operations pay the expected recipient', async () => {
+    const input = baseInput();
+    stubStellarHorizonPayments([
+      horizonPaymentRecord({
+        txHash: input.txHash,
+        from: input.fromAddress,
+        to: generateRandomStellarAddress(),
+        amount: '19.9960000',
+      }),
+    ]);
+
+    await assertThrowsAsync(
+      () => getStellarTransactionInfoFromNetwork(input as any),
+      undefined,
+    );
+  });
+
+  it('should select a create_account operation funding the expected recipient', async () => {
+    const input = baseInput({ amount: 100 });
+    stubStellarHorizonPayments([
+      horizonPaymentRecord({
+        txHash: input.txHash,
+        from: input.fromAddress,
+        to: generateRandomStellarAddress(),
+        amount: '55.0000000',
+      }),
+      horizonPaymentRecord({
+        type: 'create_account',
+        txHash: input.txHash,
+        from: input.fromAddress,
+        to: input.toAddress,
+        amount: '100.0000000',
+      }),
+    ]);
+
+    const info = await getStellarTransactionInfoFromNetwork(input as any);
+    expect(info.to).to.equal(input.toAddress);
+    expect(info.amount).to.equal(100);
+  });
+}

--- a/src/services/chains/stellar/transactionService.test.ts
+++ b/src/services/chains/stellar/transactionService.test.ts
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { getStellarTransactionInfoFromNetwork } from './transactionService';
 import { ChainType } from '../../../types/network';
 import { NETWORK_IDS } from '../../../provider';
+import { errorMessages } from '../../../utils/errorMessages';
 import {
   assertThrowsAsync,
   generateRandomStellarAddress,
@@ -158,7 +159,7 @@ function getStellarTransactionInfoFromNetworkTestCases() {
 
     await assertThrowsAsync(
       () => getStellarTransactionInfoFromNetwork(input as any),
-      undefined,
+      errorMessages.TRANSACTION_CANT_BE_OLDER_THAN_DONATION,
     );
   });
 
@@ -175,7 +176,7 @@ function getStellarTransactionInfoFromNetworkTestCases() {
 
     await assertThrowsAsync(
       () => getStellarTransactionInfoFromNetwork(input as any),
-      undefined,
+      errorMessages.TRANSACTION_TO_ADDRESS_IS_DIFFERENT_FROM_SENT_TO_ADDRESS,
     );
   });
 

--- a/src/services/chains/stellar/transactionService.ts
+++ b/src/services/chains/stellar/transactionService.ts
@@ -8,12 +8,20 @@ import {
   i18n,
   translationErrorMessagesKeys,
 } from '../../../utils/errorMessages';
+import {
+  byLargestStellarOperation,
+  isNativeStellarDeposit,
+  stellarOperationAmount,
+} from './stellarOperations';
 
 const STELLAR_HORIZON_API_URL =
   process.env.STELLAR_HORIZON_API_URL || 'https://horizon.stellar.org';
 
 const getStellarTransactionInfo = async (
   txHash: string,
+  toAddress: string,
+  expectedAmount: number,
+  expectedFromAddress: string,
 ): Promise<NetworkTransactionInfo | null> => {
   const NATIVE_STELLAR_ASSET_CODE = 'XLM';
   // Fetch transaction info from stellar network
@@ -22,29 +30,58 @@ const getStellarTransactionInfo = async (
     `${STELLAR_HORIZON_API_URL}/transactions/${txHash}/payments`,
   );
 
-  const transaction = response.data._embedded.records[0];
+  const records = response.data._embedded.records || [];
+
+  // A Stellar transaction can carry multiple payment operations (exchanges
+  // batch several withdrawals into one transaction, and one batch can even
+  // pay the same address for two different donations), so pick the operation
+  // this donation refers to rather than blindly taking the first record:
+  // closest to the donation's amount, then the donation's own sender, then
+  // the largest (the QR matcher's rule for which operation a donation
+  // records). When none pays the recipient, fall back to the first record so
+  // the validation below still reports the same to-address mismatch as
+  // before for transactions that don't pay this address at all.
+  const expectedFrom = expectedFromAddress?.toLowerCase();
+  const operationSender = (record: any): string | undefined =>
+    (record.from ?? record.source_account)?.toLowerCase();
+  const payingOps: any[] = records.filter((record: any) =>
+    isNativeStellarDeposit(record, toAddress),
+  );
+  const transaction =
+    payingOps.sort(
+      (a: any, b: any) =>
+        Math.abs(stellarOperationAmount(a) - expectedAmount) -
+          Math.abs(stellarOperationAmount(b) - expectedAmount) ||
+        Number(operationSender(b) === expectedFrom) -
+          Number(operationSender(a) === expectedFrom) ||
+        byLargestStellarOperation(a, b),
+    )[0] ?? records[0];
 
   if (!transaction) return null;
+
+  // Horizon's created_at is an ISO string; NetworkTransactionInfo carries
+  // epoch seconds (the staleness validation subtracts timestamps).
+  const timestampSecs = new Date(transaction.created_at).getTime() / 1000;
 
   // when a transaction is made to a newly created account, Stellar mark it as type 'create_account'
   if (transaction.type === 'create_account') {
     return {
       hash: transaction.transaction_hash,
-      amount: Number(transaction.starting_balance),
+      amount: stellarOperationAmount(transaction),
       from: transaction.source_account,
       to: transaction.account,
       currency: NATIVE_STELLAR_ASSET_CODE,
-      timestamp: transaction.created_at,
+      timestamp: timestampSecs,
     };
   } else if (transaction.type === 'payment') {
     if (transaction.asset_type !== 'native') return null;
     return {
       hash: transaction.transaction_hash,
-      amount: Number(transaction.amount),
+      amount: stellarOperationAmount(transaction),
       from: transaction.from,
       to: transaction.to,
       currency: NATIVE_STELLAR_ASSET_CODE,
-      timestamp: transaction.created_at,
+      timestamp: timestampSecs,
     };
   } else return null;
 };
@@ -52,7 +89,12 @@ const getStellarTransactionInfo = async (
 export async function getStellarTransactionInfoFromNetwork(
   input: TransactionDetailInput,
 ): Promise<NetworkTransactionInfo> {
-  const txData = await getStellarTransactionInfo(input.txHash);
+  const txData = await getStellarTransactionInfo(
+    input.txHash,
+    input.toAddress,
+    input.amount,
+    input.fromAddress,
+  );
   if (!txData) {
     throw new Error(
       i18n.__(translationErrorMessagesKeys.TRANSACTION_NOT_FOUND),

--- a/src/services/cronJobs/checkQRTransactionJob.ts
+++ b/src/services/cronJobs/checkQRTransactionJob.ts
@@ -29,6 +29,10 @@ import { QfRound } from '../../entities/qfRound';
 import { syncDonationStatusWithBlockchainNetwork } from '../donationService';
 import { notifyClients } from '../sse/sse';
 import { calculateGivbackFactor } from '../givbackService';
+import {
+  isNativeStellarDeposit,
+  stellarOperationAmount,
+} from '../chains/stellar/stellarOperations';
 
 const STELLAR_HORIZON_API =
   (config.get('STELLAR_HORIZON_API_URL') as string) ||
@@ -67,12 +71,31 @@ export const DRAFT_DONATION_EXPIRY_GRACE_MS = 60 * 1000;
 // its expiry, so a payment Horizon indexed late (after the frontend timed
 // the draft out via markDraftDonationAsFailed) can still be reconciled to
 // matched. Bounded so failed drafts are not Horizon-scanned forever.
+// NOTE: the CASE 1 payment-acceptance window below is derived from this
+// value — tuning this constant changes both scanning cost and which late
+// payments are accepted.
 export const QR_FAILED_DRAFT_RECONCILIATION_WINDOW_MS = 30 * 60 * 1000;
+// How long after expiry (plus grace) a memo-identified (CASE 1, see
+// checkTransactions) payment is still accepted. Deliberately the same span
+// as the reconciliation window: the cron stops scanning a draft when that
+// window closes, so a longer acceptance window would be unreachable there —
+// but verifyQRDonationTransaction has no scannability filter, so this bound
+// is what limits late matches on the user-triggered verify path.
+export const QR_LATE_PAYMENT_ACCEPTANCE_WINDOW_MS =
+  QR_FAILED_DRAFT_RECONCILIATION_WINDOW_MS;
 // How long a matcher waits for another execution's per-draft or per-tx lock,
 // and the cap on any single Horizon request. Bounded so a hung execution can
 // only delay a draft, never pin connections or wedge the cron indefinitely.
 const QR_DRAFT_LOCK_WAIT_MS = 30 * 1000;
 const HORIZON_REQUEST_TIMEOUT_MS = 30 * 1000;
+
+// DraftDonation.amount and Donation.amount are Postgres `real` (float4)
+// columns, so an amount with more than float4's ~7 significant digits reads
+// back as a slightly different double than the exact on-chain value. Compare
+// amounts at float4 precision so a donor's exact payment still matches such
+// a draft.
+const amountsMatchAtFloat4Precision = (a: number, b: number): boolean =>
+  Math.fround(a) === Math.fround(b);
 
 // Only the cron waits for a contended lock: it is a single sequential runner,
 // and waiting lets it finish a draft this tick. The public
@@ -414,6 +437,45 @@ export async function checkTransactions(
     const CLOCK_SKEW = 60 * 1000;
     const draftCreatedAt = new Date(donation.createdAt).getTime();
 
+    // Two matching regimes, depending on whether the recipient address
+    // requires its own memo (toWalletMemo). This block is the single source
+    // of truth for the regime; the identification pass, the candidate
+    // ordering, and the under-lock re-check below all point back here.
+    // - CASE 1 (no recipient memo): the Stellar memo carries this draft's
+    //   unique id, so memo + destination identify the payment — for every
+    //   operation type, create_account included. The amount is whatever
+    //   actually arrived (exchanges like Binance deduct their withdrawal fee
+    //   before broadcasting), and because the memo identifies the draft, a
+    //   payment broadcast after expiry stays acceptable for
+    //   QR_LATE_PAYMENT_ACCEPTANCE_WINDOW_MS.
+    // - CASE 2 (recipient requires its own memo): several drafts to the same
+    //   project can share destination and memo, so the draft amount remains
+    //   the only disambiguator (compared at float4 precision, the column
+    //   type) and the validity window stays tight: without a unique
+    //   identifier a late payment must not be guessed at. create_account has
+    //   no memo to distinguish it with, so it keeps amount-only matching.
+    // Known limitation, accepted with issue #2347: CASE 1 deliberately has
+    // no amount condition — an exact, tolerance or minimum-amount rule would
+    // reject legitimately fee-reduced payments. Because the memo is the
+    // draft's sequential id (public via the QR and enumerable), a third
+    // party can send a dust payment carrying a pending draft's memo. The
+    // candidate ordering below picks the real payment whenever both are on
+    // the Horizon page, but a dust payment scanned on a tick before the real
+    // one exists still claims the draft, and the real payment then needs
+    // manual reconciliation. Fully closing this needs a product change — an
+    // unguessable memo token instead of the draft id, or crediting every
+    // memo-matching payment — not a matching-rule tweak.
+    // Known limitation (pre-existing): donations are keyed by transaction
+    // hash, so one exchange batch transaction carrying payments for TWO
+    // CASE 2 drafts (same address and memo, different amounts) can only ever
+    // credit one of them — the second draft skips the already-claimed hash
+    // until it fails at expiry. Crediting both needs per-(hash, operation)
+    // donation keying, a schema/product decision.
+    const requiresRecipientMemo = Boolean(toWalletMemo);
+    const paymentWindowEndMs = requiresRecipientMemo
+      ? expiresAtDate
+      : expiresAtDate + QR_LATE_PAYMENT_ACCEPTANCE_WINDOW_MS;
+
     // Prepared at most once per draft (it depends only on the draft), so a
     // payment that turns out to belong to another draft does not repeat the
     // Coingecko price call and the token/project/user/QF-round queries.
@@ -423,267 +485,314 @@ export async function checkTransactions(
     // failed insert). Scanning stops for this tick; see the handling below.
     let abortReason: string | undefined;
 
+    // First pass — identification only, pure and in-memory: which operations
+    // on the page belong to this draft at all (operation shape, destination,
+    // validity window, memo). The matching flow below then runs over these
+    // candidates only.
+    const candidates: { transaction: any; opAmount: number }[] = [];
     for (const transaction of transactions) {
       const transactionCreatedAt = new Date(transaction.created_at).getTime();
+      // What this operation transferred on-chain — the one number the amount
+      // check, the ranking, and the recorded donation amount all judge.
+      // (isNativeStellarDeposit guarantees it is finite for candidates.)
+      const opAmount = stellarOperationAmount(transaction);
 
-      const isNativePayment =
-        transaction.asset_type === 'native' &&
-        transaction.type === 'payment' &&
-        transaction.to === toWalletAddress &&
-        Number(transaction.amount) === amount;
+      // CASE 1 waives the amount for every operation type (identification is
+      // the memo check below); CASE 2 requires the draft amount.
+      const amountMatches =
+        !requiresRecipientMemo ||
+        amountsMatchAtFloat4Precision(opAmount, amount);
 
-      const isCreateAccount =
-        transaction.type === 'create_account' &&
-        transaction.account === toWalletAddress &&
-        Number(transaction.starting_balance) === amount;
-
-      // The payment must fall inside the draft's validity window: not before
-      // creation (minus clock skew) and not after expiry (plus the same grace
-      // minute the expiry check uses).
+      // Validity window: not before creation (minus clock skew) and not
+      // after the case-dependent end (see paymentWindowEndMs above).
       const isMatchingTransaction =
-        (isNativePayment || isCreateAccount) &&
+        isNativeStellarDeposit(transaction, toWalletAddress) &&
+        amountMatches &&
         transactionCreatedAt >= draftCreatedAt - CLOCK_SKEW &&
-        transactionCreatedAt <= expiresAtDate;
+        transactionCreatedAt <= paymentWindowEndMs;
 
-      if (isMatchingTransaction) {
-        const memo = transaction.transaction.memo;
+      if (!isMatchingTransaction) continue;
 
-        if (transaction.type === 'payment') {
-          if (toWalletMemo) {
-            if (memo !== toWalletMemo) {
-              logger.debug(
-                `Transaction memo does not match donation memo for donation ID ${donation.id}`,
-              );
-              // Skip this payment and keep scanning: another donation to the
-              // same address may carry a different memo. Bailing here (return)
-              // would abandon the search before reaching this donation's payment.
-              continue;
-            }
-          } else if (memo !== id.toString()) {
-            logger.debug(
-              `Transaction memo does not match draft id for donation ID ${donation.id}`,
-            );
-            continue;
-          }
-        }
-
-        const txHash = transaction.transaction_hash?.toLowerCase();
-        if (!txHash) {
-          // A payment without a transaction hash can neither be deduplicated
-          // nor recorded as a donation. Skip it and keep scanning, so other
-          // payments and the expiry handling below stay reachable.
+      const memo = transaction.transaction?.memo;
+      if (requiresRecipientMemo) {
+        // CASE 2: payments must carry the recipient's own memo
+        // (create_account has none to check — see the regime notes above).
+        if (transaction.type === 'payment' && memo !== toWalletMemo) {
           logger.debug(
-            `Skipping payment without transaction hash for draft donation ID ${donation.id}`,
+            `Transaction memo does not match donation memo for donation ID ${donation.id}`,
           );
           continue;
         }
-        let createdDonationId: number | undefined;
-        // What this payment amounted to for this draft:
-        // - created: a donation was created and the draft updated — stop
-        //   scanning and run the post-creation side effects.
-        // - settled: the draft already references a live donation (or a
-        //   concurrent execution matched it) — nothing left to do.
-        // - skip: this payment cannot serve this draft (it belongs to
-        //   another draft, or its donation mismatches) — keep scanning older
-        //   payments and leave the expiry handling below reachable.
-        // - abort: environmental or lock failure (missing token/project,
-        //   lock wait timeout, donation insert failure) — stop scanning
-        //   without failing the draft; the next tick retries from scratch.
-        // (an object property, not a let, so TypeScript doesn't narrow the
-        // value across the lock closure that mutates it)
-        const matchOutcome: {
-          verdict: 'created' | 'settled' | 'skip' | 'abort';
-        } = { verdict: 'abort' };
+      } else if (memo !== id.toString()) {
+        // CASE 1: every operation type must name this very draft — including
+        // create_account, which historically matched on exact amount with no
+        // memo at all. That memo-less acceptance path was removed with issue
+        // #2347 (once the amount condition is waived, a memo-less rule would
+        // accept any deposit): a donor funding a fresh address without a
+        // memo now needs manual reconciliation. Not logged: with no amount
+        // prefilter, every other payment on a shared address takes this
+        // branch on every tick — expected, not an event.
+        continue;
+      }
 
-        // Slow externals run before the locks so the critical section is
-        // only the existence re-checks and the insert itself. This unlocked
-        // existing-donation pre-check merely skips the preparation when the
-        // donation obviously exists already; the authoritative check runs
-        // under the locks below.
-        let creationContext: QrDonationCreationContext | null = null;
-        if (!(await findDonationsByTransactionId(txHash))) {
-          if (!preparedContext) {
-            preparedContext = await prepareQrDonationCreationContext(donation);
-          }
-          creationContext = preparedContext;
-          // Missing token/project configuration: nothing can be created this
-          // tick, and the draft must not be failed on that evidence alone.
-          if (!creationContext) {
-            abortReason =
-              'QR donation configuration unavailable (missing token or project)';
-            break;
-          }
+      // A record without a transaction hash can neither be deduplicated nor
+      // recorded as a donation.
+      if (!transaction.transaction_hash) {
+        logger.debug(
+          `Skipping malformed payment record for draft donation ID ${donation.id}`,
+        );
+        continue;
+      }
+
+      candidates.push({ transaction, opAmount });
+    }
+
+    // Several payments can identify the same draft — in CASE 1 anyone can
+    // send a payment carrying its memo — so order the attempts: successful
+    // transactions before failed ones (a donor's failed full-amount attempt
+    // must not outrank their successful retry), then by on-chain amount,
+    // largest first, so a dust payment cannot outrank the real one when both
+    // are already on the page (see the limitation note above). Ordering
+    // never rejects a payment; ties keep Horizon's newest-first order
+    // (Array.prototype.sort is stable), so CASE 2 — where every candidate
+    // equals the draft amount — behaves as before.
+    candidates.sort(
+      (a, b) =>
+        Number(Boolean(b.transaction.transaction_successful)) -
+          Number(Boolean(a.transaction.transaction_successful)) ||
+        b.opAmount - a.opAmount,
+    );
+
+    // One attempt per transaction: sibling operations of a multi-op tx share
+    // the hash, and the match verdict depends only on the hash, so only the
+    // best-ranked operation per transaction is worth the lock cycle.
+    const seenTxHashes = new Set<string>();
+    const rankedCandidates = candidates.filter(candidate => {
+      const hash = candidate.transaction.transaction_hash.toLowerCase();
+      if (seenTxHashes.has(hash)) return false;
+      seenTxHashes.add(hash);
+      return true;
+    });
+
+    // The donation records what the matched operation actually transferred
+    // (opAmount), not the draft's requested amount (see the CASE 1 notes).
+    for (const {
+      transaction,
+      opAmount: actualOnChainAmount,
+    } of rankedCandidates) {
+      const txHash = transaction.transaction_hash.toLowerCase();
+      let createdDonationId: number | undefined;
+      // What this payment amounted to for this draft:
+      // - created: a donation was created and the draft updated — stop
+      //   scanning and run the post-creation side effects.
+      // - settled: the draft already references a live donation (or a
+      //   concurrent execution matched it) — nothing left to do.
+      // - skip: this payment cannot serve this draft (it belongs to
+      //   another draft, or its donation mismatches) — keep trying the
+      //   remaining candidates and leave the expiry handling below reachable.
+      // - abort: environmental or lock failure (missing token/project,
+      //   lock wait timeout, donation insert failure) — stop scanning
+      //   without failing the draft; the next tick retries from scratch.
+      // (an object property, not a let, so TypeScript doesn't narrow the
+      // value across the lock closure that mutates it)
+      const matchOutcome: {
+        verdict: 'created' | 'settled' | 'skip' | 'abort';
+      } = { verdict: 'abort' };
+
+      // Slow externals run before the locks so the critical section is
+      // only the existence re-checks and the insert itself. This unlocked
+      // existing-donation pre-check merely skips the preparation when the
+      // donation obviously exists already; the authoritative check runs
+      // under the locks below.
+      let creationContext: QrDonationCreationContext | null = null;
+      if (!(await findDonationsByTransactionId(txHash))) {
+        if (!preparedContext) {
+          preparedContext = await prepareQrDonationCreationContext(donation);
         }
+        creationContext = preparedContext;
+        // Missing token/project configuration: nothing can be created this
+        // tick, and the draft must not be failed on that evidence alone.
+        if (!creationContext) {
+          abortReason =
+            'QR donation configuration unavailable (missing token or project)';
+          break;
+        }
+      }
 
-        const matchUnderLocks = async () => {
-          // Re-check under the locks: another execution may have already
-          // created the donation for this transaction. Reconcile the draft
-          // with it only when the donation is positively this draft's: other
-          // pending drafts to the same project can share address, memo and
-          // amount, and a donation already claimed by another draft must not
-          // be claimed here too.
-          const existingDonation = await findDonationsByTransactionId(txHash);
-          if (existingDonation) {
-            const claimingDraft = await findDraftDonationByMatchedDonationId(
-              existingDonation.id,
-            );
-            if (
-              (claimingDraft && claimingDraft.id !== donation.id) ||
-              existingDonation.toWalletAddress !== donation.toWalletAddress ||
-              Number(existingDonation.amount) !== amount
-            ) {
-              // This payment is spoken for by another draft; an older
-              // payment further down the list may still be this draft's own.
-              matchOutcome.verdict = 'skip';
-              return;
-            }
-            const liveDonation = await reconcileDraftWithMatchedDonation(
-              donation,
-              source,
-              { donation: existingDonation, linkFailedDonation: true },
-            );
-            // When the linked donation failed on-chain, keep scanning: the
-            // donor may have retried with another payment.
-            matchOutcome.verdict = liveDonation ? 'settled' : 'skip';
+      const matchUnderLocks = async () => {
+        // Re-check under the locks: another execution may have already
+        // created the donation for this transaction. Reconcile the draft
+        // with it only when the donation is positively this draft's: a
+        // donation already claimed by another draft must not be claimed
+        // here too, and for CASE 2 the amount must also match, mirroring
+        // the identification pass (see the CASE 1/CASE 2 notes above).
+        const existingDonation = await findDonationsByTransactionId(txHash);
+        if (existingDonation) {
+          const claimingDraft = await findDraftDonationByMatchedDonationId(
+            existingDonation.id,
+          );
+          if (
+            (claimingDraft && claimingDraft.id !== donation.id) ||
+            existingDonation.toWalletAddress !== donation.toWalletAddress ||
+            (requiresRecipientMemo &&
+              !amountsMatchAtFloat4Precision(
+                Number(existingDonation.amount),
+                amount,
+              ))
+          ) {
+            // This payment is spoken for by another draft; another
+            // candidate further down the list may still be this draft's own.
+            matchOutcome.verdict = 'skip';
             return;
           }
+          const liveDonation = await reconcileDraftWithMatchedDonation(
+            donation,
+            source,
+            { donation: existingDonation, linkFailedDonation: true },
+          );
+          // When the linked donation failed on-chain, keep scanning: the
+          // donor may have retried with another payment.
+          matchOutcome.verdict = liveDonation ? 'settled' : 'skip';
+          return;
+        }
 
-          // Re-read the draft under the lock; the in-memory entity may be
-          // stale if another execution matched it meanwhile. A draft linked
-          // to a failed donation may still be re-matched by a retry payment.
-          const freshDraft = await DraftDonation.findOne({
-            where: { id: donation.id },
-          });
+        // Re-read the draft under the lock; the in-memory entity may be
+        // stale if another execution matched it meanwhile. A draft linked
+        // to a failed donation may still be re-matched by a retry payment.
+        const freshDraft = await DraftDonation.findOne({
+          where: { id: donation.id },
+        });
+        if (
+          !freshDraft ||
+          freshDraft.status === DRAFT_DONATION_STATUS.MATCHED
+        ) {
+          matchOutcome.verdict = 'settled';
+          return;
+        }
+        if (freshDraft.matchedDonationId) {
+          const linkedDonation = await findDonationById(
+            freshDraft.matchedDonationId,
+          );
           if (
-            !freshDraft ||
-            freshDraft.status === DRAFT_DONATION_STATUS.MATCHED
+            linkedDonation &&
+            linkedDonation.status !== DONATION_STATUS.FAILED
           ) {
             matchOutcome.verdict = 'settled';
             return;
           }
-          if (freshDraft.matchedDonationId) {
-            const linkedDonation = await findDonationById(
-              freshDraft.matchedDonationId,
-            );
-            if (
-              linkedDonation &&
-              linkedDonation.status !== DONATION_STATUS.FAILED
-            ) {
-              matchOutcome.verdict = 'settled';
-              return;
-            }
-          }
+        }
 
-          if (!creationContext) {
-            // The unlocked pre-check saw a donation for this hash, but it is
-            // gone now and nothing was prepared to create one. Leave the
-            // 'abort' verdict: the next tick retries with a clean view.
-            return;
-          }
+        if (!creationContext) {
+          // The unlocked pre-check saw a donation for this hash, but it is
+          // gone now and nothing was prepared to create one. Leave the
+          // 'abort' verdict: the next tick retries with a clean view.
+          return;
+        }
 
-          const returnedDonation = await createDonation({
-            amount: donation.amount,
-            project: creationContext.project,
-            transactionNetworkId: donation.networkId,
-            fromWalletAddress: transaction.source_account,
-            transactionId: transaction.transaction_hash,
-            tokenAddress: donation.tokenAddress,
-            isProjectGivbackEligible: creationContext.project.isGivbackEligible,
-            donorUser: creationContext.donor,
-            isTokenEligibleForGivback: creationContext.token.isGivbackEligible,
-            segmentNotified: false,
-            toWalletAddress: donation.toWalletAddress,
-            donationAnonymous: false,
-            transakId: '',
-            token: donation.currency,
-            valueUsd: donation.amount * creationContext.tokenPrice,
-            priceUsd: creationContext.tokenPrice,
-            status: transaction.transaction_successful ? 'verified' : 'failed',
-            isQRDonation: true,
-            toWalletMemo,
-            qfRound: creationContext.qfRound,
-            chainType: creationContext.token.chainType,
-            givbackFactor: creationContext.givbackFactor,
-            projectRank: creationContext.projectRank,
-            bottomRankInRound: creationContext.bottomRankInRound,
-            powerRound: creationContext.powerRound,
-          });
+        const returnedDonation = await createDonation({
+          amount: actualOnChainAmount,
+          project: creationContext.project,
+          transactionNetworkId: donation.networkId,
+          fromWalletAddress: transaction.source_account,
+          transactionId: transaction.transaction_hash,
+          tokenAddress: donation.tokenAddress,
+          isProjectGivbackEligible: creationContext.project.isGivbackEligible,
+          donorUser: creationContext.donor,
+          isTokenEligibleForGivback: creationContext.token.isGivbackEligible,
+          segmentNotified: false,
+          toWalletAddress: donation.toWalletAddress,
+          donationAnonymous: false,
+          transakId: '',
+          token: donation.currency,
+          valueUsd: actualOnChainAmount * creationContext.tokenPrice,
+          priceUsd: creationContext.tokenPrice,
+          status: transaction.transaction_successful ? 'verified' : 'failed',
+          isQRDonation: true,
+          toWalletMemo,
+          qfRound: creationContext.qfRound,
+          chainType: creationContext.token.chainType,
+          givbackFactor: creationContext.givbackFactor,
+          projectRank: creationContext.projectRank,
+          bottomRankInRound: creationContext.bottomRankInRound,
+          powerRound: creationContext.powerRound,
+        });
 
-          if (!returnedDonation) {
-            // info, not debug: a real payment matched this draft but no
-            // donation row could be created — that needs eyes in production.
-            logger.info(
-              `Error creating donation for draft donation ID ${donation.id}`,
-            );
-            return;
-          }
+        if (!returnedDonation) {
+          // info, not debug: a real payment matched this draft but no
+          // donation row could be created — that needs eyes in production.
+          logger.info(
+            `Error creating donation for draft donation ID ${donation.id}`,
+          );
+          return;
+        }
 
-          // Update draft donation status to matched and add matched donation ID with source address
-          await updateDraftDonationStatus({
-            donationId: donation.id,
-            status: transaction.transaction_successful
-              ? DRAFT_DONATION_STATUS.MATCHED
-              : DRAFT_DONATION_STATUS.FAILED,
-            fromWalletAddress: transaction.source_account,
-            matchedDonationId: returnedDonation.id,
-            txHash,
-            source,
-          });
+        // Update draft donation status to matched and add matched donation ID with source address
+        await updateDraftDonationStatus({
+          donationId: donation.id,
+          status: transaction.transaction_successful
+            ? DRAFT_DONATION_STATUS.MATCHED
+            : DRAFT_DONATION_STATUS.FAILED,
+          fromWalletAddress: transaction.source_account,
+          matchedDonationId: returnedDonation.id,
+          txHash,
+          source,
+        });
 
-          createdDonationId = returnedDonation.id;
-          matchOutcome.verdict = 'created';
-        };
+        createdDonationId = returnedDonation.id;
+        matchOutcome.verdict = 'created';
+      };
 
-        // Serialize the match across processes at two levels, acquired in a
-        // single lock transaction, always in this order (tx first, then
-        // draft — a fixed order plus bounded try-lock polling means no
-        // deadlock):
-        // - per transaction: two different drafts sharing address, memo and
-        //   amount must not both turn this payment into a donation;
-        // - per draft: overlapping cron runs and concurrent GraphQL
-        //   verifications must not match this draft twice.
-        await withQrXactLocks(
-          [
-            {
-              namespace: QR_TX_LOCK_NAMESPACE,
-              lockId: txHashToLockId(txHash),
-            },
-            {
-              namespace: QR_DRAFT_DONATION_LOCK_NAMESPACE,
-              lockId: donation.id,
-            },
-          ],
-          lockWaitMsForSource(source),
-          matchUnderLocks,
-        );
+      // Serialize the match across processes at two levels, acquired in a
+      // single lock transaction, always in this order (tx first, then
+      // draft — a fixed order plus bounded try-lock polling means no
+      // deadlock):
+      // - per transaction: two different drafts sharing address, memo and
+      //   amount must not both turn this payment into a donation;
+      // - per draft: overlapping cron runs and concurrent GraphQL
+      //   verifications must not match this draft twice.
+      await withQrXactLocks(
+        [
+          {
+            namespace: QR_TX_LOCK_NAMESPACE,
+            lockId: txHashToLockId(txHash),
+          },
+          {
+            namespace: QR_DRAFT_DONATION_LOCK_NAMESPACE,
+            lockId: donation.id,
+          },
+        ],
+        lockWaitMsForSource(source),
+        matchUnderLocks,
+      );
 
-        // Outside the advisory locks: slow external calls that don't touch
-        // lock-protected draft state must not extend the lock hold time.
-        if (createdDonationId) {
-          await syncDonationStatusWithBlockchainNetwork({
+      // Outside the advisory locks: slow external calls that don't touch
+      // lock-protected draft state must not extend the lock hold time.
+      if (createdDonationId) {
+        // Notify clients first: the donor's QR screen is waiting for this
+        // event, it needs nothing from the sync below, and the sync can take
+        // seconds (Horizon fetch, statistics, materialized-view refresh).
+        notifyClients({
+          type: 'new-donation',
+          data: {
             donationId: createdDonationId,
-          });
+            draftDonationId: donation.id,
+          },
+        });
 
-          // Notify clients of new donation
-          notifyClients({
-            type: 'new-donation',
-            data: {
-              donationId: createdDonationId,
-              draftDonationId: donation.id,
-            },
-          });
-        }
-
-        // Only 'skip' keeps scanning older payments (and leaves the expiry
-        // handling below reachable): 'created' and 'settled' mean the draft
-        // is resolved, 'abort' means the environment must recover before
-        // anything is decided — see the abort handling below.
-        if (matchOutcome.verdict === 'abort') {
-          abortReason = 'no donation could be created for the matched payment';
-          break;
-        }
-        if (matchOutcome.verdict !== 'skip') return;
+        await syncDonationStatusWithBlockchainNetwork({
+          donationId: createdDonationId,
+        });
       }
+
+      // Only 'skip' keeps trying remaining candidates (and leaves the expiry
+      // handling below reachable): 'created' and 'settled' mean the draft
+      // is resolved, 'abort' means the environment must recover before
+      // anything is decided — see the abort handling below.
+      if (matchOutcome.verdict === 'abort') {
+        abortReason = 'no donation could be created for the matched payment';
+        break;
+      }
+      if (matchOutcome.verdict !== 'skip') return;
     }
 
     if (abortReason) {

--- a/src/services/cronJobs/checkQRTransactionJob.ts
+++ b/src/services/cronJobs/checkQRTransactionJob.ts
@@ -75,12 +75,12 @@ export const DRAFT_DONATION_EXPIRY_GRACE_MS = 60 * 1000;
 // value — tuning this constant changes both scanning cost and which late
 // payments are accepted.
 export const QR_FAILED_DRAFT_RECONCILIATION_WINDOW_MS = 30 * 60 * 1000;
-// How long after expiry (plus grace) a memo-identified (CASE 1, see
-// checkTransactions) payment is still accepted. Deliberately the same span
-// as the reconciliation window: the cron stops scanning a draft when that
-// window closes, so a longer acceptance window would be unreachable there —
-// but verifyQRDonationTransaction has no scannability filter, so this bound
-// is what limits late matches on the user-triggered verify path.
+// How long after expiry a memo-identified (CASE 1, see checkTransactions)
+// payment is still accepted. Deliberately the same span AND the same base
+// (raw expiresAt, no grace term) as the reconciliation window, so a payment
+// is acceptable exactly as long as the cron still scans the draft.
+// verifyQRDonationTransaction has no scannability filter, so on that path
+// this bound alone limits late matches.
 export const QR_LATE_PAYMENT_ACCEPTANCE_WINDOW_MS =
   QR_FAILED_DRAFT_RECONCILIATION_WINDOW_MS;
 // How long a matcher waits for another execution's per-draft or per-tx lock,
@@ -96,6 +96,15 @@ const HORIZON_REQUEST_TIMEOUT_MS = 30 * 1000;
 // a draft.
 const amountsMatchAtFloat4Precision = (a: number, b: number): boolean =>
   Math.fround(a) === Math.fround(b);
+
+// A CASE 1 (memo-identified) payment must carry at least this fraction of
+// the draft amount. Exchange withdrawal fees only ever reduce the amount,
+// and by tiny fractions (Binance's XLM fee is ~0.002 XLM: 19.996/20 =
+// 0.9998), so this one-sided floor accepts every fee-reduced payment with
+// orders of magnitude of headroom while rejecting dust sent with a guessed
+// draft-id memo to claim someone else's pending draft. Deliberately no
+// upper bound: an overpayment is still the donor's payment.
+export const QR_CASE1_MIN_AMOUNT_FACTOR = 0.9;
 
 // Only the cron waits for a contended lock: it is a single sequential runner,
 // and waiting lets it finish a draft this tick. The public
@@ -443,28 +452,24 @@ export async function checkTransactions(
     // ordering, and the under-lock re-check below all point back here.
     // - CASE 1 (no recipient memo): the Stellar memo carries this draft's
     //   unique id, so memo + destination identify the payment — for every
-    //   operation type, create_account included. The amount is whatever
-    //   actually arrived (exchanges like Binance deduct their withdrawal fee
-    //   before broadcasting), and because the memo identifies the draft, a
-    //   payment broadcast after expiry stays acceptable for
-    //   QR_LATE_PAYMENT_ACCEPTANCE_WINDOW_MS.
+    //   operation type, create_account included. The amount only needs to
+    //   clear QR_CASE1_MIN_AMOUNT_FACTOR of the draft: exchanges deduct
+    //   tiny withdrawal fees before broadcasting, and the one-sided floor
+    //   accepts every fee-reduced payment while rejecting dust carrying a
+    //   guessed draft-id memo (the id is sequential and printed in the QR).
+    //   Because the memo identifies the draft, a payment broadcast after
+    //   expiry stays acceptable for QR_LATE_PAYMENT_ACCEPTANCE_WINDOW_MS.
+    //   Additionally, a create_account funding with the float4-exact draft
+    //   amount inside the normal validity window is accepted without a memo
+    //   — the pre-#2347 behavior some wallets rely on (no memo field on
+    //   account funding), safe to keep because it demands the exact amount
+    //   and the tight window.
     // - CASE 2 (recipient requires its own memo): several drafts to the same
     //   project can share destination and memo, so the draft amount remains
     //   the only disambiguator (compared at float4 precision, the column
     //   type) and the validity window stays tight: without a unique
     //   identifier a late payment must not be guessed at. create_account has
     //   no memo to distinguish it with, so it keeps amount-only matching.
-    // Known limitation, accepted with issue #2347: CASE 1 deliberately has
-    // no amount condition — an exact, tolerance or minimum-amount rule would
-    // reject legitimately fee-reduced payments. Because the memo is the
-    // draft's sequential id (public via the QR and enumerable), a third
-    // party can send a dust payment carrying a pending draft's memo. The
-    // candidate ordering below picks the real payment whenever both are on
-    // the Horizon page, but a dust payment scanned on a tick before the real
-    // one exists still claims the draft, and the real payment then needs
-    // manual reconciliation. Fully closing this needs a product change — an
-    // unguessable memo token instead of the draft id, or crediting every
-    // memo-matching payment — not a matching-rule tweak.
     // Known limitation (pre-existing): donations are keyed by transaction
     // hash, so one exchange batch transaction carrying payments for TWO
     // CASE 2 drafts (same address and memo, different amounts) can only ever
@@ -472,9 +477,12 @@ export async function checkTransactions(
     // until it fails at expiry. Crediting both needs per-(hash, operation)
     // donation keying, a schema/product decision.
     const requiresRecipientMemo = Boolean(toWalletMemo);
-    const paymentWindowEndMs = requiresRecipientMemo
-      ? expiresAtDate
-      : expiresAtDate + QR_LATE_PAYMENT_ACCEPTANCE_WINDOW_MS;
+    // CASE 1's extended acceptance window shares the reconciliation window's
+    // base (raw expiresAt, no grace term), so it ends exactly when the cron
+    // stops scanning the draft — see getScannableDraftDonations.
+    const caseOneWindowEndMs =
+      (expiresAt ? new Date(expiresAt).getTime() : 0) +
+      QR_LATE_PAYMENT_ACCEPTANCE_WINDOW_MS;
 
     // Prepared at most once per draft (it depends only on the draft), so a
     // payment that turns out to belong to another draft does not repeat the
@@ -491,48 +499,46 @@ export async function checkTransactions(
     // candidates only.
     const candidates: { transaction: any; opAmount: number }[] = [];
     for (const transaction of transactions) {
+      if (!isNativeStellarDeposit(transaction, toWalletAddress)) continue;
+
+      // Never consider payments made before the draft (minus clock skew).
       const transactionCreatedAt = new Date(transaction.created_at).getTime();
+      if (transactionCreatedAt < draftCreatedAt - CLOCK_SKEW) continue;
+
       // What this operation transferred on-chain — the one number the amount
-      // check, the ranking, and the recorded donation amount all judge.
-      // (isNativeStellarDeposit guarantees it is finite for candidates.)
+      // checks, the ranking, and the recorded donation amount all judge.
+      // (isNativeStellarDeposit guarantees it is finite.)
       const opAmount = stellarOperationAmount(transaction);
-
-      // CASE 1 waives the amount for every operation type (identification is
-      // the memo check below); CASE 2 requires the draft amount.
-      const amountMatches =
-        !requiresRecipientMemo ||
-        amountsMatchAtFloat4Precision(opAmount, amount);
-
-      // Validity window: not before creation (minus clock skew) and not
-      // after the case-dependent end (see paymentWindowEndMs above).
-      const isMatchingTransaction =
-        isNativeStellarDeposit(transaction, toWalletAddress) &&
-        amountMatches &&
-        transactionCreatedAt >= draftCreatedAt - CLOCK_SKEW &&
-        transactionCreatedAt <= paymentWindowEndMs;
-
-      if (!isMatchingTransaction) continue;
-
       const memo = transaction.transaction?.memo;
+
       if (requiresRecipientMemo) {
-        // CASE 2: payments must carry the recipient's own memo
-        // (create_account has none to check — see the regime notes above).
+        // CASE 2: float4-exact amount, tight window, and payments must carry
+        // the recipient's own memo (see the regime notes above).
+        if (
+          !amountsMatchAtFloat4Precision(opAmount, amount) ||
+          transactionCreatedAt > expiresAtDate
+        ) {
+          continue;
+        }
         if (transaction.type === 'payment' && memo !== toWalletMemo) {
           logger.debug(
             `Transaction memo does not match donation memo for donation ID ${donation.id}`,
           );
           continue;
         }
-      } else if (memo !== id.toString()) {
-        // CASE 1: every operation type must name this very draft — including
-        // create_account, which historically matched on exact amount with no
-        // memo at all. That memo-less acceptance path was removed with issue
-        // #2347 (once the amount condition is waived, a memo-less rule would
-        // accept any deposit): a donor funding a fresh address without a
-        // memo now needs manual reconciliation. Not logged: with no amount
-        // prefilter, every other payment on a shared address takes this
-        // branch on every tick — expected, not an event.
-        continue;
+      } else {
+        // CASE 1 (see the regime notes above). Memo mismatches are not
+        // logged: every other payment on a shared address fails that check
+        // on every tick — expected, not an event.
+        const memoIdentified =
+          memo === id.toString() &&
+          opAmount >= amount * QR_CASE1_MIN_AMOUNT_FACTOR &&
+          transactionCreatedAt <= caseOneWindowEndMs;
+        const isExactCreateAccount =
+          transaction.type === 'create_account' &&
+          amountsMatchAtFloat4Precision(opAmount, amount) &&
+          transactionCreatedAt <= expiresAtDate;
+        if (!memoIdentified && !isExactCreateAccount) continue;
       }
 
       // A record without a transaction hash can neither be deduplicated nor
@@ -547,15 +553,13 @@ export async function checkTransactions(
       candidates.push({ transaction, opAmount });
     }
 
-    // Several payments can identify the same draft — in CASE 1 anyone can
-    // send a payment carrying its memo — so order the attempts: successful
+    // Several payments can identify the same draft (a donor's double-send,
+    // or a failed attempt plus its retry), so order the attempts: successful
     // transactions before failed ones (a donor's failed full-amount attempt
     // must not outrank their successful retry), then by on-chain amount,
-    // largest first, so a dust payment cannot outrank the real one when both
-    // are already on the page (see the limitation note above). Ordering
-    // never rejects a payment; ties keep Horizon's newest-first order
-    // (Array.prototype.sort is stable), so CASE 2 — where every candidate
-    // equals the draft amount — behaves as before.
+    // largest first. Ordering never rejects a payment; ties keep Horizon's
+    // newest-first order (Array.prototype.sort is stable), so CASE 2 — where
+    // every candidate equals the draft amount — behaves as before.
     candidates.sort(
       (a, b) =>
         Number(Boolean(b.transaction.transaction_successful)) -

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -482,3 +482,16 @@ export const generateRandomNumericCode = (digits: number = 6): number => {
   const max = Math.pow(10, digits) - 1;
   return Math.floor(min + Math.random() * (max - min + 1));
 };
+
+export function generateHexNumber(len: number): string {
+  const hex = '0123456789abcdef';
+  let output = '';
+  for (let i = 0; i < len; i++) {
+    output += hex.charAt(Math.floor(Math.random() * hex.length));
+  }
+  return output;
+}
+
+export function generateRandomEtheriumAddress(): string {
+  return `0x${generateHexNumber(40)}`;
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -482,16 +482,3 @@ export const generateRandomNumericCode = (digits: number = 6): number => {
   const max = Math.pow(10, digits) - 1;
   return Math.floor(min + Math.random() * (max - min + 1));
 };
-
-export function generateHexNumber(len: number): string {
-  const hex = '0123456789abcdef';
-  let output = '';
-  for (let i = 0; i < len; i++) {
-    output += hex.charAt(Math.floor(Math.random() * hex.length));
-  }
-  return output;
-}
-
-export function generateRandomEtheriumAddress(): string {
-  return `0x${generateHexNumber(40)}`;
-}

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -10,10 +10,6 @@ import {
   EnterpriseAddress,
   Credential,
 } from '@emurgo/cardano-serialization-lib-nodejs';
-import {
-  generateHexNumber,
-  generateRandomEtheriumAddress,
-} from '../src/utils/utils';
 import config from '../src/config';
 import { NETWORK_IDS } from '../src/provider';
 import { User } from '../src/entities/user';
@@ -2113,7 +2109,18 @@ export const saveMainCategoryDirectlyToDb = async (
   }).save();
 };
 
-export { generateHexNumber, generateRandomEtheriumAddress };
+export function generateHexNumber(len: number): string {
+  const hex = '0123456789abcdef';
+  let output = '';
+  for (let i = 0; i < len; i++) {
+    output += hex.charAt(Math.floor(Math.random() * hex.length));
+  }
+  return output;
+}
+
+export function generateRandomEtheriumAddress(): string {
+  return `0x${generateHexNumber(40)}`;
+}
 
 export function generateRandomSolanaAddress(): string {
   return Keypair.generate().publicKey.toString();

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -1,5 +1,7 @@
 import { randomBytes } from 'crypto';
 import { assert } from 'chai';
+import sinon from 'sinon';
+import axios from 'axios';
 import * as jwt from 'jsonwebtoken';
 import { Keypair } from '@solana/web3.js';
 import { Keypair as StellarKeypair } from '@stellar/stellar-sdk';
@@ -8,6 +10,10 @@ import {
   EnterpriseAddress,
   Credential,
 } from '@emurgo/cardano-serialization-lib-nodejs';
+import {
+  generateHexNumber,
+  generateRandomEtheriumAddress,
+} from '../src/utils/utils';
 import config from '../src/config';
 import { NETWORK_IDS } from '../src/provider';
 import { User } from '../src/entities/user';
@@ -2107,9 +2113,7 @@ export const saveMainCategoryDirectlyToDb = async (
   }).save();
 };
 
-export function generateRandomEtheriumAddress(): string {
-  return `0x${generateHexNumber(40)}`;
-}
+export { generateHexNumber, generateRandomEtheriumAddress };
 
 export function generateRandomSolanaAddress(): string {
   return Keypair.generate().publicKey.toString();
@@ -2141,14 +2145,53 @@ export function generateRandomStellarTxHash(): string {
   return generateRandomAlphanumeric(64);
 }
 
-export function generateHexNumber(len): string {
-  const hex = '0123456789abcdef';
-  let output = '';
-  /* eslint-disable no-plusplus */
-  for (let i = 0; i < len; i++) {
-    output += hex.charAt(Math.floor(Math.random() * hex.length));
-  }
-  return output;
+// Stubs every axios.get with a Stellar Horizon payments-page envelope. The
+// single definition of the mocked envelope shape — shared by the QR matcher
+// and transaction-service test suites.
+export function stubStellarHorizonPayments(
+  records: any[],
+): sinon.SinonStub<any[], any> {
+  return sinon
+    .stub(axios, 'get')
+    .resolves({ data: { _embedded: { records } } });
+}
+
+// One canonical Stellar Horizon operation-record shape for tests, shared by
+// the QR matcher and transaction-service suites so their fixtures cannot
+// drift from each other.
+export function horizonPaymentRecord(opts: {
+  type?: 'payment' | 'create_account';
+  to: string;
+  from?: string;
+  amount: number | string;
+  txHash?: string;
+  memo?: string;
+  successful?: boolean;
+  createdAt?: Date;
+}) {
+  const from = opts.from ?? generateRandomStellarAddress();
+  const base = {
+    transaction_hash: opts.txHash ?? generateRandomStellarTxHash(),
+    source_account: from,
+    created_at: (opts.createdAt ?? new Date()).toISOString(),
+    transaction_successful: opts.successful ?? true,
+    transaction: { memo: opts.memo },
+  };
+  return opts.type === 'create_account'
+    ? {
+        ...base,
+        type: 'create_account',
+        account: opts.to,
+        starting_balance: String(opts.amount),
+      }
+    : {
+        ...base,
+        type: 'payment',
+        asset_type: 'native',
+        to: opts.to,
+        from,
+        amount: String(opts.amount),
+      };
 }
 
 function generateRandomAlphanumeric(length) {


### PR DESCRIPTION
## Isssue

https://github.com/Giveth/impact-graph/issues/2347

## Description

Fixes Stellar QR donation matching when the amount received on-chain differs from the amount requested in the draft donation due to exchange withdrawal fees.

For example, a donor may request a **20 XLM** withdrawal from Binance, but Binance deducts its withdrawal fee before broadcasting the transaction, so only **19.996 XLM** arrives at the project's Stellar address.

Previously, the QR matcher required an exact amount match before checking the memo, causing these donations to remain unmatched.

## Changes

### Stellar QR matching

For recipients that **do not require their own memo**:

- Match donations using the **destination address + draft donation ID in the Stellar memo**.
- Do not require the received amount to equal the draft amount.
- Store the **actual amount received on-chain** in the final Donation.
- Calculate USD value using the actual received amount.
- Allow delayed exchange withdrawals to be reconciled within the existing failed-draft reconciliation window.

For recipients that **require their own memo**:

- Keep the existing amount-based matching behavior because the memo cannot uniquely identify the draft.
- Amount comparisons use the database's float4 precision to avoid false mismatches caused by numeric storage precision.

### Additional robustness

- Correctly handle Stellar transactions containing multiple payment operations.
- Prefer successful payments over failed attempts.
- When multiple memo-matching payments exist, prefer the largest successful payment so a dust payment does not outrank the real donation when both are available.
- Deduplicate candidate operations belonging to the same transaction.
- Prevent duplicate donations through the existing transaction/draft locking mechanism.
- Use shared Stellar operation helpers for payment/create-account handling.
- Fix Stellar transaction timestamps to use epoch seconds during transaction verification.
- Notify the QR client immediately after the donation is created, before the full donation synchronization completes.

## Example

Before:

`20 XLM requested → 19.996 XLM received → donation not matched`

After:

`20 XLM requested → 19.996 XLM received → donation matched → 19.996 XLM recorded`

## Tests

Added/updated coverage for:

- Exact-amount Stellar QR donations
- Exchange fee-reduced amounts
- Actual on-chain amount and USD value
- Wrong destination
- Wrong draft memo
- Recipient-required memo behavior
- Delayed exchange withdrawals
- Duplicate transaction protection
- Multiple payments to the same address
- Multiple operations in a single Stellar transaction
- Dust payment vs real payment
- Failed payment followed by successful retry
- `create_account` operations
- Stellar transaction verification for batched payments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Stellar payment matching for QR donations, including memo-based matching, amount precision tolerance, duplicate prevention, and multi-operation transactions.
  * Added support for Stellar account-creation funding and failed-payment retries.
  * Payments can now be accepted during a late-payment window, with donations recording the actual amount received.
  * Improved transaction verification by selecting the most relevant payment and rejecting stale or incorrectly addressed transactions.

* **Tests**
  * Expanded coverage for Stellar QR matching and transaction verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Behavior changes from the `timestamp` fix (files this PR doesn't touch)

`NetworkTransactionInfo.timestamp` for Stellar was Horizon's ISO string in a `number`-typed field; it is now epoch seconds. Two checks that were silently dead for Stellar (`NaN` comparisons) now enforce:

1. **Staleness check** (`src/services/chains/index.ts:251`): `TRANSACTION_CANT_BE_OLDER_THAN_DONATION` now fires for Stellar. QR donations are exempt (`importedFromDraftOrBackupService`), so the reachable case is the AdminJS *add donation* flow, where reconciling a transaction mined more than an hour before the hand-entered timestamp now fails.
2. **QF round-period guard** (`src/server/adminJs/tabs/donationTab.ts:428`): previously passed unconditionally for Stellar (`Invalid Date` compares false both ways); it now rejects admin attempts to attach an out-of-window Stellar transaction to a round.

Also addressed in review follow-up (2368be87): AdminJS `createdAt` now uses `timestamp * 1000` for every chain; CASE 1 matching gained a one-sided minimum-amount floor (`QR_CASE1_MIN_AMOUNT_FACTOR = 0.9`) that accepts fee-reduced payments and rejects dust; the memo-less exact-amount `create_account` accept path is restored inside the tight validity window.
